### PR TITLE
fix(docker): re-include docs/agents/workflows in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ node_modules
 *.db-shm
 .env*
 docs
+!docs/agents/workflows


### PR DESCRIPTION
Closes #43

One line: `!docs/agents/workflows` after the `docs` exclusion in `.dockerignore`. The Dockerfile has copied that directory since #37, so every image build since has failed with `"/app/docs/agents/workflows": not found` — surfaced during the 2026-08-02 reboot recovery, hotfixed identically on the VPS working tree (this PR makes it permanent before the next `git pull` conflicts with that local edit).

Also note for #40's investigation: #37's deploy reported success despite this Dockerfile being unbuildable — the deploy pipeline can go green without shipping the merged image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)