### PR TITLE
Proof of concept: land a change through the ticket-loop unattended

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,11 @@ Local dev runs the orchestrator via `doppler run -- pnpm dev` — orchestrator s
 - **Agent-container network:** run `docker network create interlude` once. Agent containers attach to the `interlude` network, which Compose creates on the VPS but `pnpm dev` does not — without it, task runs fail with "network interlude not found".
 - **Claude credentials mount:** set `CLAUDE_CREDENTIALS_PATH` (in `interlude/dev`) to your host `~/.claude/.credentials.json` so agent containers get Claude auth — otherwise the agent errors with "Not logged in".
 
-## Current Status: Phase 4 implemented + locally verified; VPS deploy pending
+## Current Status: Phase 4 done and verified on VPS; Phase 5 next
 
 Phases 1, 2a, 2.5, 2b, 2c, 2d, and 3 are done and tested end-to-end on VPS. The full flow works: create task → agent runs in Docker → output streams to chat UI → branch pushed to GitHub after each turn → interactive follow-up messages → live preview of dev server via subdomain → complete task. GitHub issues labeled `interlude` auto-create tasks, and agent work auto-produces draft PRs.
 
-Phase 4 (Discord bot + Discord-first task lifecycle) is merged (#8, plus backlog polish in #10) and deployed to the VPS. End-to-end verification of the Discord loop on the VPS — link a channel, dispatch, idle notification, ✅ complete — is the remaining confirmation.
+Phase 4 (Discord bot + Discord-first task lifecycle) is merged (#8, plus backlog polish in #10), deployed to the VPS, and verified end to end there — link a channel, dispatch, idle notification, ✅ complete.
 
 Phase 5 (autonomous ticket-loop + fleet observability) is specced —
 `docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md` — and awaiting
@@ -118,7 +118,7 @@ decomposition into tickets. It depends on Phase 4 being live on the VPS.
 - Spec: `docs/specs/2026-03-27-phase3-github-integration-design.md`
 - Plan: `docs/plans/2026-03-27-phase3-github-integration.md`
 
-### Phase 4: Discord Bot + Discord-First Lifecycle (implemented, local E2E verified; VPS deploy pending)
+### Phase 4: Discord Bot + Discord-First Lifecycle (done)
 - Discord bot via discord.js Gateway for bidirectional messaging (chose Discord over Slack/Telegram)
 - Channel-per-project mapping via `!link` / `!unlink`; messages create tasks, replies deliver follow-ups, `cancel` cancels
 - Outbound lifecycle embeds: queued / completed / failed


### PR DESCRIPTION
Closes #29

## What

`CLAUDE.md` still claimed Phase 4's VPS verification was outstanding. It isn't — Phase 4 merged in #8/#10, deployed, and was verified end to end on the VPS. This corrects the three stale statements and nothing else:

- Current Status heading: "Phase 4 implemented + locally verified; VPS deploy pending" → "Phase 4 done and verified on VPS; Phase 5 next"
- Phase 4 status paragraph: now states merged (#8, plus backlog polish in #10), deployed, and verified end to end
- Roadmap heading: "(implemented, local E2E verified; VPS deploy pending)" → "(done)", matching every other completed phase

One file, 3 insertions, 3 deletions — deliberately minimal per the ticket ("the smaller the diff, the clearer the signal"). The real deliverable is the mechanism this PR exercises: worktree implement pass → PR → ungated-docs gate evaluation → auto-merge armed → reviewer machine account approves → merge with no human touch.

## Validation

- `pnpm test`: 27/27 pass
- `pnpm lint`: 17 errors / 2 warnings, all pre-existing on main in source files this branch never touched (`custom-server.js`, `src/components/preview-pane.tsx`, `src/lib/orchestrator/turn-manager.ts`, …). Out of scope for a minimal-diff docs ticket.

## Self-review (code-review skill vs origin/main, issue #29 as spec)

Both axes clean — no hard standards violations, no spec gaps, no scope creep. Two judgement-call suggestions were raised and **deliberately not taken**, both for the same reason — the ticket's "No other content changes" criterion:

1. Fold Phase 4 into the "Phases 1, 2a, 2.5, 2b, 2c, 2d, and 3 are done and tested end-to-end on VPS" list. Declined: the doc's convention gives the newest phase its own status paragraph, and the very next line now states Phase 4's status explicitly.
2. Refresh "It depends on Phase 4 being live on the VPS" in the Phase 5 paragraph. Declined: the sentence states a dependency, which this change makes satisfied rather than false — cosmetic at most.

## Attempt context

Attempt 2/3. Attempt 1 made the identical edit but was killed by the repo allowlist missing `git commit` and all `gh` verbs for non-interactive passes (recorded on #29). This attempt confirms the allowlist fix works: commit, push, and `gh pr create` all ran without prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)