### PR TITLE
Add platform repo integration for agent containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,9 @@ Phases 1, 2a, 2.5, 2b, and 2c are done and tested end-to-end on VPS. The full fl
 - Phase 2a plan: `docs/plans/2026-03-11-phase2a-agent-orchestrator.md`
 - VPS deployment spec: `docs/specs/2026-03-12-vps-deployment-design.md`
 - Overall design: see `docs/plans/2026-03-10-remote-agent-dev-environment-design.md` (external)
+
+## Platform Context
+
+Platform standards and choices: see /workspace/platform/ (in agent containers)
+or ~/code/platform/ (on local machines).
+This project's registry entry: products/interlude.yaml

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -73,3 +73,6 @@ export function getConfig(): AppConfig {
 export function resetConfig(): void {
   _config = null;
 }
+
+// Platform repo URL — cloned into agent containers for estate-wide context
+export const PLATFORM_REPO_URL = process.env.PLATFORM_REPO_URL || 'https://github.com/lennons301/platform.git';

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -1,7 +1,7 @@
 import Docker from "dockerode";
 import { getDocker } from "./client";
 import { getImageName, ensureImage } from "./image-builder";
-import { getConfig } from "../config";
+import { getConfig, PLATFORM_REPO_URL } from "../config";
 
 export interface WorkspaceOptions {
   taskId: string;
@@ -84,6 +84,7 @@ export async function execSetup(
         'git config --global user.name "$GIT_USER_NAME"',
         'git config --global user.email "$GIT_USER_EMAIL"',
         'git clone "https://${GIT_TOKEN}@${GIT_URL#https://}" /workspace/repo',
+        `git clone --depth 1 ${PLATFORM_REPO_URL} /workspace/platform 2>/dev/null || echo "WARN: platform repo clone failed, continuing without platform context"`,
         "cd /workspace/repo",
         'git checkout -b "$GIT_BRANCH"',
         // If Doppler token is set, download secrets to .env.local


### PR DESCRIPTION
## Summary
- Adds platform context pointer to CLAUDE.md
- Modifies `container-manager.ts` to clone the platform repo (`lennons301/platform`) into agent containers at `/workspace/platform/`
- Adds `PLATFORM_REPO_URL` config with public default, overridable via env var
- Clone uses `--depth 1` and fails gracefully (warning, not error)

## Context
Part of the platform repo rollout — see [lennons301/platform](https://github.com/lennons301/platform) for the full estate management system. This gives every Interlude agent access to estate-wide standards, choices, and product registry.

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Create a test task and verify `/workspace/platform/` exists in the container
- [ ] Verify task still succeeds if platform repo clone fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)