### PR TITLE
Agent auth via CLAUDE_CODE_OAUTH_TOKEN from Doppler — retire the mounted credentials file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Auth — one of these is required:
-# Option 1: Use Claude Code subscription (auto-detected from ~/.claude/.credentials.json)
-# Option 2: ANTHROPIC_API_KEY=sk-ant-...
+# Option 1 (preferred): long-lived token from `claude setup-token`, injected into
+#   agent containers at exec. Production stores it in Doppler (interlude/prd).
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# Option 2 (legacy fallback): mounted credentials file — auto-detected from
+#   ~/.claude/.credentials.json, or see CLAUDE_CREDENTIALS_PATH below
+# Option 3: ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional
 GIT_USER_NAME=Interlude Agent
@@ -23,7 +27,7 @@ MAX_BUDGET_USD=5.00
 #   same config for the reverse proxy. Never hand-set DOMAIN in the VPS .env
 #   (issue #25). Set it here only for local (non-Doppler) subdomain testing.
 # DOMAIN=interlude.dev
-# CLAUDE_CREDENTIALS_PATH=/home/deploy/.claude/.credentials.json  # host path passed to agent containers; not mounted into app container
+# CLAUDE_CREDENTIALS_PATH=/home/deploy/.claude/.credentials.json  # legacy fallback: host path mounted into agent containers (not the app container); removed once CLAUDE_CODE_OAUTH_TOKEN is verified on the VPS (#48)
 
 # GitHub App — REQUIRED for git (clone/push) and for issue sync + PR creation.
 # The agent authenticates git using a short-lived App installation token; there is no PAT to rotate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ pnpm lint         # Run ESLint
 Local dev runs the orchestrator via `doppler run -- pnpm dev` — orchestrator secrets live in the Doppler `interlude/dev` config, not a `.env`. Two things Compose provides on the VPS that you must set up by hand locally:
 
 - **Agent-container network:** run `docker network create interlude` once. Agent containers attach to the `interlude` network, which Compose creates on the VPS but `pnpm dev` does not — without it, task runs fail with "network interlude not found".
-- **Claude credentials mount:** set `CLAUDE_CREDENTIALS_PATH` (in `interlude/dev`) to your host `~/.claude/.credentials.json` so agent containers get Claude auth — otherwise the agent errors with "Not logged in".
+- **Claude auth for agent containers:** set `CLAUDE_CODE_OAUTH_TOKEN` (in `interlude/dev`) to a token minted with `claude setup-token` — otherwise the agent errors with "Not logged in". The legacy fallback still works while both mechanisms exist: set `CLAUDE_CREDENTIALS_PATH` to your host `~/.claude/.credentials.json` to mount credentials into agent containers instead (slated for removal once the token path is verified on the VPS — #48).
 
 ## Current Status: Phase 4 done and verified on VPS; Phase 5 next
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 export interface AppConfig {
   /** Anthropic API key (optional if using OAuth credentials) */
   anthropicApiKey: string | null;
+  /** Long-lived OAuth token from `claude setup-token`, injected into agent containers at exec (preferred over the mounted credentials file) */
+  claudeCodeOauthToken: string | null;
   /** Path to Claude OAuth credentials file inside this container */
   claudeCredentialsPath: string | null;
   /** Host path for mounting credentials into agent containers */
@@ -49,6 +51,7 @@ export function getConfig(): AppConfig {
   if (_config) return _config;
 
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY ?? null;
+  const claudeCodeOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN ?? null;
 
   // Find Claude credentials file — check the container mount path first,
   // then fall back to CLAUDE_CREDENTIALS_PATH or $HOME default
@@ -63,10 +66,15 @@ export function getConfig(): AppConfig {
   const claudeCredentialsPath =
     fs.existsSync(credentialsPath) ? credentialsPath : null;
 
-  if (!anthropicApiKey && !claudeCredentialsPath && !process.env.CLAUDE_CREDENTIALS_PATH) {
+  if (
+    !anthropicApiKey &&
+    !claudeCodeOauthToken &&
+    !claudeCredentialsPath &&
+    !process.env.CLAUDE_CREDENTIALS_PATH
+  ) {
     console.warn(
-      "Warning: No auth configured. Set ANTHROPIC_API_KEY, CLAUDE_CREDENTIALS_PATH, " +
-        "or ensure ~/.claude/.credentials.json exists."
+      "Warning: No auth configured. Set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`), " +
+        "ANTHROPIC_API_KEY, CLAUDE_CREDENTIALS_PATH, or ensure ~/.claude/.credentials.json exists."
     );
   }
 
@@ -77,6 +85,7 @@ export function getConfig(): AppConfig {
 
   _config = {
     anthropicApiKey,
+    claudeCodeOauthToken,
     claudeCredentialsPath,
     claudeCredentialsHostPath,
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildSetupScript, buildPushScript } from "../container-manager";
+import {
+  buildSetupScript,
+  buildPushScript,
+  buildTurnEnv,
+} from "../container-manager";
 
 describe("buildSetupScript", () => {
   const script = buildSetupScript("https://github.com/lennons301/platform.git");
@@ -23,6 +27,36 @@ describe("buildSetupScript", () => {
 
   it("still writes Doppler secrets when DOPPLER_TOKEN is set", () => {
     expect(script).toContain('if [ -n "$DOPPLER_TOKEN" ]');
+  });
+});
+
+describe("buildTurnEnv", () => {
+  it("always carries the prompt and git auth token", () => {
+    const env = buildTurnEnv({
+      prompt: "do the thing",
+      gitAuthToken: "ghs_abc",
+      claudeCodeOauthToken: null,
+    });
+    expect(env).toContain("CLAUDE_PROMPT=do the thing");
+    expect(env).toContain("GIT_AUTH_TOKEN=ghs_abc");
+  });
+
+  it("injects CLAUDE_CODE_OAUTH_TOKEN when configured", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "t",
+      claudeCodeOauthToken: "sk-ant-oat01-xyz",
+    });
+    expect(env).toContain("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xyz");
+  });
+
+  it("omits CLAUDE_CODE_OAUTH_TOKEN when not configured", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "t",
+      claudeCodeOauthToken: null,
+    });
+    expect(env.some((e) => e.startsWith("CLAUDE_CODE_OAUTH_TOKEN"))).toBe(false);
   });
 });
 

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -24,6 +24,27 @@ export function buildSetupScript(platformRepoUrl: string): string {
   ].join(" && ");
 }
 
+/**
+ * Env for a Claude turn exec. Auth is exec-scoped, mirroring GIT_AUTH_TOKEN:
+ * the long-lived setup-token never lands in the container's persistent env.
+ * The CLI prefers CLAUDE_CODE_OAUTH_TOKEN over the mounted credentials file,
+ * which stays as a fallback until the token path is verified on the VPS (#48).
+ */
+export function buildTurnEnv(options: {
+  prompt: string;
+  gitAuthToken: string;
+  claudeCodeOauthToken: string | null;
+}): string[] {
+  const env = [
+    `CLAUDE_PROMPT=${options.prompt}`,
+    `GIT_AUTH_TOKEN=${options.gitAuthToken}`,
+  ];
+  if (options.claudeCodeOauthToken) {
+    env.push(`CLAUDE_CODE_OAUTH_TOKEN=${options.claudeCodeOauthToken}`);
+  }
+  return env;
+}
+
 /** Bash run after each turn: commit any changes and push the branch via origin. */
 export function buildPushScript(): string {
   return [
@@ -206,7 +227,11 @@ export async function execClaudeTurn(
   const token = await getInstallationToken();
   const exec = await options.container.exec({
     Cmd: ["bash", "-c", cmdParts.join(" ")],
-    Env: [`CLAUDE_PROMPT=${options.prompt}`, `GIT_AUTH_TOKEN=${token}`],
+    Env: buildTurnEnv({
+      prompt: options.prompt,
+      gitAuthToken: token,
+      claudeCodeOauthToken: config.claudeCodeOauthToken,
+    }),
     AttachStdout: true,
     AttachStderr: true,
   });


### PR DESCRIPTION
Closes #48

## What

Agent-container Claude auth moves to a long-lived `claude setup-token` credential delivered as `CLAUDE_CODE_OAUTH_TOKEN`, with the bind-mounted `.credentials.json` kept as a fallback while both mechanisms exist.

- **`config.ts`** reads `CLAUDE_CODE_OAUTH_TOKEN` (new `claudeCodeOauthToken` field) and includes it in the no-auth warning.
- **`container-manager.ts`** injects the token into the Claude turn exec via a new pure `buildTurnEnv` builder (same idiom as `buildSetupScript`/`buildPushScript`). Injection is **exec-scoped, mirroring `GIT_AUTH_TOKEN`** — the long-lived token never lands in the container's persistent env, so it isn't visible in `docker inspect` of the container. `execClaudeTurn` is the only exec that runs the `claude` CLI (both interactive and autonomous turns flow through it); the setup/push execs are git-only.
- **Fallback untouched:** the `CLAUDE_CREDENTIALS_PATH` bind-mount in `createWorkspaceContainer` stays as-is. The CLI prefers the env token over the mounted file, so once the token is in Doppler it wins; the mount removal (which resolves #28) is the issue's explicit post-VPS-verification step, not this PR.
- **Docs:** `.env.example` auth options reordered (token preferred, mount marked legacy fallback); CLAUDE.md local-dev note now says local dev can use either.

## Not in this PR (per the issue)

- Mount + `CLAUDE_CREDENTIALS_PATH` plumbing removal — gated on VPS verification.
- Preflight credential-validity check (#35 tie-in) — no credential preflight exists in the codebase yet; nothing to make mechanism-agnostic.
- Owner prerequisite: mint the token (`claude setup-token`) and store it as `CLAUDE_CODE_OAUTH_TOKEN` in Doppler `interlude/prd` (and `dev`).

## Validation

- `pnpm test`: 227/227 pass (3 new `buildTurnEnv` tests).
- `pnpm lint`: the changed files lint clean. The full run fails on pre-existing errors in `custom-server.js`, `src/components/preview-pane.tsx`, and `src/lib/orchestrator/__tests__/output-parser.test.ts` — all untouched by this branch and failing identically on `main`; left out of scope for a gated-path PR.
- Self-review (two-axis, vs `origin/main`, issue #48 as spec): Spec axis — no missing requirements, no scope creep. Standards axis — no hard violations; flagged that the `credentials`, `agent-sandbox`, and `.env*` gates fire, so this PR expects `human-signoff` (correct per the issue), and a judgement call that the "legacy fallback" story is restated in several places — accepted, since every site carries a `#48` breadcrumb for the removal ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)