### PR TITLE
docs(spec): arming traces to a human decision, not to who types it

### DIFF
--- a/docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md
+++ b/docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md
@@ -39,7 +39,8 @@ Interlude becomes a **second executor of the platform's ticket-loop contract**,
 running the same loop the laptop runner runs, unattended, on the VPS.
 
 I arm work by applying `ready-for-agent` to an issue — that label is the launch
-button and only a human ever applies it. Interlude notices (webhook, backed by a
+button, and applying it always requires a human decision — mine directly, or my
+yes to an agent that asked. Interlude notices (webhook, backed by a
 reconciliation sweep), waits for a free slot, and runs the loop: implement pass
 in its own container on `agent/issue-<n>`, draft PR, deterministic review-gate
 evaluation, then a review pass with fresh context under the separate reviewer
@@ -62,7 +63,8 @@ acknowledge constantly isn't autonomy.
 Two smaller pieces complete the loop. An agent that hits a decision its ticket
 doesn't resolve **stops and asks** rather than guessing, using the existing
 idle-and-reply plumbing. And a **triage pass** meets handwritten issues as they
-arrive: it either recommends the ticket for arming (I click the label), asks for
+arrive: it either recommends the ticket for arming (I confirm — a label click, or
+a yes in Discord that the orchestrator acts on), asks for
 the missing information, or tells me this one needs a grilling session before
 anyone writes code.
 
@@ -698,8 +700,11 @@ They keep working exactly as they do today; this phase only adds beside them.
 
 ## Further Notes
 
-The security model reduces to one sentence: *only a human can arm work, and only
-trusted code can land it.* Everything else — the author allow-list, directive
+The security model reduces to one sentence: *arming always traces to a human
+decision, and only trusted code can land it.* An unattended pass may recommend
+but never arm, because it reads untrusted input; a human's yes — by label click
+or in Discord — is a decision and may be acted on. Everything else — the author
+allow-list, directive
 clamping, gate config read from the default branch, the reviewer PAT never
 entering a container, orchestrator-posted approvals, triage's inability to apply
 `ready-for-agent` — is defence in depth behind that sentence. Autonomous agents


### PR DESCRIPTION
Aligns the Phase 5 spec with the restated estate rule in lennons301/platform#11.

The spec said arming required a human to *apply the label* — "I click the label". That forbids a route we expect to use often: a triage pass recommending a ticket in Discord, the owner replying yes, and the orchestrator applying the label on that confirmation. It would also have forbidden an interactive `/to-tickets` run from arming tickets the owner had just approved.

The rule is about provenance, not mechanism. Arming must trace to an explicit human decision; an unattended pass may recommend but never arm on its own judgement, because it reads untrusted input. Three passages updated: the solution overview, the triage exit, and the security-model sentence in Further Notes.

Ticket #23's acceptance criteria were updated to match — exit one may arm on explicit confirmation, the route is recorded on the issue, and silence is never consent.

Docs-only; no code, schema or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
