### PR TITLE
Phase 5: review-gate evaluation and auto-merge arming

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "tailwind-merge": "^3.5.0",
     "tar-fs": "^3.1.2",
     "tw-animate-css": "^1.4.0",
-    "ulidx": "^2.4.1"
+    "ulidx": "^2.4.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       ulidx:
         specifier: ^2.4.1
         version: 2.4.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -104,7 +107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1))
+        version: 4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))
 
 packages:
 
@@ -4346,6 +4349,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -5754,14 +5762,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@20.19.37)(typescript@5.9.3)
-      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)
+      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -8592,7 +8600,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1):
+  vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -8605,11 +8613,12 @@ snapshots:
       esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 2.6.1
+      yaml: 2.9.0
 
-  vitest@4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)):
+  vitest@4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -8626,7 +8635,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)
+      vite: 8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
@@ -8715,6 +8724,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -169,6 +169,38 @@ export async function notifySlotsSaturated(
 }
 
 /**
+ * Tell the owner gate evaluation failed closed for a PR — the gate config
+ * was missing or unparseable, so nothing was armed. Sent once per failure
+ * (the autonomy sweep tracks the announcement; this just delivers). No-op
+ * when no fleet channel is configured: the sweep already logged it.
+ */
+export async function notifyGateConfigError(
+  channelId: string | null,
+  payload: { issueRef: string; prNumber: number; reason: string }
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Gate config error — nothing armed`)
+      .setDescription(
+        `${payload.issueRef} (PR #${payload.prNumber}) finished its implement pass, ` +
+          `but the review-gate config could not be read: ${payload.reason}\n\n` +
+          `The PR stays disarmed until the config on the default branch is fixed.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send gate-config-error notification:`, err);
+  }
+}
+
+/**
  * Post an "agent finished a turn — your move" idle notification.
  * Returns the Discord message ID so it can become the task's current
  * interactive message (for ✅-to-complete and reply-to-continue).

--- a/src/lib/github/contents.ts
+++ b/src/lib/github/contents.ts
@@ -1,4 +1,4 @@
-import { getOctokit } from "./client";
+import { getOctokit, isGitHubConfigured } from "./client";
 
 /**
  * Reading a file from a repo's default branch. `missing` (a 404 or a
@@ -20,6 +20,10 @@ export async function fetchFileFromDefaultBranch(
   repo: string,
   path: string
 ): Promise<RepoFileResult> {
+  if (!isGitHubConfigured()) {
+    return { ok: false, missing: false, reason: "GitHub is not configured" };
+  }
+
   try {
     const octokit = await getOctokit();
     const { data } = await octokit.rest.repos.getContent({ owner, repo, path });

--- a/src/lib/github/contents.ts
+++ b/src/lib/github/contents.ts
@@ -1,0 +1,41 @@
+import { getOctokit } from "./client";
+
+/**
+ * Reading a file from a repo's default branch. `missing` (a 404 or a
+ * directory where a file should be) is a real config problem the caller
+ * fails closed on; `transient` is an API hiccup worth retrying silently.
+ */
+export type RepoFileResult =
+  | { ok: true; text: string }
+  | { ok: false; missing: true }
+  | { ok: false; missing: false; reason: string };
+
+/**
+ * Fetch one file from a repo's default branch. No `ref` is ever passed:
+ * for gate config this is a security property — a PR must not be able to
+ * widen its own gates from its head branch.
+ */
+export async function fetchFileFromDefaultBranch(
+  owner: string,
+  repo: string,
+  path: string
+): Promise<RepoFileResult> {
+  try {
+    const octokit = await getOctokit();
+    const { data } = await octokit.rest.repos.getContent({ owner, repo, path });
+
+    if (Array.isArray(data) || data.type !== "file" || typeof data.content !== "string") {
+      return { ok: false, missing: true };
+    }
+    return { ok: true, text: Buffer.from(data.content, "base64").toString("utf8") };
+  } catch (err) {
+    if ((err as { status?: number }).status === 404) {
+      return { ok: false, missing: true };
+    }
+    return {
+      ok: false,
+      missing: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/lib/github/pull-requests.ts
+++ b/src/lib/github/pull-requests.ts
@@ -50,6 +50,126 @@ export async function createDraftPr(options: CreatePrOptions): Promise<PrResult 
 }
 
 /**
+ * The slice of PR state gate evaluation depends on. Null on any API failure
+ * — the caller skips the PR this sweep and retries on the next.
+ */
+export async function getPrState(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<{ open: boolean; autoMergeArmed: boolean } | null> {
+  if (!isGitHubConfigured()) return null;
+
+  try {
+    const octokit = await getOctokit();
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+    return { open: pr.state === "open", autoMergeArmed: pr.auto_merge != null };
+  } catch (err) {
+    console.error(`[github] Failed to read PR #${prNumber} state:`, err);
+    return null;
+  }
+}
+
+/**
+ * Every path a PR changes, from the GitHub API. Renames contribute both
+ * sides: a gated file moved away still deserves its gate. Null on failure
+ * so gate evaluation can fail closed rather than evaluate a partial list.
+ */
+export async function listChangedFiles(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<string[] | null> {
+  if (!isGitHubConfigured()) return null;
+
+  try {
+    const octokit = await getOctokit();
+    const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+    });
+    const paths = new Set<string>();
+    for (const file of files) {
+      paths.add(file.filename);
+      if (file.previous_filename) paths.add(file.previous_filename);
+    }
+    return [...paths];
+  } catch (err) {
+    console.error(`[github] Failed to list files of PR #${prNumber}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Add a label to a PR (PRs are issues to the labels API).
+ */
+export async function labelPr(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  label: string
+): Promise<boolean> {
+  if (!isGitHubConfigured()) return false;
+
+  try {
+    const octokit = await getOctokit();
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: [label],
+    });
+    return true;
+  } catch (err) {
+    console.error(`[github] Failed to label PR #${prNumber} with "${label}":`, err);
+    return false;
+  }
+}
+
+/**
+ * Arm auto-merge (squash) on a PR. With branch protection in place the PR
+ * merges only once its required approval lands — arming after the final
+ * push means that approval will be the reviewer's, not a stale one.
+ */
+export async function armAutoMergeSquash(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<boolean> {
+  if (!isGitHubConfigured()) return false;
+
+  try {
+    const octokit = await getOctokit();
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    await octokit.graphql(
+      `
+      mutation($id: ID!) {
+        enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) {
+          pullRequest { id }
+        }
+      }
+    `,
+      { id: pr.node_id }
+    );
+    return true;
+  } catch (err) {
+    console.error(`[github] Failed to arm auto-merge on PR #${prNumber}:`, err);
+    return false;
+  }
+}
+
+/**
  * Mark a draft PR as ready for review.
  */
 export async function markPrReady(

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -3,6 +3,7 @@ import {
   decideNext,
   type AutonomySnapshot,
   type CandidateIssue,
+  type PendingGateEvaluation,
   type ProjectSnapshot,
 } from "../decide";
 
@@ -52,6 +53,25 @@ function makeSnapshot(overrides: Partial<AutonomySnapshot> = {}): AutonomySnapsh
     projects: [makeProject()],
     candidates: [makeCandidate()],
     inFlightClaims: [],
+    pendingGateEvaluations: [],
+    announcedGateConfigErrors: [],
+    ...overrides,
+  };
+}
+
+function makePending(
+  overrides: Partial<PendingGateEvaluation> = {}
+): PendingGateEvaluation {
+  return {
+    runId: "run-1",
+    issueRef: "acme/widgets#7",
+    prNumber: 41,
+    changedPaths: ["src/lib/util.ts"],
+    gateConfig: {
+      ok: true,
+      estate: { "visual-ui": ["**/components/**"] },
+      extension: { infrastructure: ["Caddyfile"] },
+    },
     ...overrides,
   };
 }
@@ -472,12 +492,152 @@ describe("decideNext — slot saturation announcement", () => {
   });
 });
 
+describe("decideNext — gate evaluation of a finished implement pass", () => {
+  it("arms auto-merge for an ungated PR", () => {
+    const actions = decideNext(
+      makeSnapshot({ candidates: [], pendingGateEvaluations: [makePending()] })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "armAutoMerge",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+      },
+    ]);
+  });
+
+  it("gates a PR whose changed paths match, naming the categories", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({
+            changedPaths: ["src/components/Button.tsx", "Caddyfile"],
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "gatePr",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        categories: ["infrastructure", "visual-ui"],
+      },
+    ]);
+  });
+
+  it("fails closed on missing or unparseable config: nothing armed, owner told", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({
+            gateConfig: { ok: false, reason: "estate config missing from default branch" },
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "notify",
+        event: "gate-config-error",
+        payload: {
+          runId: "run-1",
+          issueRef: "acme/widgets#7",
+          prNumber: 41,
+          reason: "estate config missing from default branch",
+        },
+      },
+    ]);
+  });
+
+  it("stays quiet about a config failure it has already announced", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({ gateConfig: { ok: false, reason: "invalid YAML" } }),
+        ],
+        announcedGateConfigErrors: ["run-1"],
+      })
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("decides each pending PR independently", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending(),
+          makePending({
+            runId: "run-2",
+            issueRef: "acme/widgets#9",
+            prNumber: 44,
+            changedPaths: ["src/components/Nav.tsx"],
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      { type: "armAutoMerge", runId: "run-1", issueRef: "acme/widgets#7", prNumber: 41 },
+      {
+        type: "gatePr",
+        runId: "run-2",
+        issueRef: "acme/widgets#9",
+        prNumber: 44,
+        categories: ["visual-ui"],
+      },
+    ]);
+  });
+
+  it("finishes gate decisions before starting new claims", () => {
+    // Reducer priority order: in-flight work first, then a new claim
+    const actions = decideNext(
+      makeSnapshot({ pendingGateEvaluations: [makePending()] })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual(["armAutoMerge", "claimIssue"]);
+  });
+
+  it("gate decisions do not consume claimable slots", () => {
+    // Gate evaluation is orchestrator work, not container work — a pending
+    // decision must not block the last free slot from a new claim.
+    const actions = decideNext(
+      makeSnapshot({
+        slots: { total: 2, occupied: 1, occupants: ["implement: acme/widgets#7"] },
+        pendingGateEvaluations: [makePending()],
+      })
+    );
+
+    expect(actions.filter((a) => a.type === "claimIssue")).toHaveLength(1);
+  });
+});
+
 describe("arming boundary — interlude never applies ready-for-agent", () => {
   // The executor performs only what the reducer can emit. This is the
-  // complete action vocabulary, and none of its members mutates labels —
-  // so no path through the autonomy loop can press the launch button.
-  // Widening this list is a signal to re-review the arming boundary.
-  const EXECUTOR_VOCABULARY = ["claimIssue", "pausePickup", "notify"];
+  // complete action vocabulary, and none of its members mutates the
+  // ready-for-agent label — so no path through the autonomy loop can press
+  // the launch button. gatePr and armAutoMerge joined with issue #16:
+  // gatePr only ever *adds* human oversight (the human-signoff label), and
+  // armAutoMerge is reachable solely through the deterministic gate
+  // evaluator over config read from the default branch — never from issue
+  // text. Widening this list is a signal to re-review the arming boundary.
+  const EXECUTOR_VOCABULARY = [
+    "claimIssue",
+    "pausePickup",
+    "notify",
+    "gatePr",
+    "armAutoMerge",
+  ];
 
   const stressMatrix: AutonomySnapshot[] = [
     makeSnapshot(),
@@ -499,6 +659,23 @@ describe("arming boundary — interlude never applies ready-for-agent", () => {
     }),
     makeSnapshot({
       candidates: [makeCandidate({ attemptsMade: 2, hasOpenBlocker: true })],
+    }),
+    makeSnapshot({
+      pendingGateEvaluations: [
+        makePending(),
+        makePending({
+          runId: "run-2",
+          issueRef: "acme/widgets#8",
+          prNumber: 42,
+          changedPaths: ["src/components/Nav.tsx", "drizzle/0001.sql"],
+        }),
+        makePending({
+          runId: "run-3",
+          issueRef: "acme/widgets#9",
+          prNumber: 43,
+          gateConfig: { ok: false, reason: "invalid YAML" },
+        }),
+      ],
     }),
   ];
 

--- a/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { matchesGateGlob, parseGateConfig } from "../gates";
+import {
+  evaluateGates,
+  matchesGateGlob,
+  parseGateConfig,
+  type GateConfig,
+} from "../gates";
 
 describe("matchesGateGlob — parity with the platform's bash evaluator", () => {
   // Every verdict below was produced by the bash evaluator itself:
@@ -100,5 +105,58 @@ describe("parseGateConfig", () => {
       ok: true,
       config: { "visual-ui": [] },
     });
+  });
+});
+
+describe("evaluateGates", () => {
+  // Estate categories as documented in the repo extension's header
+  const estate: GateConfig = {
+    "visual-ui": ["**/components/**", "**/app/**/page.*", "**/app/**/layout.*"],
+    persistence: ["**/migrations/**", "*.sql"],
+    "gate-config": ["**/review-gates.yaml"],
+  };
+  const extension: GateConfig = {
+    infrastructure: ["custom-server.js", "Caddyfile"],
+    persistence: ["src/db/schema.ts", "drizzle/**"],
+  };
+
+  it("returns no matches for paths no glob covers", () => {
+    expect(evaluateGates(estate, extension, ["src/lib/ulid.ts", "README.md"])).toEqual([]);
+  });
+
+  it("names every matched category once, sorted", () => {
+    const matches = evaluateGates(estate, extension, [
+      "src/components/Button.tsx",
+      "src/components/Card.tsx",
+      "custom-server.js",
+      "db/schema.sql",
+    ]);
+    expect(matches).toEqual(["infrastructure", "persistence", "visual-ui"]);
+  });
+
+  it("matches categories added by the repo extension", () => {
+    expect(evaluateGates(estate, extension, ["Caddyfile"])).toEqual(["infrastructure"]);
+  });
+
+  it("keeps estate globs live when the extension redefines their category", () => {
+    // Additive-only: the extension's own `persistence` globs cannot shadow
+    // the estate's — a *.sql change still gates even though the extension's
+    // persistence list doesn't mention it.
+    expect(evaluateGates(estate, extension, ["db/schema.sql"])).toEqual(["persistence"]);
+    expect(evaluateGates(estate, extension, ["src/db/schema.ts"])).toEqual(["persistence"]);
+  });
+
+  it("gates a PR that touches the gate config itself", () => {
+    expect(evaluateGates(estate, extension, ["docs/agents/review-gates.yaml"])).toEqual([
+      "gate-config",
+    ]);
+  });
+
+  it("evaluates with an empty extension against the estate alone", () => {
+    expect(evaluateGates(estate, {}, ["app/dashboard/page.tsx"])).toEqual(["visual-ui"]);
+  });
+
+  it("returns no matches for an empty change set", () => {
+    expect(evaluateGates(estate, extension, [])).toEqual([]);
   });
 });

--- a/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { matchesGateGlob } from "../gates";
+
+describe("matchesGateGlob — parity with the platform's bash evaluator", () => {
+  // Every verdict below was produced by the bash evaluator itself:
+  //   [[ $path == $glob ]] || { [[ $glob == '**/'* ]] && [[ $path == ${glob#**/} ]]; }
+  // Bash pattern matching gives `*` (and therefore `**`) free rein across `/`,
+  // and the evaluator's one extension is that a leading `**/` also matches at
+  // the repo root. Notably this is NOT gitignore: `**` is not "zero or more
+  // path segments", it is literally star — so `**/app/**/page.*` does not
+  // match `src/app/page.tsx` (nothing between `app/` and `page.`).
+  const verdicts: Array<[path: string, glob: string, matches: boolean]> = [
+    // Estate visual-ui gates
+    ["src/components/Button.tsx", "**/components/**", true],
+    ["components/Button.tsx", "**/components/**", true], // root rule
+    ["src/my-components/Button.tsx", "**/components/**", false],
+    ["src/components", "**/components/**", false],
+    ["src/app/admin/users/page.tsx", "**/app/**/page.*", true],
+    ["app/dashboard/page.tsx", "**/app/**/page.*", true], // root rule
+    ["app/page.tsx", "**/app/**/page.*", false], // ** is star, not "any depth"
+    ["src/app/page.tsx", "**/app/**/page.*", false],
+    // Self-gating: the gate config gates changes to itself
+    ["docs/agents/review-gates.yaml", "**/review-gates.yaml", true],
+    ["review-gates.yaml", "**/review-gates.yaml", true], // root rule
+    ["review-gates.yaml.bak", "**/review-gates.yaml", false],
+    ["standards/review-gates.yaml", "**/review-gates.yaml", true],
+    // Root-level match via a leading **/
+    ["middleware.ts", "**/middleware.*", true],
+    ["src/middleware.ts", "**/middleware.*", true],
+    [".env.local", "**/.env*", true],
+    ["config/.env.production", "**/.env*", true],
+    // A bare * crosses / — *.sql gates SQL anywhere in the tree
+    ["schema.sql", "*.sql", true],
+    ["db/schema.sql", "*.sql", true],
+    // Literal paths from this repo's extension
+    ["custom-server.js", "custom-server.js", true],
+    ["src/custom-server.js", "custom-server.js", false],
+    ["src/lib/docker/container-manager.ts", "src/lib/docker/**", true],
+    ["src/lib/docker", "src/lib/docker/**", false],
+    ["drizzle/0001_init.sql", "drizzle/**", true],
+    // Full bash pattern language: ? and [...] also ignore /
+    ["a/b.txt", "a?b.txt", true],
+    ["a/b.txt", "a[/x]b.txt", true],
+    ["file1.ts", "file[!0-9].ts", false],
+    ["fileA.ts", "file[!0-9].ts", true],
+  ];
+
+  it.each(verdicts)("%s vs %s -> %s", (path, glob, matches) => {
+    expect(matchesGateGlob(path, glob)).toBe(matches);
+  });
+});

--- a/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matchesGateGlob } from "../gates";
+import { matchesGateGlob, parseGateConfig } from "../gates";
 
 describe("matchesGateGlob — parity with the platform's bash evaluator", () => {
   // Every verdict below was produced by the bash evaluator itself:
@@ -47,5 +47,58 @@ describe("matchesGateGlob — parity with the platform's bash evaluator", () => 
 
   it.each(verdicts)("%s vs %s -> %s", (path, glob, matches) => {
     expect(matchesGateGlob(path, glob)).toBe(matches);
+  });
+});
+
+describe("parseGateConfig", () => {
+  it("parses categories and their globs from the estate shape", () => {
+    const text = [
+      "human_signoff:",
+      "  visual-ui:",
+      '    - "**/components/**"',
+      '    - "**/app/**/page.*"',
+      "  persistence:",
+      '    - "**/migrations/**"',
+    ].join("\n");
+
+    expect(parseGateConfig(text)).toEqual({
+      ok: true,
+      config: {
+        "visual-ui": ["**/components/**", "**/app/**/page.*"],
+        persistence: ["**/migrations/**"],
+      },
+    });
+  });
+
+  it("accepts an empty human_signoff mapping as a config with no gates", () => {
+    // A migrated repo with nothing extra to gate ships exactly this file
+    expect(parseGateConfig("# nothing beyond the estate\nhuman_signoff:\n")).toEqual({
+      ok: true,
+      config: {},
+    });
+  });
+
+  it("rejects invalid YAML with a reason", () => {
+    const result = parseGateConfig("human_signoff:\n  visual-ui: [unclosed");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBeTruthy();
+  });
+
+  it("rejects a document without a human_signoff mapping", () => {
+    expect(parseGateConfig("signoff:\n  visual-ui:\n    - '*'\n").ok).toBe(false);
+    expect(parseGateConfig("").ok).toBe(false);
+  });
+
+  it("rejects a category whose globs are not a list of strings", () => {
+    expect(parseGateConfig("human_signoff:\n  visual-ui: '**/components/**'\n").ok).toBe(false);
+    expect(parseGateConfig("human_signoff:\n  visual-ui:\n    - 42\n").ok).toBe(false);
+  });
+
+  it("treats a category with no globs as empty rather than an error", () => {
+    // A commented-out category leaves `name:` with a null value behind
+    expect(parseGateConfig("human_signoff:\n  visual-ui:\n")).toEqual({
+      ok: true,
+      config: { "visual-ui": [] },
+    });
   });
 });

--- a/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
@@ -51,6 +51,9 @@ describe("matchesGateGlob — parity with the platform's bash evaluator", () => 
     // Bash * matches absolutely anything — a newline smuggled into a
     // filename must not slip a gated path past its glob
     ["evil\nname/schema.sql", "*.sql", true],
+    // A backslash escapes the following pattern character and is discarded
+    ["a*b.ts", "a\\*b.ts", true],
+    ["axb.ts", "a\\*b.ts", false],
   ];
 
   it.each(verdicts)("%s vs %s -> %s", (path, glob, matches) => {

--- a/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/gates.test.ts
@@ -48,6 +48,9 @@ describe("matchesGateGlob — parity with the platform's bash evaluator", () => 
     ["a/b.txt", "a[/x]b.txt", true],
     ["file1.ts", "file[!0-9].ts", false],
     ["fileA.ts", "file[!0-9].ts", true],
+    // Bash * matches absolutely anything — a newline smuggled into a
+    // filename must not slip a gated path past its glob
+    ["evil\nname/schema.sql", "*.sql", true],
   ];
 
   it.each(verdicts)("%s vs %s -> %s", (path, glob, matches) => {

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -7,6 +7,7 @@
  * (sweep.ts) is a thin performer of the Actions returned here.
  */
 
+import { evaluateGates, type GateConfig } from "./gates";
 import { selectWorkflow, type WorkflowSelection } from "./ticket";
 
 export interface ProjectSnapshot {
@@ -38,6 +39,24 @@ export interface CandidateIssue {
   hasActiveRun: boolean;
 }
 
+/**
+ * A finished implement pass whose PR awaits its gate decision. The configs
+ * were read from default branches (never the PR's head) and parsed by the
+ * gatherer; a parse or read failure arrives as `ok: false` so the reducer
+ * can fail closed instead of guessing.
+ */
+export interface PendingGateEvaluation {
+  runId: string;
+  /** "owner/repo#n" */
+  issueRef: string;
+  prNumber: number;
+  /** Paths the PR changes, from the GitHub API */
+  changedPaths: string[];
+  gateConfig:
+    | { ok: true; estate: GateConfig; extension: GateConfig }
+    | { ok: false; reason: string };
+}
+
 export interface AutonomySnapshot {
   now: Date;
   autonomyEnabledGlobal: boolean;
@@ -57,6 +76,11 @@ export interface AutonomySnapshot {
   candidates: CandidateIssue[];
   /** Issue refs whose claim is currently being executed (idempotency) */
   inFlightClaims: string[];
+  /** Finished implement passes whose PRs await a gate decision */
+  pendingGateEvaluations: PendingGateEvaluation[];
+  /** Run IDs whose gate-config failure was already announced — the owner is
+   * told once per failure, not once per sweep */
+  announcedGateConfigErrors: string[];
 }
 
 export type PauseReason =
@@ -83,6 +107,19 @@ export type Action =
       type: "notify";
       event: "slots-saturated";
       payload: { occupied: number; total: number; occupants: string[] };
+    }
+  | {
+      type: "gatePr";
+      runId: string;
+      issueRef: string;
+      prNumber: number;
+      categories: string[];
+    }
+  | { type: "armAutoMerge"; runId: string; issueRef: string; prNumber: number }
+  | {
+      type: "notify";
+      event: "gate-config-error";
+      payload: { runId: string; issueRef: string; prNumber: number; reason: string };
     };
 
 /** Allowed by default: the repo owner; extended by the configured allow-list. */
@@ -108,6 +145,51 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
         occupants: snapshot.slots.occupants,
       },
     });
+  }
+
+  // Gate decisions come before new claims: finish in-flight work first.
+  // Whether an agent-authored PR may merge without a human is decided here,
+  // by data — changed paths against config from default branches. A config
+  // that is missing or unparseable fails closed: nothing armed, the owner
+  // told (once), and the run left pending so a config fix picks it up again.
+  for (const pending of snapshot.pendingGateEvaluations) {
+    if (!pending.gateConfig.ok) {
+      if (!snapshot.announcedGateConfigErrors.includes(pending.runId)) {
+        actions.push({
+          type: "notify",
+          event: "gate-config-error",
+          payload: {
+            runId: pending.runId,
+            issueRef: pending.issueRef,
+            prNumber: pending.prNumber,
+            reason: pending.gateConfig.reason,
+          },
+        });
+      }
+      continue;
+    }
+
+    const categories = evaluateGates(
+      pending.gateConfig.estate,
+      pending.gateConfig.extension,
+      pending.changedPaths
+    );
+    if (categories.length > 0) {
+      actions.push({
+        type: "gatePr",
+        runId: pending.runId,
+        issueRef: pending.issueRef,
+        prNumber: pending.prNumber,
+        categories,
+      });
+    } else {
+      actions.push({
+        type: "armAutoMerge",
+        runId: pending.runId,
+        issueRef: pending.issueRef,
+        prNumber: pending.prNumber,
+      });
+    }
   }
 
   if (snapshot.candidates.length === 0) return actions;

--- a/src/lib/orchestrator/autonomy/gates.ts
+++ b/src/lib/orchestrator/autonomy/gates.ts
@@ -72,6 +72,34 @@ export function parseGateConfig(text: string): GateConfigResult {
 }
 
 /**
+ * Which gate categories do these changed paths trip? The estate config and
+ * the repo extension merge by glob-list union, so an extension can only ever
+ * add gates: a category redefined by the extension still carries every
+ * estate glob. Returns matched category names, sorted and unique — empty
+ * means the PR is ungated and may be armed.
+ */
+export function evaluateGates(
+  estateConfig: GateConfig,
+  repoExtension: GateConfig,
+  changedPaths: string[]
+): string[] {
+  const merged: GateConfig = {};
+  for (const source of [estateConfig, repoExtension]) {
+    for (const [category, globs] of Object.entries(source)) {
+      merged[category] = [...(merged[category] ?? []), ...globs];
+    }
+  }
+
+  const matched = new Set<string>();
+  for (const [category, globs] of Object.entries(merged)) {
+    if (changedPaths.some((path) => globs.some((glob) => matchesGateGlob(path, glob)))) {
+      matched.add(category);
+    }
+  }
+  return [...matched].sort();
+}
+
+/**
  * Translate one bash pattern to an anchored RegExp. Bash `[[ == ]]` matching
  * knows nothing about path separators: `*` and `?` match `/` like any other
  * character, and consecutive stars collapse to one.

--- a/src/lib/orchestrator/autonomy/gates.ts
+++ b/src/lib/orchestrator/autonomy/gates.ts
@@ -145,7 +145,10 @@ function bashPatternToRegex(pattern: string): RegExp {
       i++;
     }
   }
-  return new RegExp(`^${re}$`);
+  // The `s` flag keeps `.` matching newlines: bash patterns have no notion
+  // of a special character, and a newline smuggled into a filename must not
+  // slip a gated path past its glob (that would fail open).
+  return new RegExp(`^${re}$`, "s");
 }
 
 /**

--- a/src/lib/orchestrator/autonomy/gates.ts
+++ b/src/lib/orchestrator/autonomy/gates.ts
@@ -8,6 +8,8 @@
  * `**` + `/` also matches at the repo root.
  */
 
+import { parse as parseYaml } from "yaml";
+
 /** Label a gated PR receives; a human must approve and merge it. */
 export const HUMAN_SIGNOFF_LABEL = "human-signoff";
 
@@ -16,6 +18,58 @@ export const ESTATE_GATES_PATH = "standards/review-gates.yaml";
 
 /** A repo's additive extension, read from its own default branch. */
 export const REPO_GATES_PATH = "docs/agents/review-gates.yaml";
+
+/** Gate categories: name -> the globs that trip it. */
+export type GateConfig = Record<string, string[]>;
+
+export type GateConfigResult =
+  | { ok: true; config: GateConfig }
+  | { ok: false; reason: string };
+
+/**
+ * Parse one review-gates.yaml. The contract shape is a `human_signoff`
+ * mapping of category name to a list of globs; anything else is unparseable
+ * and the caller fails closed. Two deliberate leniencies match real files:
+ * an empty `human_signoff:` means "no gates here", and a category left with
+ * no globs (a commented-out list) means an empty category, not an error.
+ */
+export function parseGateConfig(text: string): GateConfigResult {
+  let doc: unknown;
+  try {
+    doc = parseYaml(text);
+  } catch (err) {
+    return { ok: false, reason: `invalid YAML: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (doc === null || doc === undefined || typeof doc !== "object" || Array.isArray(doc)) {
+    return { ok: false, reason: "document is not a mapping with a human_signoff key" };
+  }
+  if (!("human_signoff" in doc)) {
+    return { ok: false, reason: "document has no human_signoff key" };
+  }
+
+  const signoff = (doc as Record<string, unknown>).human_signoff;
+  if (signoff === null || signoff === undefined) return { ok: true, config: {} };
+  if (typeof signoff !== "object" || Array.isArray(signoff)) {
+    return { ok: false, reason: "human_signoff is not a mapping of categories" };
+  }
+
+  const config: GateConfig = {};
+  for (const [category, globs] of Object.entries(signoff as Record<string, unknown>)) {
+    if (globs === null || globs === undefined) {
+      config[category] = [];
+      continue;
+    }
+    if (!Array.isArray(globs) || globs.some((g) => typeof g !== "string" || g === "")) {
+      return {
+        ok: false,
+        reason: `category "${category}" is not a list of glob strings`,
+      };
+    }
+    config[category] = globs as string[];
+  }
+  return { ok: true, config };
+}
 
 /**
  * Translate one bash pattern to an anchored RegExp. Bash `[[ == ]]` matching

--- a/src/lib/orchestrator/autonomy/gates.ts
+++ b/src/lib/orchestrator/autonomy/gates.ts
@@ -1,0 +1,80 @@
+/**
+ * Review-gate evaluation (issue #16) — the deterministic answer to "may this
+ * agent-authored PR merge without a human?". Pure: config text and changed
+ * paths come in, matched categories come out. The laptop runner's bash
+ * evaluator and this module are two executors of one contract, so the glob
+ * semantics here must reproduce bash `[[ == ]]` exactly: `*` (and therefore
+ * `**`) crosses `/`, and the evaluator's single extension is that a leading
+ * `**` + `/` also matches at the repo root.
+ */
+
+/** Label a gated PR receives; a human must approve and merge it. */
+export const HUMAN_SIGNOFF_LABEL = "human-signoff";
+
+/** Estate-wide gate config, read from the platform repo's default branch. */
+export const ESTATE_GATES_PATH = "standards/review-gates.yaml";
+
+/** A repo's additive extension, read from its own default branch. */
+export const REPO_GATES_PATH = "docs/agents/review-gates.yaml";
+
+/**
+ * Translate one bash pattern to an anchored RegExp. Bash `[[ == ]]` matching
+ * knows nothing about path separators: `*` and `?` match `/` like any other
+ * character, and consecutive stars collapse to one.
+ */
+function bashPatternToRegex(pattern: string): RegExp {
+  let re = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*") {
+      re += ".*";
+      while (pattern[i] === "*") i++;
+    } else if (c === "?") {
+      re += ".";
+      i++;
+    } else if (c === "[") {
+      // Bash class: `!` (or `^`) negates, a `]` in first position is literal,
+      // an unterminated `[` is a literal bracket.
+      let j = i + 1;
+      let body = "";
+      let negate = false;
+      if (pattern[j] === "!" || pattern[j] === "^") {
+        negate = true;
+        j++;
+      }
+      if (pattern[j] === "]") {
+        body += "\\]";
+        j++;
+      }
+      while (j < pattern.length && pattern[j] !== "]") {
+        body += pattern[j] === "-" ? "-" : pattern[j].replace(/[\\^\]]/g, "\\$&").replace(/[.*+?()[{|$]/g, "\\$&");
+        j++;
+      }
+      if (j >= pattern.length) {
+        re += "\\[";
+        i++;
+      } else {
+        re += `[${negate ? "^" : ""}${body}]`;
+        i = j + 1;
+      }
+    } else {
+      re += c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      i++;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/**
+ * Does a changed path hit a gate glob? Exactly the bash evaluator's test:
+ * `[[ $path == $glob ]]`, plus the root rule that a glob starting `**\/`
+ * also matches with that prefix stripped.
+ */
+export function matchesGateGlob(path: string, glob: string): boolean {
+  if (bashPatternToRegex(glob).test(path)) return true;
+  if (glob.startsWith("**/") && bashPatternToRegex(glob.slice(3)).test(path)) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/orchestrator/autonomy/gates.ts
+++ b/src/lib/orchestrator/autonomy/gates.ts
@@ -99,10 +99,22 @@ export function evaluateGates(
   return [...matched].sort();
 }
 
+/** Escape one character for use as a regex literal. */
+function escapeLiteral(c: string): string {
+  return c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Escape one character for use inside a regex character class. */
+function escapeForClass(c: string): string {
+  if (c === "-") return "-"; // keep ranges like 0-9 intact
+  return c.replace(/[\\^\]]/g, "\\$&").replace(/[.*+?()[{|$]/g, "\\$&");
+}
+
 /**
  * Translate one bash pattern to an anchored RegExp. Bash `[[ == ]]` matching
  * knows nothing about path separators: `*` and `?` match `/` like any other
- * character, and consecutive stars collapse to one.
+ * character, consecutive stars collapse to one, and a backslash escapes the
+ * following pattern character (the backslash itself is discarded).
  */
 function bashPatternToRegex(pattern: string): RegExp {
   let re = "";
@@ -115,6 +127,9 @@ function bashPatternToRegex(pattern: string): RegExp {
     } else if (c === "?") {
       re += ".";
       i++;
+    } else if (c === "\\" && i + 1 < pattern.length) {
+      re += escapeLiteral(pattern[i + 1]);
+      i += 2;
     } else if (c === "[") {
       // Bash class: `!` (or `^`) negates, a `]` in first position is literal,
       // an unterminated `[` is a literal bracket.
@@ -130,7 +145,7 @@ function bashPatternToRegex(pattern: string): RegExp {
         j++;
       }
       while (j < pattern.length && pattern[j] !== "]") {
-        body += pattern[j] === "-" ? "-" : pattern[j].replace(/[\\^\]]/g, "\\$&").replace(/[.*+?()[{|$]/g, "\\$&");
+        body += escapeForClass(pattern[j]);
         j++;
       }
       if (j >= pattern.length) {
@@ -141,7 +156,7 @@ function bashPatternToRegex(pattern: string): RegExp {
         i = j + 1;
       }
     } else {
-      re += c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      re += escapeLiteral(c);
       i++;
     }
   }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -9,10 +9,21 @@ import { db } from "@/db";
 import { projects, runs, tasks } from "@/db/schema";
 import { eq, isNotNull } from "drizzle-orm";
 import { newId } from "../../ulid";
-import { getConfig } from "../../config";
+import { getConfig, PLATFORM_REPO_URL } from "../../config";
 import { getOctokit, isGitHubConfigured } from "../../github/client";
+import { fetchFileFromDefaultBranch } from "../../github/contents";
 import { commentOnIssue, parseIssueRef } from "../../github/issues";
-import { notifySlotsSaturated } from "../../discord/notifications";
+import {
+  armAutoMergeSquash,
+  getPrState,
+  labelPr,
+  listChangedFiles,
+} from "../../github/pull-requests";
+import { parseRepoFromGitUrl } from "../../github/repo";
+import {
+  notifyGateConfigError,
+  notifySlotsSaturated,
+} from "../../discord/notifications";
 import { getCapacity } from "../capacity";
 import { occupiedSlots } from "../queue";
 import { getActiveTasks } from "../turn-manager";
@@ -21,7 +32,15 @@ import {
   type Action,
   type AutonomySnapshot,
   type CandidateIssue,
+  type PendingGateEvaluation,
 } from "./decide";
+import {
+  ESTATE_GATES_PATH,
+  HUMAN_SIGNOFF_LABEL,
+  REPO_GATES_PATH,
+  parseGateConfig,
+  type GateConfig,
+} from "./gates";
 import { ARMING_LABEL, labelNames, parseBlockedByRefs } from "./ticket";
 import { buildImplementPrompt } from "./workflow";
 
@@ -46,6 +65,9 @@ let sweepInterval: ReturnType<typeof setInterval> | null = null;
 let sweeping = false;
 let saturationAnnounced = false;
 const inFlightClaims = new Set<string>();
+// Run IDs whose gate-config failure the owner has already been told about —
+// once per failure, not once per sweep. Pruned as runs leave the pending set.
+const announcedGateConfigErrors = new Set<string>();
 
 export function startAutonomySweeps(): void {
   if (sweepInterval) return;
@@ -180,7 +202,134 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     })),
     candidates,
     inFlightClaims: [...inFlightClaims],
+    pendingGateEvaluations: await gatherPendingGateEvaluations(allRuns),
+    announcedGateConfigErrors: [...announcedGateConfigErrors],
   };
+}
+
+/** How one gate-config source read went: usable config, a real config
+ * problem to fail closed on, or an API hiccup worth retrying silently. */
+type GateConfigRead =
+  | { kind: "ok"; config: GateConfig }
+  | { kind: "failed"; reason: string }
+  | { kind: "transient" };
+
+async function readGateConfigFile(
+  owner: string,
+  repo: string,
+  path: string,
+  label: string
+): Promise<GateConfigRead> {
+  const file = await fetchFileFromDefaultBranch(owner, repo, path);
+  if (!file.ok) {
+    if (file.missing) {
+      return {
+        kind: "failed",
+        reason: `${label} (${path} in ${owner}/${repo}) is missing from the default branch`,
+      };
+    }
+    console.error(`[autonomy] Could not read ${path} from ${owner}/${repo}: ${file.reason}`);
+    return { kind: "transient" };
+  }
+  const parsed = parseGateConfig(file.text);
+  if (!parsed.ok) {
+    return {
+      kind: "failed",
+      reason: `${label} (${path} in ${owner}/${repo}) is unparseable: ${parsed.reason}`,
+    };
+  }
+  return { kind: "ok", config: parsed.config };
+}
+
+/**
+ * Finished implement passes whose PRs await a gate decision. A run enters
+ * this set only once its final push, PR-ready flip and PR-number recording
+ * have all happened (completeTask does them in that order), so arming
+ * always follows the final push — branch protection dismisses stale
+ * approvals, and an early arm would be dismissed with them.
+ *
+ * Gate config is read from default branches, never the PR's head: a PR
+ * cannot widen its own gates. Transient API failures skip the run for this
+ * sweep; the reconciliation loop retries. Already-armed, closed and merged
+ * PRs have nothing left to decide.
+ */
+async function gatherPendingGateEvaluations(
+  allRuns: Array<typeof runs.$inferSelect>
+): Promise<PendingGateEvaluation[]> {
+  const awaiting = allRuns.filter(
+    (r) => r.status === "implementing" && r.pullRequestNumber != null
+  );
+
+  // The owner is re-told about a config failure only if the run left the
+  // pending set and somehow returned; otherwise one announcement stands.
+  for (const runId of [...announcedGateConfigErrors]) {
+    if (!awaiting.some((r) => r.id === runId)) announcedGateConfigErrors.delete(runId);
+  }
+
+  if (awaiting.length === 0) return [];
+
+  // The estate config lives in the platform repo; one read serves the sweep.
+  const platformRepo = parseRepoFromGitUrl(PLATFORM_REPO_URL);
+  const estate: GateConfigRead = platformRepo
+    ? await readGateConfigFile(
+        platformRepo.owner,
+        platformRepo.repo,
+        ESTATE_GATES_PATH,
+        "estate gate config"
+      )
+    : { kind: "failed", reason: `platform repo URL is unparseable: ${PLATFORM_REPO_URL}` };
+  if (estate.kind === "transient") return [];
+
+  const extensionsByRepo = new Map<string, GateConfigRead>();
+  const pending: PendingGateEvaluation[] = [];
+
+  for (const run of awaiting) {
+    const ref = parseIssueRef(run.githubIssue);
+    if (!ref) {
+      console.error(`[autonomy] Run ${run.id} has unparsable issue ref: ${run.githubIssue}`);
+      continue;
+    }
+
+    const pr = await getPrState(ref.owner, ref.repo, run.pullRequestNumber!);
+    if (!pr) continue;
+    if (!pr.open || pr.autoMergeArmed) continue;
+
+    const repoKey = `${ref.owner}/${ref.repo}`;
+    let extension = extensionsByRepo.get(repoKey);
+    if (!extension) {
+      extension = await readGateConfigFile(
+        ref.owner,
+        ref.repo,
+        REPO_GATES_PATH,
+        "repo gate extension"
+      );
+      extensionsByRepo.set(repoKey, extension);
+    }
+    if (extension.kind === "transient") continue;
+
+    let gateConfig: PendingGateEvaluation["gateConfig"];
+    let changedPaths: string[] = [];
+    if (estate.kind === "failed") {
+      gateConfig = { ok: false, reason: estate.reason };
+    } else if (extension.kind === "failed") {
+      gateConfig = { ok: false, reason: extension.reason };
+    } else {
+      const files = await listChangedFiles(ref.owner, ref.repo, run.pullRequestNumber!);
+      if (files === null) continue;
+      changedPaths = files;
+      gateConfig = { ok: true, estate: estate.config, extension: extension.config };
+    }
+
+    pending.push({
+      runId: run.id,
+      issueRef: run.githubIssue,
+      prNumber: run.pullRequestNumber!,
+      changedPaths,
+      gateConfig,
+    });
+  }
+
+  return pending;
 }
 
 /** When ready-for-agent was applied — the "armed at" ordering key. Paginates
@@ -249,6 +398,12 @@ async function executeActions(actions: Action[]): Promise<void> {
       case "claimIssue":
         await executeClaim(action);
         break;
+      case "gatePr":
+        await executeGatePr(action);
+        break;
+      case "armAutoMerge":
+        await executeArmAutoMerge(action);
+        break;
       case "pausePickup":
         console.log(
           `[autonomy] Pickup paused (${action.reason})${action.detail ? `: ${action.detail}` : ""}`
@@ -260,10 +415,85 @@ async function executeActions(actions: Action[]): Promise<void> {
             `[autonomy] All ${action.payload.total} slot(s) busy: ${action.payload.occupants.join(", ")}`
           );
           await notifySlotsSaturated(getConfig().discordFleetChannelId, action.payload);
+        } else if (action.event === "gate-config-error") {
+          await executeGateConfigError(action.payload);
         }
         break;
     }
   }
+}
+
+/**
+ * A gated PR: label it human-signoff, leave auto-merge disarmed, record the
+ * matched categories on the run, and say so on the issue. The label goes on
+ * first — if it fails, the run stays pending and the next sweep retries.
+ */
+async function executeGatePr(action: Extract<Action, { type: "gatePr" }>): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  const labeled = await labelPr(ref.owner, ref.repo, action.prNumber, HUMAN_SIGNOFF_LABEL);
+  if (!labeled) return;
+
+  db.update(runs)
+    .set({ status: "gated", gateCategories: action.categories })
+    .where(eq(runs.id, action.runId))
+    .run();
+
+  console.log(
+    `[autonomy] Gated ${action.issueRef} PR #${action.prNumber}: ${action.categories.join(", ")}`
+  );
+  await commentOnIssue(
+    action.issueRef,
+    `Review gates: PR #${action.prNumber} touches **${action.categories.join(", ")}** — ` +
+      `labelled \`${HUMAN_SIGNOFF_LABEL}\`, auto-merge left disarmed. A human approves and merges this one.`
+  );
+}
+
+/**
+ * An ungated PR: arm auto-merge (squash) and say so on the issue. Arming
+ * failure (e.g. auto-merge disabled on the repo) leaves the run pending for
+ * the next sweep and is already logged by the GitHub helper.
+ */
+async function executeArmAutoMerge(
+  action: Extract<Action, { type: "armAutoMerge" }>
+): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  const armed = await armAutoMergeSquash(ref.owner, ref.repo, action.prNumber);
+  if (!armed) return;
+
+  console.log(`[autonomy] Armed auto-merge on ${action.issueRef} PR #${action.prNumber}`);
+  await commentOnIssue(
+    action.issueRef,
+    `Review gates: PR #${action.prNumber} matched no gates — auto-merge (squash) armed; ` +
+      `an approving review will land it.`
+  );
+}
+
+/**
+ * Gate config missing or unparseable: nothing is armed, and the owner is
+ * told — on the issue, in the fleet channel, and in the log — once per
+ * failure. The run stays pending, so fixing the config on the default
+ * branch lets the next sweep decide it with no further ceremony.
+ */
+async function executeGateConfigError(payload: {
+  runId: string;
+  issueRef: string;
+  prNumber: number;
+  reason: string;
+}): Promise<void> {
+  announcedGateConfigErrors.add(payload.runId);
+  console.error(
+    `[autonomy] Gate evaluation failed closed for ${payload.issueRef} PR #${payload.prNumber}: ${payload.reason}`
+  );
+  await commentOnIssue(
+    payload.issueRef,
+    `Review gates could not be evaluated: ${payload.reason}. ` +
+      `Failing closed — PR #${payload.prNumber} stays disarmed until the config on the default branch is fixed.`
+  );
+  await notifyGateConfigError(getConfig().discordFleetChannelId, payload);
 }
 
 /**

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -68,6 +68,13 @@ const inFlightClaims = new Set<string>();
 // Run IDs whose gate-config failure the owner has already been told about —
 // once per failure, not once per sweep. Pruned as runs leave the pending set.
 const announcedGateConfigErrors = new Set<string>();
+// Consecutive sweeps each config source has failed to read for reasons that
+// looked transient (keyed "owner/repo:path"). A network blip retries
+// silently, but a persistent failure — a permissions problem reads the same
+// as a timeout from here — must eventually fail closed and tell the owner
+// rather than loop quietly forever.
+const consecutiveTransientReads = new Map<string, number>();
+const TRANSIENT_READ_ESCALATION_SWEEPS = 10;
 
 export function startAutonomySweeps(): void {
   if (sweepInterval) return;
@@ -220,17 +227,32 @@ async function readGateConfigFile(
   path: string,
   label: string
 ): Promise<GateConfigRead> {
+  const sourceKey = `${owner}/${repo}:${path}`;
   const file = await fetchFileFromDefaultBranch(owner, repo, path);
   if (!file.ok) {
     if (file.missing) {
+      consecutiveTransientReads.delete(sourceKey);
       return {
         kind: "failed",
         reason: `${label} (${path} in ${owner}/${repo}) is missing from the default branch`,
       };
     }
-    console.error(`[autonomy] Could not read ${path} from ${owner}/${repo}: ${file.reason}`);
+    const failures = (consecutiveTransientReads.get(sourceKey) ?? 0) + 1;
+    consecutiveTransientReads.set(sourceKey, failures);
+    console.error(
+      `[autonomy] Could not read ${path} from ${owner}/${repo} (attempt ${failures}): ${file.reason}`
+    );
+    if (failures >= TRANSIENT_READ_ESCALATION_SWEEPS) {
+      return {
+        kind: "failed",
+        reason:
+          `${label} (${path} in ${owner}/${repo}) could not be read for ` +
+          `${failures} consecutive sweeps: ${file.reason}`,
+      };
+    }
     return { kind: "transient" };
   }
+  consecutiveTransientReads.delete(sourceKey);
   const parsed = parseGateConfig(file.text);
   if (!parsed.ok) {
     return {


### PR DESCRIPTION
Closes #16

## What this does

Whether an agent-authored PR may merge without a human is now decided by data. After an implement pass's final push (run `implementing` + PR number recorded, which `completeTask` only does after the push and the ready flip), the sweep reads the estate gate config from the platform repo and the repo's additive extension from the target repo — both from **default branches**, never the PR's head — matches the PR's changed paths against them, and `decideNext` maps the result:

- **Match** → `gatePr`: PR labelled `human-signoff`, auto-merge left disarmed, matched categories recorded on the run (`status: gated`, `gateCategories`), outcome commented on the issue.
- **No match** → `armAutoMerge`: auto-merge (squash) armed via GraphQL, outcome commented on the issue. Arming always follows the final push, so branch protection's stale-approval dismissal can't disarm it.
- **Config missing or unparseable** → fail closed: nothing armed, the owner told once (issue comment + fleet channel + log), and the run left pending so a config fix self-heals on a later sweep.

## Glob semantics

`evaluateGates` is a pure TypeScript port of the bash evaluator: `*` (and `**`) cross `/`, `?` and `[...]` ignore `/` too, a backslash escapes the next pattern character, and a leading `**/` also matches at the repo root. Every expected verdict in the parity table (`gates.test.ts`) was generated by running the actual bash `[[ == ]]` evaluator — including the trap that `**` is star, not gitignore's any-depth (`**/app/**/page.*` does **not** match `src/app/page.tsx`). Estate + extension merge by glob-list union, so extensions are additive by construction: a category redefined in the repo file still carries every estate glob (tested).

Matching uses dotall regexes so a newline smuggled into a filename can't slip a gated path past its glob — failing there would fail open.

## Tests

TDD per the `workflow:tdd` label, at the two confirmed seams only: 27 bash-parity verdicts + parse/evaluate cases for `evaluateGates`, and the `gatePr` / `armAutoMerge` / fail-closed / announce-once mapping for `decideNext`. The arming-boundary vocabulary test widens to the two new actions and proves neither can touch `ready-for-agent`. No Docker/GitHub/Discord/DB mocking anywhere.

## Self-review findings (fixed point origin/main, spec #16)

Acted on:
- **Backslash parity** — bash discards `\` and takes the next pattern char literally; the matcher now does the same (was: latent divergence).
- **Persistent read failures escalate** — a config source failing 10 consecutive sweeps (~5 min) stops counting as transient and fails closed with the owner told; a permissions problem reads the same as a network blip from the API, and only one of them heals on retry.
- **`fetchFileFromDefaultBranch`** gains the `isGitHubConfigured()` guard every other `src/lib/github` helper has.

Disagreed with, deliberately:
- **Rename old-paths gated** (`previous_filename` included in changed paths): a possible input divergence from the laptop runner, kept because it only ever fails *safe* — a PR that moves a gated file away still gates.
- **Externally-armed PRs skipped**: a PR whose auto-merge a human armed by hand is treated as decided. Re-evaluating would have the orchestrator fight a human act; arming is owner-only under branch protection.
- **`node_id` refetch in `armAutoMergeSquash`**: avoiding it would thread a GraphQL identifier through the pure Action vocabulary (gather-time state into execute-time), which couples the reducer to GitHub for the price of one REST call on a rare event.
- **Flat `runId/issueRef/prNumber` action fields**: matches the existing flat `claimIssue` vocabulary style.
- **Announce-once set is in-memory**: resets on redeploy, worst case one duplicate owner ping per restart — bounded and cosmetic.

## Notes

- `pnpm lint` has pre-existing failures in `custom-server.js`, `src/components/preview-pane.tsx`, `src/lib/discord/client.ts` and `src/lib/orchestrator/__tests__/output-parser.test.ts` — none of them touched by this branch; all files changed here are lint-clean.
- `pnpm build` races on first-time migration of a cold `local.db` (parallel page-data workers all run the module-level migrator) — pre-existing; builds pass after a serial `drizzle-kit migrate`.
- New dependency: `yaml` (config parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
