### PR TITLE
Phase 5: container resource limits and derived slot capacity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ KEEP_CONTAINERS=false
 MAX_TURNS=50
 MAX_BUDGET_USD=5.00
 
+# Capacity — slots derive at boot from the Docker daemon's CPU/memory;
+# override only when the derivation is wrong for a workload
+# CAPACITY_SLOTS=2
+# AGENT_MEMORY_MB=1200  # per-agent hard memory cap; also the slot divisor
+
 # Deployment (production only)
 # DATABASE_URL=/data/interlude.db  # set in docker-compose.yml environment block; override here only if needed
 # DOMAIN — production's single source of truth is Doppler (interlude/prd): the

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,8 @@ export interface AppConfig {
   maxTurns: number;
   /** Max budget in USD per task (default: 5.00) */
   maxBudgetUsd: number;
+  /** Explicit agent slot count, overriding the boot-time derivation. Null = derive from the Docker daemon */
+  capacitySlots: number | null;
   /** Domain for subdomain-based preview (e.g. "interludes.co.uk"). Null = path-based fallback */
   domain: string | null;
   /** GitHub App ID (from app settings page) */
@@ -72,6 +74,9 @@ export function getConfig(): AppConfig {
     keepContainers: process.env.KEEP_CONTAINERS === "true",
     maxTurns: parseInt(process.env.MAX_TURNS ?? "50", 10),
     maxBudgetUsd: parseFloat(process.env.MAX_BUDGET_USD ?? "5.00"),
+    capacitySlots: process.env.CAPACITY_SLOTS
+      ? parseInt(process.env.CAPACITY_SLOTS, 10)
+      : null,
     domain: process.env.DOMAIN ?? null,
     githubAppId: process.env.GITHUB_APP_ID ?? null,
     githubAppPrivateKey: process.env.GITHUB_APP_PRIVATE_KEY ?? null,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,8 @@ export interface AppConfig {
   maxBudgetUsd: number;
   /** Explicit agent slot count, overriding the boot-time derivation. Null = derive from the Docker daemon */
   capacitySlots: number | null;
+  /** Per-agent memory allocation in MiB (container cap + slot divisor). Null = default */
+  agentMemoryMb: number | null;
   /** Domain for subdomain-based preview (e.g. "interludes.co.uk"). Null = path-based fallback */
   domain: string | null;
   /** GitHub App ID (from app settings page) */
@@ -76,6 +78,9 @@ export function getConfig(): AppConfig {
     maxBudgetUsd: parseFloat(process.env.MAX_BUDGET_USD ?? "5.00"),
     capacitySlots: process.env.CAPACITY_SLOTS
       ? parseInt(process.env.CAPACITY_SLOTS, 10)
+      : null,
+    agentMemoryMb: process.env.AGENT_MEMORY_MB
+      ? parseInt(process.env.AGENT_MEMORY_MB, 10)
       : null,
     domain: process.env.DOMAIN ?? null,
     githubAppId: process.env.GITHUB_APP_ID ?? null,

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -3,6 +3,7 @@ import { getDocker } from "./client";
 import { getImageName, ensureImage } from "./image-builder";
 import { getConfig, PLATFORM_REPO_URL } from "../config";
 import { getInstallationToken } from "../github/client";
+import { getCapacity } from "../orchestrator/capacity";
 
 /**
  * Bash run at container setup: install an env-based git credential helper
@@ -89,6 +90,8 @@ export async function createWorkspaceContainer(
   // DNS-safe subdomain derived from task ID (last 8 chars of ULID, lowercased)
   const previewSubdomain = `task-${options.taskId.slice(-8).toLowerCase()}`;
 
+  const capacity = await getCapacity();
+
   const container = await docker.createContainer({
     Image: getImageName(),
     name: containerName,
@@ -98,6 +101,11 @@ export async function createWorkspaceContainer(
     HostConfig: {
       NetworkMode: "interlude",
       Binds: binds.length > 0 ? binds : undefined,
+      // Hard caps: a runaway agent fails its own task, never the platform.
+      // MemorySwap = Memory disables swap, so the cap bites immediately.
+      Memory: capacity.perAgentMemory,
+      MemorySwap: capacity.perAgentMemory,
+      NanoCpus: capacity.cpuQuota,
     },
     NetworkingConfig: {
       EndpointsConfig: {

--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deriveCapacity } from "../capacity";
+import { createLocalCapacityProvider, deriveCapacity } from "../capacity";
 
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
@@ -33,6 +33,11 @@ describe("deriveCapacity", () => {
       daemon: { memTotalBytes: 2 * GiB, cpuCount: 1 },
       slots: 1,
     },
+    {
+      name: "a daemon reporting garbage still yields the minimum of 1, never NaN",
+      daemon: { memTotalBytes: NaN, cpuCount: 0 },
+      slots: 1,
+    },
   ])("$name", ({ daemon, slots }) => {
     expect(deriveCapacity(daemon).slots).toBe(slots);
   });
@@ -60,5 +65,27 @@ describe("deriveCapacity", () => {
     const capacity = deriveCapacity({ memTotalBytes: 4 * GiB, cpuCount: 2 });
     expect(capacity.perAgentMemory).toBe(1_258_291_200);
     expect(capacity.cpuQuota).toBe(1_000_000_000);
+  });
+});
+
+describe("capacity provider", () => {
+  const twoSlots = deriveCapacity({ memTotalBytes: 4 * GiB, cpuCount: 2 });
+
+  it("reports a slot available while active agents are below the slot count", async () => {
+    const provider = createLocalCapacityProvider(twoSlots, () => 1);
+    await expect(provider.isSlotAvailable()).resolves.toBe(true);
+  });
+
+  it("reports no slot once every slot is occupied", async () => {
+    const provider = createLocalCapacityProvider(twoSlots, () => 2);
+    await expect(provider.isSlotAvailable()).resolves.toBe(false);
+  });
+
+  it("frees a slot when an active agent finishes", async () => {
+    let active = 2;
+    const provider = createLocalCapacityProvider(twoSlots, () => active);
+    await expect(provider.isSlotAvailable()).resolves.toBe(false);
+    active = 1;
+    await expect(provider.isSlotAvailable()).resolves.toBe(true);
   });
 });

--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -66,6 +66,27 @@ describe("deriveCapacity", () => {
     expect(capacity.perAgentMemory).toBe(1_258_291_200);
     expect(capacity.cpuQuota).toBe(1_000_000_000);
   });
+
+  it("a per-agent memory override resizes the container cap and the slot divisor together", () => {
+    const capacity = deriveCapacity(
+      { memTotalBytes: 4 * GiB, cpuCount: 2 },
+      { perAgentMemoryMb: 2000 }
+    );
+    expect(capacity.perAgentMemory).toBe(2000 * MiB);
+    expect(capacity.slots).toBe(1);
+  });
+
+  it.each([{ perAgentMemoryMb: 0 }, { perAgentMemoryMb: -500 }, { perAgentMemoryMb: NaN }])(
+    "an invalid per-agent memory override ($perAgentMemoryMb) is ignored",
+    (overrides) => {
+      const capacity = deriveCapacity(
+        { memTotalBytes: 4 * GiB, cpuCount: 2 },
+        overrides
+      );
+      expect(capacity.perAgentMemory).toBe(1_258_291_200);
+      expect(capacity.slots).toBe(2);
+    }
+  );
 });
 
 describe("capacity provider", () => {

--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { deriveCapacity } from "../capacity";
+
+const MiB = 1024 * 1024;
+const GiB = 1024 * MiB;
+
+describe("deriveCapacity", () => {
+  // Slot derivation: (memTotal - orchestrator reserve) / per-agent allocation,
+  // capped by CPU count, minimum 1.
+  it.each([
+    {
+      name: "CX22 nominal (4 GiB, 2 vCPU) yields 2 — today's practical ceiling",
+      daemon: { memTotalBytes: 4 * GiB, cpuCount: 2 },
+      slots: 2,
+    },
+    {
+      name: "CX22 as the daemon actually reports it (~3.8 GiB) still yields 2",
+      daemon: { memTotalBytes: 4_000_000_000, cpuCount: 2 },
+      slots: 2,
+    },
+    {
+      name: "resize to CX32 (8 GiB, 4 vCPU) changes the answer: memory allows 5, CPU caps at 4",
+      daemon: { memTotalBytes: 8 * GiB, cpuCount: 4 },
+      slots: 4,
+    },
+    {
+      name: "memory-only resize (8 GiB, still 2 vCPU) stays CPU-capped at 2",
+      daemon: { memTotalBytes: 8 * GiB, cpuCount: 2 },
+      slots: 2,
+    },
+    {
+      name: "a box too small for the formula (2 GiB, 1 vCPU) still gets the minimum of 1",
+      daemon: { memTotalBytes: 2 * GiB, cpuCount: 1 },
+      slots: 1,
+    },
+  ])("$name", ({ daemon, slots }) => {
+    expect(deriveCapacity(daemon).slots).toBe(slots);
+  });
+
+  it("an explicit slots override replaces the derivation for when it is wrong for a workload", () => {
+    const capacity = deriveCapacity(
+      { memTotalBytes: 4 * GiB, cpuCount: 2 },
+      { slots: 4 }
+    );
+    expect(capacity.slots).toBe(4);
+  });
+
+  it.each([{ slots: 0 }, { slots: -1 }, { slots: NaN }])(
+    "an invalid slots override ($slots) is ignored rather than halting the fleet",
+    (overrides) => {
+      const capacity = deriveCapacity(
+        { memTotalBytes: 4 * GiB, cpuCount: 2 },
+        overrides
+      );
+      expect(capacity.slots).toBe(2);
+    }
+  );
+
+  it("returns per-agent container limits: 1200 MiB of memory and 1 CPU in NanoCpus", () => {
+    const capacity = deriveCapacity({ memTotalBytes: 4 * GiB, cpuCount: 2 });
+    expect(capacity.perAgentMemory).toBe(1_258_291_200);
+    expect(capacity.cpuQuota).toBe(1_000_000_000);
+  });
+});

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -1,0 +1,56 @@
+/**
+ * Slot capacity derived from what the Docker daemon reports, so a VPS resize
+ * is understood at boot with no config change (Phase 5, issue #14).
+ *
+ * Defaults are tuned so the current CX22 (4 GB nominal, ~3.7-3.9 GiB as the
+ * daemon reports it) derives 2 slots — today's practical ceiling. The spec's
+ * illustrative ~1.5 GB reserve only yields 2 against the *nominal* 4096 MiB;
+ * against the daemon's reported total it yields 1, so the reserve default is
+ * 1 GiB (orchestrator + Caddy + system headroom) instead.
+ */
+
+const MiB = 1024 * 1024;
+
+export const DEFAULT_ORCHESTRATOR_RESERVE_MB = 1024;
+export const DEFAULT_AGENT_MEMORY_MB = 1200;
+export const DEFAULT_AGENT_CPUS = 1;
+
+export interface DaemonInfo {
+  /** Docker `info.MemTotal` — total memory in bytes as the daemon reports it */
+  memTotalBytes: number;
+  /** Docker `info.NCPU` */
+  cpuCount: number;
+}
+
+export interface CapacityOverrides {
+  /** Explicit slot count for when the derivation is wrong for a workload */
+  slots?: number;
+}
+
+export interface DerivedCapacity {
+  /** Concurrent agent slots */
+  slots: number;
+  /** Hard memory limit per agent container, in bytes */
+  perAgentMemory: number;
+  /** Hard CPU limit per agent container, in NanoCpus (1e9 = one CPU) */
+  cpuQuota: number;
+}
+
+export function deriveCapacity(
+  daemon: DaemonInfo,
+  overrides: CapacityOverrides = {}
+): DerivedCapacity {
+  const perAgentMemory = DEFAULT_AGENT_MEMORY_MB * MiB;
+  const available = daemon.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
+  const derived = Math.max(
+    1,
+    Math.min(Math.floor(available / perAgentMemory), daemon.cpuCount)
+  );
+  const override = overrides.slots;
+  const slots =
+    override !== undefined && Number.isInteger(override) && override >= 1
+      ? override
+      : derived;
+
+  return { slots, perAgentMemory, cpuQuota: DEFAULT_AGENT_CPUS * 1e9 };
+}

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -9,6 +9,9 @@
  * 1 GiB (orchestrator + Caddy + system headroom) instead.
  */
 
+import { getDocker } from "../docker/client";
+import { getConfig } from "../config";
+
 const MiB = 1024 * 1024;
 
 export const DEFAULT_ORCHESTRATOR_RESERVE_MB = 1024;
@@ -72,4 +75,23 @@ export function createLocalCapacityProvider(
     capacity,
     isSlotAvailable: async () => activeCount() < capacity.slots,
   };
+}
+
+let _capacity: DerivedCapacity | null = null;
+
+/**
+ * Capacity as derived at boot from the daemon's reported CPU and memory
+ * (first call queries `docker info`; a VPS resize is picked up on restart).
+ * `CAPACITY_SLOTS` overrides the slot count when the derivation is wrong
+ * for a workload.
+ */
+export async function getCapacity(): Promise<DerivedCapacity> {
+  if (_capacity) return _capacity;
+
+  const info = await getDocker().info();
+  _capacity = deriveCapacity(
+    { memTotalBytes: info.MemTotal, cpuCount: info.NCPU },
+    { slots: getConfig().capacitySlots ?? undefined }
+  );
+  return _capacity;
 }

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -28,6 +28,8 @@ export interface DaemonInfo {
 export interface CapacityOverrides {
   /** Explicit slot count for when the derivation is wrong for a workload */
   slots?: number;
+  /** Per-agent memory allocation in MiB — resizes the container cap and the slot divisor together */
+  perAgentMemoryMb?: number;
 }
 
 export interface DerivedCapacity {
@@ -43,7 +45,12 @@ export function deriveCapacity(
   daemon: DaemonInfo,
   overrides: CapacityOverrides = {}
 ): DerivedCapacity {
-  const perAgentMemory = DEFAULT_AGENT_MEMORY_MB * MiB;
+  const memoryOverride = overrides.perAgentMemoryMb;
+  const perAgentMb =
+    memoryOverride !== undefined && Number.isFinite(memoryOverride) && memoryOverride > 0
+      ? memoryOverride
+      : DEFAULT_AGENT_MEMORY_MB;
+  const perAgentMemory = perAgentMb * MiB;
   const available = daemon.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
   const byMemory = Math.floor(available / perAgentMemory);
   const capped = Math.min(byMemory, daemon.cpuCount);
@@ -82,16 +89,20 @@ let _capacity: DerivedCapacity | null = null;
 /**
  * Capacity as derived at boot from the daemon's reported CPU and memory
  * (first call queries `docker info`; a VPS resize is picked up on restart).
- * `CAPACITY_SLOTS` overrides the slot count when the derivation is wrong
- * for a workload.
+ * `CAPACITY_SLOTS` overrides the slot count and `AGENT_MEMORY_MB` the
+ * per-agent allocation when the derivation is wrong for a workload.
  */
 export async function getCapacity(): Promise<DerivedCapacity> {
   if (_capacity) return _capacity;
 
   const info = await getDocker().info();
+  const config = getConfig();
   _capacity = deriveCapacity(
     { memTotalBytes: info.MemTotal, cpuCount: info.NCPU },
-    { slots: getConfig().capacitySlots ?? undefined }
+    {
+      slots: config.capacitySlots ?? undefined,
+      perAgentMemoryMb: config.agentMemoryMb ?? undefined,
+    }
   );
   return _capacity;
 }

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -42,10 +42,9 @@ export function deriveCapacity(
 ): DerivedCapacity {
   const perAgentMemory = DEFAULT_AGENT_MEMORY_MB * MiB;
   const available = daemon.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
-  const derived = Math.max(
-    1,
-    Math.min(Math.floor(available / perAgentMemory), daemon.cpuCount)
-  );
+  const byMemory = Math.floor(available / perAgentMemory);
+  const capped = Math.min(byMemory, daemon.cpuCount);
+  const derived = Number.isFinite(capped) ? Math.max(1, capped) : 1;
   const override = overrides.slots;
   const slots =
     override !== undefined && Number.isInteger(override) && override >= 1
@@ -53,4 +52,24 @@ export function deriveCapacity(
       : derived;
 
   return { slots, perAgentMemory, cpuQuota: DEFAULT_AGENT_CPUS * 1e9 };
+}
+
+/**
+ * The seam callers consume instead of querying Docker directly — Phase 7's
+ * on-demand remote compute answers the same question differently, so the
+ * answer is async even though the local provider is not.
+ */
+export interface CapacityProvider {
+  capacity: DerivedCapacity;
+  isSlotAvailable(): Promise<boolean>;
+}
+
+export function createLocalCapacityProvider(
+  capacity: DerivedCapacity,
+  activeCount: () => number
+): CapacityProvider {
+  return {
+    capacity,
+    isSlotAvailable: async () => activeCount() < capacity.slots,
+  };
 }

--- a/src/lib/orchestrator/init.ts
+++ b/src/lib/orchestrator/init.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { newId } from "../ulid";
 import { getDocker, isDockerAvailable } from "../docker/client";
 import { startQueue } from "./queue";
+import { getCapacity } from "./capacity";
 import { isGitHubConfigured } from "../github/client";
 import { isDiscordConfigured, startDiscordBot } from "../discord/client";
 
@@ -108,6 +109,13 @@ export async function initOrchestrator(): Promise<void> {
   const dockerAvailable = await isDockerAvailable();
   if (dockerAvailable) {
     console.log("[orchestrator] Docker available, starting task queue");
+
+    const capacity = await getCapacity();
+    console.log(
+      `[orchestrator] Capacity: ${capacity.slots} agent slot(s), ` +
+        `${Math.round(capacity.perAgentMemory / (1024 * 1024))} MiB + ` +
+        `${capacity.cpuQuota / 1e9} CPU per agent`
+    );
     if (isGitHubConfigured()) {
       console.log("[orchestrator] GitHub App configured -- webhooks and PR creation enabled");
     } else {

--- a/src/lib/orchestrator/queue.ts
+++ b/src/lib/orchestrator/queue.ts
@@ -3,12 +3,34 @@ import { tasks, messages } from "@/db/schema";
 import { eq, and, isNull, asc } from "drizzle-orm";
 import { startTask } from "./turn-manager";
 import { getActiveTasks, processQueuedMessages, scanForDevServer } from "./turn-manager";
+import {
+  createLocalCapacityProvider,
+  getCapacity,
+  type CapacityProvider,
+} from "./capacity";
 
 let pollInterval: ReturnType<typeof setInterval> | null = null;
 let pollCount = 0;
 
 /** Track which tasks are currently being processed to prevent double-dispatch */
 const processingTasks = new Set<string>();
+
+let capacityProvider: CapacityProvider | null = null;
+let saturationLogged = false;
+
+/**
+ * Slots in use: live containers plus pickups still provisioning theirs
+ * (a task sits in processingTasks before it registers in activeTasks —
+ * without counting those, back-to-back polls could overfill the box).
+ */
+function occupiedSlots(): number {
+  const active = getActiveTasks();
+  let count = active.size;
+  for (const taskId of processingTasks) {
+    if (!active.has(taskId)) count++;
+  }
+  return count;
+}
 
 export function startQueue(): void {
   if (pollInterval) return;
@@ -19,7 +41,8 @@ export function startQueue(): void {
     try {
       pollCount++;
 
-      // 1. Pick up new queued tasks
+      // 1. Pick up new queued tasks — through the capacity provider seam,
+      // never a direct Docker query at the call site
       const next = db
         .select()
         .from(tasks)
@@ -28,15 +51,30 @@ export function startQueue(): void {
         .get();
 
       if (next && !processingTasks.has(next.id)) {
-        processingTasks.add(next.id);
-        console.log(
-          `[orchestrator] Picked up task: ${next.id} — ${next.title}`
-        );
-        startTask(next.id)
-          .catch((err) =>
-            console.error(`[orchestrator] Task ${next.id} failed:`, err)
-          )
-          .finally(() => processingTasks.delete(next.id));
+        if (!capacityProvider) {
+          capacityProvider = createLocalCapacityProvider(
+            await getCapacity(),
+            occupiedSlots
+          );
+        }
+
+        if (await capacityProvider.isSlotAvailable()) {
+          saturationLogged = false;
+          processingTasks.add(next.id);
+          console.log(
+            `[orchestrator] Picked up task: ${next.id} — ${next.title}`
+          );
+          startTask(next.id)
+            .catch((err) =>
+              console.error(`[orchestrator] Task ${next.id} failed:`, err)
+            )
+            .finally(() => processingTasks.delete(next.id));
+        } else if (!saturationLogged) {
+          saturationLogged = true;
+          console.log(
+            `[orchestrator] All ${capacityProvider.capacity.slots} slot(s) busy — task ${next.id} waits in queue`
+          );
+        }
       }
 
       // 2. Check idle tasks for queued messages


### PR DESCRIPTION
Closes #14

## What this does

- **Hard limits on every agent container**: `createWorkspaceContainer` — the single creation site for all agent kinds — now sets `Memory`, `MemorySwap` (= `Memory`, so the cap bites without swapping the box to death) and `NanoCpus` on `HostConfig`. A runaway agent OOMs its own process and fails its task through the existing turn-failure path; the orchestrator and Caddy are outside the cgroup.
- **Slot capacity derived at boot** (`src/lib/orchestrator/capacity.ts`): `deriveCapacity(daemonInfo, overrides) -> { slots, perAgentMemory, cpuQuota }` — pure, `(memTotal − reserve) / perAgent`, capped by CPU, minimum 1, garbage-daemon-shape safe. First `getCapacity()` call queries `docker info`; a VPS resize is picked up on restart with no config change.
- **Provider seam**: queue pickup consumes capacity via `CapacityProvider.isSlotAvailable()` (async so Phase 7's remote compute can answer differently), never a direct Docker query at the call site. Occupancy counts live containers **plus** pickups still provisioning theirs, so back-to-back polls can't overfill the box.
- **Overrides**: `CAPACITY_SLOTS` (explicit slot count) and `AGENT_MEMORY_MB` (per-agent allocation — container cap and slot divisor together). Invalid values are ignored by the validated derivation rather than halting the fleet.
- **Tests**: table-driven at the two seams the ticket confirmed, including a CX32 resize changing the answer. 45 pass; no Docker/GitHub/Discord/DB mocking.

## Deviation from the spec's illustrative numbers

The Phase 5 spec sketches ~1.5 GB reserve / ~1.2 GB per agent. Against the daemon's **reported** total (a "4 GB" box reports ~3.8–3.9 GiB — verified locally: 4,106,444,800 bytes on a 4 GB WSL host), a 1536 MiB reserve derives **1** slot, violating the binding criterion "yields 2 on the current CX22". The reserve default is therefore 1 GiB (orchestrator ≈300 MB + Caddy ≈50 MB + system headroom), keeping 2×1200 MiB agents + reserve inside the reported total. Pinned by the "as the daemon actually reports it" test row.

## Self-review findings (vs origin/main, spec = #14)

Acted on:
- Per-agent memory override added (`AGENT_MEMORY_MB`) — "wrong for a workload" covers agent sizing, not just slot count.
- `CAPACITY_SLOTS` / `AGENT_MEMORY_MB` documented in `.env.example`.

Declined, with reasons:
- *Rename `cpuQuota` → `perAgentNanoCpus`*: the ticket's confirmed seam names the field `cpuQuota`; kept the spec's vocabulary, units documented in JSDoc.
- *Restart accounting hole (in-memory occupancy misses containers surviving a restart)*: doesn't exist under current semantics — `recoverOrphanedTasks()` force-removes every running task's container **before** `startQueue()`, so no container outlives the process to be miscounted. The Phase 5 restart-re-claim ticket changes those semantics and must own the accounting then.
- *Construct the provider in `startQueue` instead of lazily in the poll*: keeps `startQueue` synchronous; the lazy init is awaited in-tick, so no pickup is ever skipped.

Notes for verification on the VPS:
- Boot log now states the derived capacity (`[orchestrator] Capacity: N agent slot(s), …`) — expect **2** on the CX22.
- The memory-cap→task-fails path is structural (hard cap + existing exec-failure handling) and can't be unit-tested without Docker mocking, which the ticket forbids — worth one deliberate OOM on the VPS before ticking that box.

Pre-existing repo lint debt (19 problems in `custom-server.js`, `preview-pane.tsx`, `discord/client.ts`, `output-parser.test.ts`, `turn-manager.ts`) is untouched — none of it is in files this PR changes, and there is no CI lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)