### PR TITLE
chore: Phase 4 backlog polish (5 hardening fixes)

### DIFF
--- a/src/lib/discord/client.ts
+++ b/src/lib/discord/client.ts
@@ -30,7 +30,7 @@ export async function startDiscordBot(): Promise<void> {
     partials: [Partials.Message, Partials.Reaction, Partials.Channel],
   });
 
-  client.on("ready", () => {
+  client.on("clientReady", () => {
     console.log(`[discord] Bot connected as ${client!.user?.tag}`);
     setBotClient(client!);
   });
@@ -57,9 +57,9 @@ async function handleMessage(message: Message): Promise<void> {
   const content = message.content.trim();
   if (!content) return;
 
-  // Handle !link command
-  if (content.startsWith("!link ")) {
-    await handleLinkCommand(message, content.slice(6).trim());
+  // Handle !link command (with or without an argument — bare "!link" shows usage)
+  if (content === "!link" || content.startsWith("!link ")) {
+    await handleLinkCommand(message, content.slice("!link".length).trim());
     return;
   }
 

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -1,4 +1,4 @@
-import { Client, EmbedBuilder, TextChannel } from "discord.js";
+import { Client, EmbedBuilder, TextChannel, type Message } from "discord.js";
 
 // The bot client is set once, in the instrumentation/orchestrator context where
 // the Discord bot connects (client.ts -> setBotClient). But notification helpers
@@ -15,6 +15,30 @@ export function setBotClient(client: Client): void {
 
 export function getBotClient(): Client | null {
   return globalForBot.__interludeBotClient ?? null;
+}
+
+/**
+ * Send an embed with a few retries + backoff, so a transient network blip
+ * (e.g. flaky connection) doesn't silently drop a notification. Throws if all
+ * attempts fail — callers already wrap sends in try/catch (fire-and-forget).
+ */
+async function sendWithRetry(
+  channel: TextChannel,
+  embed: EmbedBuilder,
+  attempts = 3
+): Promise<Message> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await channel.send({ embeds: [embed] });
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        await new Promise((r) => setTimeout(r, 1000 * (i + 1)));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 /**
@@ -39,7 +63,7 @@ export async function notifyTaskQueued(
       .setURL(`https://${domain}/tasks/${task.id}`)
       .setColor(0x7b61ff);
 
-    const msg = await (channel as TextChannel).send({ embeds: [embed] });
+    const msg = await sendWithRetry(channel as TextChannel, embed);
     return msg.id;
   } catch (err) {
     console.error(`[discord] Failed to send queued notification:`, err);
@@ -80,7 +104,7 @@ export async function notifyTaskCompleted(
     }
     embed.setDescription(lines.join("\n"));
 
-    await (channel as TextChannel).send({ embeds: [embed] });
+    await sendWithRetry(channel as TextChannel, embed);
   } catch (err) {
     console.error(`[discord] Failed to send completed notification:`, err);
   }
@@ -107,7 +131,7 @@ export async function notifyTaskFailed(
       .setURL(`https://${domain}/tasks/${task.id}`)
       .setColor(0xef4444);
 
-    await (channel as TextChannel).send({ embeds: [embed] });
+    await sendWithRetry(channel as TextChannel, embed);
   } catch (err) {
     console.error(`[discord] Failed to send failed notification:`, err);
   }
@@ -142,7 +166,7 @@ export async function notifyTaskIdle(
       .setURL(`https://${domain}/tasks/${task.id}`)
       .setColor(0xf59e0b);
 
-    const msg = await (channel as TextChannel).send({ embeds: [embed] });
+    const msg = await sendWithRetry(channel as TextChannel, embed);
     return msg.id;
   } catch (err) {
     console.error(`[discord] Failed to send idle notification:`, err);

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -237,6 +237,7 @@ export async function execFallbackCommitAndPush(
   });
 
   const stream = await exec.start({});
+  let output = "";
 
   await new Promise<void>((resolve) => {
     let resolved = false;
@@ -249,6 +250,9 @@ export async function execFallbackCommitAndPush(
       resolve();
     };
 
+    stream.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
     stream.on("end", done);
     stream.resume();
 
@@ -266,7 +270,10 @@ export async function execFallbackCommitAndPush(
 
   const inspectResult = await exec.inspect();
   if (inspectResult.ExitCode !== 0) {
-    throw new Error(`Commit and push failed with exit code ${inspectResult.ExitCode}`);
+    const detail = output.replace(/[^ -~]+/g, " ").trim().slice(-800);
+    throw new Error(
+      `Commit and push failed (exit ${inspectResult.ExitCode})${detail ? ": " + detail : ""}`
+    );
   }
 }
 

--- a/src/lib/github/__tests__/repo.test.ts
+++ b/src/lib/github/__tests__/repo.test.ts
@@ -34,6 +34,10 @@ describe("parseRepoFromGitUrl", () => {
     expect(parseRepoFromGitUrl("https://gitlab.com/lennons301/test-repo.git")).toBeNull();
   });
 
+  it("returns null for a browser-style URL with extra path segments", () => {
+    expect(parseRepoFromGitUrl("https://github.com/lennons301/test-repo/tree/main")).toBeNull();
+  });
+
   it("returns null for unparseable input", () => {
     expect(parseRepoFromGitUrl("not a url")).toBeNull();
     expect(parseRepoFromGitUrl("")).toBeNull();

--- a/src/lib/github/repo.ts
+++ b/src/lib/github/repo.ts
@@ -8,11 +8,11 @@ export function parseRepoFromGitUrl(
   if (!gitUrl) return null;
 
   // scp-style: git@github.com:owner/repo(.git)
-  const scp = gitUrl.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?\/?$/);
+  const scp = gitUrl.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
   if (scp) return { owner: scp[1], repo: scp[2] };
 
   // https: https://github.com/owner/repo(.git)(/)
-  const https = gitUrl.match(/^https?:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/);
+  const https = gitUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
   if (https) return { owner: https[1], repo: https[2] };
 
   return null;


### PR DESCRIPTION
Five small, low-risk fixes from the Phase 4 backlog. No schema/infra changes; pure code.

1. **Notification retry** (`notifications.ts`) — embed sends now retry 3× with backoff, so a transient network blip doesn't silently drop a notification (observed live: an idle notification lost on flaky wifi).
2. **Git stderr capture** (`container-manager.ts`) — `execFallbackCommitAndPush` now captures the command output and includes it in the "Commit and push failed" error, instead of the empty `"Push failed:"` we hit during debugging.
3. **`parseRepoFromGitUrl` regex** (`repo.ts`) — repo group anchored to `[^/]+` so a browser-style URL (`…/owner/repo/tree/main`) returns `null` rather than a bad `repo` value. New test case added.
4. **Bare `!link` guard** (`client.ts`) — `!link` with no argument now shows the usage hint instead of creating a junk task titled "!link" in a linked channel.
5. **`ready` → `clientReady`** (`client.ts`) — clears the discord.js v14 deprecation warning. Verified `Events.ClientReady = "clientReady"` is emitted in 14.26 before switching (so the bot still connects).

## Verification
`pnpm build` clean; **full vitest suite 27/27 green** (includes the new repo test + the output-parser tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)