### PR TITLE
Phase 5: ticket directives, budgets, attempt accounting and the daily cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,15 @@ GIT_USER_NAME=Interlude Agent
 GIT_USER_EMAIL=agent@interlude.dev
 KEEP_CONTAINERS=false
 
-# Agent limits (per task)
+# Agent limits. MAX_BUDGET_USD changed meaning in Phase 5 (issue #18): it is
+# the default budget per autonomous *attempt* (one claim, fresh container) —
+# raisable per ticket via a `budget:` directive up to a hard $75 ceiling —
+# and interactive tasks inherit the same per-task default. It was a $5
+# per-task cap before Phase 5; the default deliberately rose with the change.
+# Review passes carry their own ~$5 allowance. MAX_TURNS is per exec; a
+# ticket's `max-turns:` directive may raise an attempt's to at most 100.
 MAX_TURNS=50
-MAX_BUDGET_USD=5.00
+MAX_BUDGET_USD=20.00
 
 # Capacity — slots derive at boot from the Docker daemon's CPU/memory;
 # override only when the derivation is wrong for a workload

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Auth — one of these is required:
-# Option 1: Use Claude Code subscription (auto-detected from ~/.claude/.credentials.json)
-# Option 2: ANTHROPIC_API_KEY=sk-ant-...
+# Option 1 (preferred): long-lived token from `claude setup-token`, injected into
+#   agent containers at exec. Production stores it in Doppler (interlude/prd).
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# Option 2 (legacy fallback): mounted credentials file — auto-detected from
+#   ~/.claude/.credentials.json, or see CLAUDE_CREDENTIALS_PATH below
+# Option 3: ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional
 GIT_USER_NAME=Interlude Agent
@@ -29,7 +33,7 @@ MAX_BUDGET_USD=20.00
 #   same config for the reverse proxy. Never hand-set DOMAIN in the VPS .env
 #   (issue #25). Set it here only for local (non-Doppler) subdomain testing.
 # DOMAIN=interlude.dev
-# CLAUDE_CREDENTIALS_PATH=/home/deploy/.claude/.credentials.json  # host path passed to agent containers; not mounted into app container
+# CLAUDE_CREDENTIALS_PATH=/home/deploy/.claude/.credentials.json  # legacy fallback: host path mounted into agent containers (not the app container); removed once CLAUDE_CODE_OAUTH_TOKEN is verified on the VPS (#48)
 
 # GitHub App — REQUIRED for git (clone/push) and for issue sync + PR creation.
 # The agent authenticates git using a short-lived App installation token; there is no PAT to rotate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Interlude is a self-hosted, agent-first development platform. You dispatch tasks
 Schema at `src/db/schema.ts`. Four tables: `projects`, `tasks`, `messages`, `runs`.
 
 - `runs` is the Phase 5 autonomy ledger — one row per attempt at one ticket; a run owns one or more tasks (its implement pass plus any review passes). Interactive tasks have no run, which exempts them from the daily autonomous spend cap by construction (`src/lib/orchestrator/spend.ts`)
+- Budgets (issue #18): `MAX_BUDGET_USD` is the **$20 per-attempt** default — it was $5 per *task* before Phase 5, and interactive tasks deliberately inherit the new, more generous default. A ticket's `budget:` directive (Workflow section) may raise one attempt to at most $75; review passes carry their own ~$5; the $500/day autonomous cap and all ceilings live in `src/lib/orchestrator/autonomy/budgets.ts`
 - `runs.reviewResult` holds a finished review pass's parsed verdict until the orchestrator has acted on it; `runs.reviewVerdict` is the last verdict actually posted to GitHub
 - `tasks.kind` distinguishes interactive (default) / implement / review / triage; `tasks.runId` links a task to its run
 - `projects` carries `autonomyEnabled` (default off) plus cached `preflightStatus`/`preflightReason`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ pnpm lint         # Run ESLint
 Local dev runs the orchestrator via `doppler run -- pnpm dev` — orchestrator secrets live in the Doppler `interlude/dev` config, not a `.env`. Two things Compose provides on the VPS that you must set up by hand locally:
 
 - **Agent-container network:** run `docker network create interlude` once. Agent containers attach to the `interlude` network, which Compose creates on the VPS but `pnpm dev` does not — without it, task runs fail with "network interlude not found".
-- **Claude credentials mount:** set `CLAUDE_CREDENTIALS_PATH` (in `interlude/dev`) to your host `~/.claude/.credentials.json` so agent containers get Claude auth — otherwise the agent errors with "Not logged in".
+- **Claude auth for agent containers:** set `CLAUDE_CODE_OAUTH_TOKEN` (in `interlude/dev`) to a token minted with `claude setup-token` — otherwise the agent errors with "Not logged in". The legacy fallback still works while both mechanisms exist: set `CLAUDE_CREDENTIALS_PATH` to your host `~/.claude/.credentials.json` to mount credentials into agent containers instead (slated for removal once the token path is verified on the VPS — #48).
 
 ## Current Status: Phase 4 done and verified on VPS; Phase 5 next
 

--- a/drizzle/0010_large_mystique.sql
+++ b/drizzle/0010_large_mystique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `runs` ADD `max_turns` integer;--> statement-breakpoint
+ALTER TABLE `runs` ADD `failure_reason` text;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,544 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b5f62fa3-804e-4772-a5bb-22cbca3fe65e",
+  "prevId": "9a2f09a9-bfe0-4702-85a8-536f7b340eb5",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1786060800000,
       "tag": "0009_grey_pet_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1786147200000,
+      "tag": "0010_large_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -46,6 +46,8 @@ export const runs = sqliteTable("runs", {
     .notNull()
     .default("claimed"),
   budgetUsd: real("budget_usd").notNull(),
+  // Per-exec turn limit from a ticket's max-turns directive; null = default
+  maxTurns: int("max_turns"),
   totalCostUsd: real("total_cost_usd").notNull().default(0),
   pullRequestNumber: int("pull_request_number"),
   pullRequestUrl: text("pull_request_url"),
@@ -68,6 +70,9 @@ export const runs = sqliteTable("runs", {
   reviewCycleCount: int("review_cycle_count").notNull().default(0),
   interruptionCount: int("interruption_count").notNull().default(0),
   blockedQuestion: text("blocked_question"),
+  // Why a failed attempt failed (budget/turn exhaustion, container error,
+  // review cycles) — human-readable, surfaced in the exhaust summary
+  failureReason: text("failure_reason"),
   claimedAt: int("claimed_at", { mode: "timestamp_ms" }).notNull(),
   startedAt: int("started_at", { mode: "timestamp_ms" }),
   finishedAt: int("finished_at", { mode: "timestamp_ms" }),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,8 @@ import { DEFAULT_ATTEMPT_BUDGET_USD } from "./orchestrator/autonomy/budgets";
 export interface AppConfig {
   /** Anthropic API key (optional if using OAuth credentials) */
   anthropicApiKey: string | null;
+  /** Long-lived OAuth token from `claude setup-token`, injected into agent containers at exec (preferred over the mounted credentials file) */
+  claudeCodeOauthToken: string | null;
   /** Path to Claude OAuth credentials file inside this container */
   claudeCredentialsPath: string | null;
   /** Host path for mounting credentials into agent containers */
@@ -66,6 +68,7 @@ export function getConfig(): AppConfig {
   if (_config) return _config;
 
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY ?? null;
+  const claudeCodeOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN ?? null;
 
   // Find Claude credentials file — check the container mount path first,
   // then fall back to CLAUDE_CREDENTIALS_PATH or $HOME default
@@ -80,10 +83,15 @@ export function getConfig(): AppConfig {
   const claudeCredentialsPath =
     fs.existsSync(credentialsPath) ? credentialsPath : null;
 
-  if (!anthropicApiKey && !claudeCredentialsPath && !process.env.CLAUDE_CREDENTIALS_PATH) {
+  if (
+    !anthropicApiKey &&
+    !claudeCodeOauthToken &&
+    !claudeCredentialsPath &&
+    !process.env.CLAUDE_CREDENTIALS_PATH
+  ) {
     console.warn(
-      "Warning: No auth configured. Set ANTHROPIC_API_KEY, CLAUDE_CREDENTIALS_PATH, " +
-        "or ensure ~/.claude/.credentials.json exists."
+      "Warning: No auth configured. Set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`), " +
+        "ANTHROPIC_API_KEY, CLAUDE_CREDENTIALS_PATH, or ensure ~/.claude/.credentials.json exists."
     );
   }
 
@@ -94,6 +102,7 @@ export function getConfig(): AppConfig {
 
   _config = {
     anthropicApiKey,
+    claudeCodeOauthToken,
     claudeCredentialsPath,
     claudeCredentialsHostPath,
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import { DEFAULT_ATTEMPT_BUDGET_USD } from "./orchestrator/autonomy/budgets";
 
 export interface AppConfig {
   /** Anthropic API key (optional if using OAuth credentials) */
@@ -11,9 +12,17 @@ export interface AppConfig {
   gitUserName: string;
   gitUserEmail: string;
   keepContainers: boolean;
-  /** Max agentic turns per task (default: 50) */
+  /** Max agentic turns per exec (default: 50; a ticket's max-turns directive
+   * may raise an autonomous attempt's to at most 100) */
   maxTurns: number;
-  /** Max budget in USD per task (default: 5.00) */
+  /**
+   * Max budget in USD (default: 20.00). Phase 5 (issue #18) changed the
+   * meaning: this is the default budget per autonomous *attempt* — one claim,
+   * fresh container — raisable per ticket via a `budget:` directive up to a
+   * hard $75 ceiling. Interactive tasks deliberately inherit the same, more
+   * generous, per-task default (it was $5 per task before Phase 5). Review
+   * passes carry their own ~$5 allowance instead.
+   */
   maxBudgetUsd: number;
   /** Explicit agent slot count, overriding the boot-time derivation. Null = derive from the Docker daemon */
   capacitySlots: number | null;
@@ -91,7 +100,9 @@ export function getConfig(): AppConfig {
     gitUserEmail: process.env.GIT_USER_EMAIL ?? "agent@interlude.dev",
     keepContainers: process.env.KEEP_CONTAINERS === "true",
     maxTurns: parseInt(process.env.MAX_TURNS ?? "50", 10),
-    maxBudgetUsd: parseFloat(process.env.MAX_BUDGET_USD ?? "5.00"),
+    maxBudgetUsd: parseFloat(
+      process.env.MAX_BUDGET_USD ?? String(DEFAULT_ATTEMPT_BUDGET_USD)
+    ),
     capacitySlots: process.env.CAPACITY_SLOTS
       ? parseInt(process.env.CAPACITY_SLOTS, 10)
       : null,

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -311,3 +311,66 @@ export async function notifyTaskIdle(
     return null;
   }
 }
+
+/**
+ * Tell the owner a ticket burnt its last attempt and went back to a human —
+ * `ready-for-agent` swapped for `ready-for-human`. Sent to the project's
+ * linked channel, or the fleet channel when the project has none. No-op when
+ * neither is configured: the sweep already logged and commented on the issue.
+ */
+export async function notifyAttemptsExhausted(
+  channelId: string | null,
+  payload: { issueRef: string; attempts: number; totalSpendUsd: number }
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Attempts exhausted — ${payload.issueRef} needs you`)
+      .setDescription(
+        `All ${payload.attempts} attempts failed ` +
+          `($${payload.totalSpendUsd.toFixed(2)} autonomous spend). ` +
+          `The ticket is now \`ready-for-human\`; the per-attempt story is on the issue.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send attempts-exhausted notification:`, err);
+  }
+}
+
+/**
+ * Announce (once per day — the sweep tracks the flag) that the daily
+ * autonomous spend cap paused pickup. Interactive work is unaffected and the
+ * pause lifts at local midnight. No-op when no fleet channel is configured.
+ */
+export async function notifyDailyCapReached(
+  channelId: string | null,
+  payload: { spentUsd: number; capUsd: number }
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Daily autonomous spend cap reached`)
+      .setDescription(
+        `$${payload.spentUsd.toFixed(2)} of the $${payload.capUsd.toFixed(2)} daily cap ` +
+          `is spent — autonomous pickup is paused until local midnight. ` +
+          `Interactive tasks are unaffected.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send daily-cap notification:`, err);
+  }
+}

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildSetupScript, buildPushScript } from "../container-manager";
+import {
+  buildSetupScript,
+  buildPushScript,
+  buildTurnEnv,
+} from "../container-manager";
 
 describe("buildSetupScript", () => {
   const script = buildSetupScript("https://github.com/lennons301/platform.git");
@@ -32,6 +36,36 @@ describe("buildSetupScript", () => {
     );
     expect(reviewScript).toContain('git checkout "$GIT_BRANCH"');
     expect(reviewScript).not.toContain('git checkout -b');
+  });
+});
+
+describe("buildTurnEnv", () => {
+  it("always carries the prompt and git auth token", () => {
+    const env = buildTurnEnv({
+      prompt: "do the thing",
+      gitAuthToken: "ghs_abc",
+      claudeCodeOauthToken: null,
+    });
+    expect(env).toContain("CLAUDE_PROMPT=do the thing");
+    expect(env).toContain("GIT_AUTH_TOKEN=ghs_abc");
+  });
+
+  it("injects CLAUDE_CODE_OAUTH_TOKEN when configured", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "t",
+      claudeCodeOauthToken: "sk-ant-oat01-xyz",
+    });
+    expect(env).toContain("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xyz");
+  });
+
+  it("omits CLAUDE_CODE_OAUTH_TOKEN when not configured", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "t",
+      claudeCodeOauthToken: null,
+    });
+    expect(env.some((e) => e.startsWith("CLAUDE_CODE_OAUTH_TOKEN"))).toBe(false);
   });
 });
 

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -51,6 +51,8 @@ export interface TurnOptions {
   sessionId?: string; // If set, uses --resume
   /** Per-exec budget override (autonomous runs carry their attempt budget) */
   maxBudgetUsd?: number;
+  /** Per-exec turn-limit override (a ticket's max-turns directive) */
+  maxTurns?: number;
 }
 
 export interface RunningContainer {
@@ -207,7 +209,7 @@ export async function execClaudeTurn(
     "--verbose",
     "--dangerously-skip-permissions",
     "--max-turns",
-    String(config.maxTurns),
+    String(options.maxTurns ?? config.maxTurns),
     "--max-budget-usd",
     String(options.maxBudgetUsd ?? config.maxBudgetUsd),
   ];

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -27,6 +27,27 @@ export function buildSetupScript(platformRepoUrl: string, checkoutExisting = fal
   ].join(" && ");
 }
 
+/**
+ * Env for a Claude turn exec. Auth is exec-scoped, mirroring GIT_AUTH_TOKEN:
+ * the long-lived setup-token never lands in the container's persistent env.
+ * The CLI prefers CLAUDE_CODE_OAUTH_TOKEN over the mounted credentials file,
+ * which stays as a fallback until the token path is verified on the VPS (#48).
+ */
+export function buildTurnEnv(options: {
+  prompt: string;
+  gitAuthToken: string;
+  claudeCodeOauthToken: string | null;
+}): string[] {
+  const env = [
+    `CLAUDE_PROMPT=${options.prompt}`,
+    `GIT_AUTH_TOKEN=${options.gitAuthToken}`,
+  ];
+  if (options.claudeCodeOauthToken) {
+    env.push(`CLAUDE_CODE_OAUTH_TOKEN=${options.claudeCodeOauthToken}`);
+  }
+  return env;
+}
+
 /** Bash run after each turn: commit any changes and push the branch via origin. */
 export function buildPushScript(): string {
   return [
@@ -221,7 +242,11 @@ export async function execClaudeTurn(
   const token = await getInstallationToken();
   const exec = await options.container.exec({
     Cmd: ["bash", "-c", cmdParts.join(" ")],
-    Env: [`CLAUDE_PROMPT=${options.prompt}`, `GIT_AUTH_TOKEN=${token}`],
+    Env: buildTurnEnv({
+      prompt: options.prompt,
+      gitAuthToken: token,
+      claudeCodeOauthToken: config.claudeCodeOauthToken,
+    }),
     AttachStdout: true,
     AttachStderr: true,
   });

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -5,6 +5,8 @@
  * never disagree about the state of the fleet.
  */
 
+import { MAX_ATTEMPTS } from "../orchestrator/autonomy/budgets";
+
 export interface FleetRows {
   /** Current time — passed in, never read inside */
   now: Date;
@@ -75,8 +77,8 @@ export interface FleetTaskRow {
   updatedAt: Date;
 }
 
-/** One attempt is allowed 3 strikes before the ticket goes ready-for-human */
-export const MAX_ATTEMPTS = 3;
+/** Re-exported from the budgets leaf so the view and the loop can't drift */
+export { MAX_ATTEMPTS };
 
 export type NeedsYouCause =
   | "blocked"

--- a/src/lib/fleet/rows.ts
+++ b/src/lib/fleet/rows.ts
@@ -9,15 +9,12 @@ import { messages, projects, runs, tasks } from "@/db/schema";
 import { and, eq, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { getConfig } from "../config";
 import { getCapacity } from "../orchestrator/capacity";
+import { DAILY_AUTONOMOUS_CAP_USD } from "../orchestrator/autonomy/budgets";
 import {
   buildFleetView,
   type FleetRows,
   type FleetView,
 } from "./fleet-view";
-
-/** Estate-wide daily autonomous spend cap (Phase 5 spec §Budgets). Moves to
- * config when the budgets ticket lands; the read model only needs a number. */
-export const DAILY_AUTONOMOUS_CAP_USD = 500;
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 

--- a/src/lib/github/issues.ts
+++ b/src/lib/github/issues.ts
@@ -33,3 +33,54 @@ export async function commentOnIssue(
     console.error(`[github] Failed to comment on ${issueRef}:`, err);
   }
 }
+
+/**
+ * Add a label to an issue. Returns false on failure so callers can retry on
+ * a later sweep; adding an already-present label is a GitHub no-op.
+ */
+export async function addLabelToIssue(issueRef: string, label: string): Promise<boolean> {
+  if (!isGitHubConfigured()) return false;
+
+  const parsed = parseIssueRef(issueRef);
+  if (!parsed) return false;
+
+  try {
+    const octokit = await getOctokit();
+    await octokit.rest.issues.addLabels({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.number,
+      labels: [label],
+    });
+    return true;
+  } catch (err) {
+    console.error(`[github] Failed to label ${issueRef} with "${label}":`, err);
+    return false;
+  }
+}
+
+/**
+ * Remove a label from an issue. A label that is already absent counts as
+ * removed (404), so retried removals stay idempotent.
+ */
+export async function removeLabelFromIssue(issueRef: string, label: string): Promise<boolean> {
+  if (!isGitHubConfigured()) return false;
+
+  const parsed = parseIssueRef(issueRef);
+  if (!parsed) return false;
+
+  try {
+    const octokit = await getOctokit();
+    await octokit.rest.issues.removeLabel({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.number,
+      name: label,
+    });
+    return true;
+  } catch (err) {
+    if ((err as { status?: number }).status === 404) return true;
+    console.error(`[github] Failed to remove label "${label}" from ${issueRef}:`, err);
+    return false;
+  }
+}

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -49,6 +49,10 @@ function makeSnapshot(overrides: Partial<AutonomySnapshot> = {}): AutonomySnapsh
     autonomyEnabledGlobal: true,
     attemptBudgetUsd: 20,
     maxAttempts: 3,
+    maxReviewCycles: 2,
+    todayAutonomousSpendUsd: 0,
+    dailyCapUsd: 500,
+    dailyCapAnnounced: false,
     allowedAuthors: [],
     slots: { total: 2, occupied: 0, occupants: [] },
     queuedInteractiveCount: 0,
@@ -98,6 +102,7 @@ function makeVerdict(overrides: Partial<PendingVerdict> = {}): PendingVerdict {
     armed: true,
     result: { kind: "approve", body: "Verified against the ticket." },
     implementTaskId: "task-impl-1",
+    reviewCycleCount: 0,
     ...overrides,
   };
 }
@@ -138,6 +143,7 @@ describe("decideNext — claiming", () => {
         attempt: 1,
         mode: "autonomous",
         budgetUsd: 20,
+        maxTurns: null,
         workflow: { source: "default" },
       },
     ]);
@@ -164,6 +170,73 @@ describe("decideNext — claiming", () => {
 
     expect(claims(actions)).toHaveLength(1);
     expect(claims(actions)[0]).toMatchObject({ attempt: 2 });
+  });
+
+  it("resolves budget and max-turns from the ticket's directives", () => {
+    const body = "Spec.\n\n## Workflow\n\nbudget: $40\nmax-turns: 80\n";
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ body })] })
+    );
+
+    expect(claims(actions)[0]).toMatchObject({ budgetUsd: 40, maxTurns: 80 });
+  });
+
+  it("clamps an over-ceiling budget directive at claim time", () => {
+    const body = "## Workflow\n\nbudget: $10000\n";
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ body })] })
+    );
+
+    expect(claims(actions)[0]).toMatchObject({ budgetUsd: 75 });
+  });
+
+  it("falls back to the snapshot's default budget and no turn override", () => {
+    const actions = decideNext(makeSnapshot());
+
+    expect(claims(actions)[0]).toMatchObject({ budgetUsd: 20, maxTurns: null });
+  });
+});
+
+describe("decideNext — attempt accounting", () => {
+  it("exhausts a ticket whose third attempt has failed instead of claiming it", () => {
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ attemptsMade: 3 })] })
+    );
+
+    expect(actions).toEqual([
+      { type: "exhaust", issueRef: "acme/widgets#7", attemptsMade: 3 },
+    ]);
+  });
+
+  it("still claims while attempts remain", () => {
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ attemptsMade: 2 })] })
+    );
+
+    expect(actions.filter((a) => a.type === "exhaust")).toEqual([]);
+    expect(claims(actions)[0]).toMatchObject({ attempt: 3 });
+  });
+
+  it("does not exhaust a ticket that somehow still has an active run", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [makeCandidate({ attemptsMade: 3, hasActiveRun: true })],
+      })
+    );
+
+    expect(actions.filter((a) => a.type === "exhaust")).toEqual([]);
+  });
+
+  it("exhausts even when a blocker is open — routing to a human is not blocked", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [makeCandidate({ attemptsMade: 3, hasOpenBlocker: true })],
+      })
+    );
+
+    expect(actions).toEqual([
+      { type: "exhaust", issueRef: "acme/widgets#7", attemptsMade: 3 },
+    ]);
   });
 });
 
@@ -473,6 +546,81 @@ describe("decideNext — pause reasons", () => {
 
   it("emits no pause when everything is claimable", () => {
     expect(pauses(decideNext(makeSnapshot()))).toEqual([]);
+  });
+
+  it("pauses with 'daily-cap' and announces it once when today's spend meets the cap", () => {
+    const actions = decideNext(
+      makeSnapshot({ todayAutonomousSpendUsd: 500, dailyCapUsd: 500 })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "notify",
+        event: "daily-cap-reached",
+        payload: { spentUsd: 500, capUsd: 500 },
+      },
+      { type: "pausePickup", reason: "daily-cap" },
+    ]);
+  });
+
+  it("does not re-announce a cap pause that was already announced", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        todayAutonomousSpendUsd: 512.4,
+        dailyCapUsd: 500,
+        dailyCapAnnounced: true,
+      })
+    );
+
+    expect(actions).toEqual([{ type: "pausePickup", reason: "daily-cap" }]);
+  });
+
+  it("claims normally while today's spend is under the cap", () => {
+    const actions = decideNext(
+      makeSnapshot({ todayAutonomousSpendUsd: 499.99, dailyCapUsd: 500 })
+    );
+
+    expect(claims(actions)).toHaveLength(1);
+    expect(pauses(actions)).toEqual([]);
+  });
+
+  it("does not pause with 'daily-cap' when there is nothing eligible to claim", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        todayAutonomousSpendUsd: 500,
+        dailyCapUsd: 500,
+        candidates: [],
+      })
+    );
+
+    expect(pauses(actions)).toEqual([]);
+  });
+
+  it("keeps driving in-flight work while the cap pauses pickup", () => {
+    // The cap pauses pickup only: a stored verdict still posts, and a burnt
+    // ticket is still routed back to a human.
+    const actions = decideNext(
+      makeSnapshot({
+        todayAutonomousSpendUsd: 500,
+        dailyCapUsd: 500,
+        dailyCapAnnounced: true,
+        pendingVerdicts: [makeVerdict()],
+        candidates: [
+          makeCandidate(),
+          makeCandidate({
+            issueRef: "acme/widgets#9",
+            number: 9,
+            attemptsMade: 3,
+          }),
+        ],
+      })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual([
+      "postVerdict",
+      "exhaust",
+      "pausePickup",
+    ]);
   });
 });
 
@@ -926,6 +1074,70 @@ describe("decideNext — verdict-to-action mapping", () => {
     );
 
     expect(actions).toEqual([]);
+  });
+
+  it("fails the attempt when a second request-changes would exceed the cycle bound", () => {
+    // Cycle 1 was implement+review; the first request-changes bought cycle 2.
+    // A second request-changes has no cycle left to spend, so the attempt
+    // fails instead of delivering another fix-up turn.
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingVerdicts: [
+          makeVerdict({
+            result: { kind: "request-changes", body: "Still wrong." },
+            reviewCycleCount: 1,
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "failAttempt",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        armed: true,
+        reason: "review-cycles-exhausted",
+        reviewBody: "Still wrong.",
+      },
+    ]);
+  });
+
+  it("fails on exhausted cycles even when the container is gone", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingVerdicts: [
+          makeVerdict({
+            result: { kind: "request-changes", body: "Still wrong." },
+            reviewCycleCount: 1,
+            implementTaskId: null,
+          }),
+        ],
+      })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual(["failAttempt"]);
+  });
+
+  it("does not hold a cycle-exhausted failure for a free slot — it releases one", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        slots: { total: 2, occupied: 2, occupants: ["a", "b"] },
+        saturationAnnounced: true,
+        pendingVerdicts: [
+          makeVerdict({
+            result: { kind: "request-changes", body: "Still wrong." },
+            reviewCycleCount: 1,
+          }),
+        ],
+      })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual(["failAttempt"]);
   });
 });
 

--- a/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
@@ -1,9 +1,100 @@
 import { describe, it, expect } from "vitest";
 import {
   parseBlockedByRefs,
+  parseTicketDirectives,
   selectWorkflow,
   shouldCreateInteractiveTask,
 } from "../ticket";
+
+describe("parseTicketDirectives", () => {
+  it("returns all-null for a body with no Workflow section", () => {
+    expect(parseTicketDirectives("Just prose.\n\nbudget: $40\n")).toEqual({
+      budget: null,
+      maxTurns: null,
+      checkpoint: null,
+      workflow: null,
+    });
+  });
+
+  it("parses a budget directive from the Workflow section", () => {
+    const body = "Intro.\n\n## Workflow\n\nbudget: $40\n";
+    expect(parseTicketDirectives(body).budget).toBe(40);
+  });
+
+  it("clamps an over-ceiling budget to $75 — issue text cannot exceed the ceiling", () => {
+    const body = "## Workflow\n\nbudget: $10000\n";
+    expect(parseTicketDirectives(body).budget).toBe(75);
+  });
+
+  it("accepts a plain number and decimals", () => {
+    expect(parseTicketDirectives("## Workflow\nbudget: 42.50").budget).toBe(42.5);
+  });
+
+  it("ignores budget values that are not positive amounts", () => {
+    expect(parseTicketDirectives("## Workflow\nbudget: lots").budget).toBeNull();
+    expect(parseTicketDirectives("## Workflow\nbudget: -5").budget).toBeNull();
+    expect(parseTicketDirectives("## Workflow\nbudget: 0").budget).toBeNull();
+    expect(parseTicketDirectives("## Workflow\nbudget: $40 per day").budget).toBeNull();
+  });
+
+  it("parses and clamps max-turns", () => {
+    expect(parseTicketDirectives("## Workflow\nmax-turns: 80").maxTurns).toBe(80);
+    expect(parseTicketDirectives("## Workflow\nmax-turns: 4000").maxTurns).toBe(100);
+    expect(parseTicketDirectives("## Workflow\nmax-turns: 0").maxTurns).toBeNull();
+    expect(parseTicketDirectives("## Workflow\nmax-turns: many").maxTurns).toBeNull();
+  });
+
+  it("parses checkpoint with its question text, and a bare checkpoint as empty", () => {
+    const body = "## Workflow\n\ncheckpoint: confirm the schema change with me\n";
+    expect(parseTicketDirectives(body).checkpoint).toBe("confirm the schema change with me");
+    expect(parseTicketDirectives("## Workflow\ncheckpoint:").checkpoint).toBe("");
+  });
+
+  it("parses the informational workflow directive", () => {
+    expect(parseTicketDirectives("## Workflow\nworkflow: tdd").workflow).toBe("tdd");
+  });
+
+  it("parses all four directives together, bulleted and case-insensitive", () => {
+    const body = [
+      "## Workflow",
+      "",
+      "- Budget: $30",
+      "- MAX-TURNS: 60",
+      "- checkpoint: pause before deploy",
+      "- workflow: tdd",
+    ].join("\n");
+    expect(parseTicketDirectives(body)).toEqual({
+      budget: 30,
+      maxTurns: 60,
+      checkpoint: "pause before deploy",
+      workflow: "tdd",
+    });
+  });
+
+  it("takes the first occurrence when a key repeats", () => {
+    const body = "## Workflow\nbudget: $30\nbudget: $75\n";
+    expect(parseTicketDirectives(body).budget).toBe(30);
+  });
+
+  it("ignores unknown keys — there is no directive that widens authority", () => {
+    const body = [
+      "## Workflow",
+      "daily-cap: 99999",
+      "reviewer: mallory",
+      "gates: off",
+      "auto-merge: on",
+      "human-signoff: off",
+      "attempts: 100",
+      "budget: $30",
+    ].join("\n");
+    expect(parseTicketDirectives(body)).toEqual({
+      budget: 30,
+      maxTurns: null,
+      checkpoint: null,
+      workflow: null,
+    });
+  });
+});
 
 describe("selectWorkflow", () => {
   it("selects the skill named by a workflow:<skill> label", () => {

--- a/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
@@ -76,6 +76,65 @@ describe("parseTicketDirectives", () => {
     expect(parseTicketDirectives(body).budget).toBe(30);
   });
 
+  it("ignores directive-shaped lines inside a code fence in the Workflow section", () => {
+    const body = [
+      "## Workflow",
+      "",
+      "Run the loop like this:",
+      "```",
+      "budget: $10000",
+      "max-turns: 4000",
+      "checkpoint: fake",
+      "```",
+      "budget: $30",
+    ].join("\n");
+    expect(parseTicketDirectives(body)).toEqual({
+      budget: 30,
+      maxTurns: null,
+      checkpoint: null,
+      workflow: null,
+    });
+  });
+
+  it("ignores a Workflow heading that is itself inside a code fence", () => {
+    const body = ["```", "## Workflow", "budget: $75", "```"].join("\n");
+    expect(parseTicketDirectives(body).budget).toBeNull();
+  });
+
+  it("ignores directive-alike prose — a mid-line mention is not a directive", () => {
+    const body = "## Workflow\n\nKeep the budget: $60 conversation for later.\n";
+    expect(parseTicketDirectives(body).budget).toBeNull();
+  });
+
+  it("stops at the next heading — directives outside the section are inert", () => {
+    const body = [
+      "## Workflow",
+      "budget: $30",
+      "",
+      "## Notes",
+      "max-turns: 90",
+    ].join("\n");
+    expect(parseTicketDirectives(body)).toEqual({
+      budget: 30,
+      maxTurns: null,
+      checkpoint: null,
+      workflow: null,
+    });
+  });
+
+  it("keeps a deeper sub-heading inside the section", () => {
+    const body = [
+      "## Workflow",
+      "#### Limits",
+      "budget: $30",
+    ].join("\n");
+    expect(parseTicketDirectives(body).budget).toBe(30);
+  });
+
+  it("reads a ### Workflow heading too", () => {
+    expect(parseTicketDirectives("### Workflow\nbudget: $25").budget).toBe(25);
+  });
+
   it("ignores unknown keys — there is no directive that widens authority", () => {
     const body = [
       "## Workflow",

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -19,3 +19,17 @@ export const MAX_TURNS_CEILING = 100;
 /** Budget for one review pass — its own allowance, separate from the
  * implement attempt's, so reviewing never eats into a fix-up's headroom. */
 export const DEFAULT_REVIEW_BUDGET_USD = 5;
+
+/** Attempts per ticket before it is routed back to a human
+ * (`ready-for-agent` swapped for `ready-for-human`). */
+export const MAX_ATTEMPTS = 3;
+
+/** Implement↔review cycles allowed within one attempt: the initial pass and
+ * its review, plus one fix-up bought by a request-changes verdict. A second
+ * request-changes fails the attempt instead of looping. */
+export const MAX_REVIEW_CYCLES_PER_ATTEMPT = 2;
+
+/** Estate-wide daily autonomous spend cap in USD. Reaching it pauses pickup
+ * until local midnight; interactive tasks (no run row) are exempt by
+ * construction. */
+export const DAILY_AUTONOMOUS_CAP_USD = 500;

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -1,12 +1,20 @@
 /**
  * Budget constants for autonomous passes. A leaf module — both the sweep
  * (claim time) and the turn manager (exec time) need these, and importing
- * either into the other would create a cycle. Issue #18 layers ticket
- * directives and clamping on top.
+ * either into the other would create a cycle. The ticket-directive parser
+ * (issue #18) clamps against the ceilings defined here.
  */
 
 /** Default per-attempt budget for an autonomous implement pass. */
 export const DEFAULT_ATTEMPT_BUDGET_USD = 20;
+
+/** Hard ceiling a ticket's `budget:` directive may raise an attempt to.
+ * Issue text is semi-trusted input; nothing it says can exceed this. */
+export const MAX_ATTEMPT_BUDGET_USD = 75;
+
+/** Hard ceiling a ticket's `max-turns:` directive may raise a pass's
+ * per-exec turn limit to (the default is the orchestrator's MAX_TURNS). */
+export const MAX_TURNS_CEILING = 100;
 
 /** Budget for one review pass — its own allowance, separate from the
  * implement attempt's, so reviewing never eats into a fix-up's headroom. */

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -11,7 +11,7 @@
 
 import { detectBlockedQuestion } from "./blocked";
 import { evaluateGates, type GateConfig } from "./gates";
-import { selectWorkflow, type WorkflowSelection } from "./ticket";
+import { parseTicketDirectives, selectWorkflow, type WorkflowSelection } from "./ticket";
 import {
   buildFeedbackTurn,
   undeliverableFeedbackBody,
@@ -99,6 +99,8 @@ export interface PendingVerdict {
   /** The implement task whose container can take a fix-up turn; null once
    * that container is gone (restart, failure, teardown) */
   implementTaskId: string | null;
+  /** Fix-up turns already bought by request-changes verdicts this attempt */
+  reviewCycleCount: number;
 }
 
 /** An implement turn that just finished, up for a park-or-proceed decision. */
@@ -126,6 +128,15 @@ export interface AutonomySnapshot {
   autonomyEnabledGlobal: boolean;
   attemptBudgetUsd: number;
   maxAttempts: number;
+  /** Implement↔review cycles allowed within one attempt */
+  maxReviewCycles: number;
+  /** Autonomous spend since local midnight — a sum over the runs ledger, so
+   * interactive tasks (which have no run) are exempt by construction */
+  todayAutonomousSpendUsd: number;
+  /** Estate-wide daily autonomous spend cap in USD */
+  dailyCapUsd: number;
+  /** Whether today's cap pause was already announced */
+  dailyCapAnnounced: boolean;
   /** Extra allow-listed authors beyond each repo's owner (lowercase) */
   allowedAuthors: string[];
   slots: { total: number; occupied: number; occupants: string[] };
@@ -165,7 +176,8 @@ export type PauseReason =
   | "autonomy-off-global"
   | "autonomy-off-project"
   | "preflight-failing"
-  | "no-slots";
+  | "no-slots"
+  | "daily-cap";
 
 export type Action =
   | {
@@ -178,6 +190,8 @@ export type Action =
       attempt: number;
       mode: "autonomous";
       budgetUsd: number;
+      /** Per-exec turn limit from a max-turns directive; null = the default */
+      maxTurns: number | null;
       workflow: WorkflowSelection;
     }
   | { type: "pausePickup"; reason: PauseReason; detail?: string }
@@ -185,6 +199,11 @@ export type Action =
       type: "notify";
       event: "slots-saturated";
       payload: { occupied: number; total: number; occupants: string[] };
+    }
+  | {
+      type: "notify";
+      event: "daily-cap-reached";
+      payload: { spentUsd: number; capUsd: number };
     }
   | {
       type: "gatePr";
@@ -235,6 +254,17 @@ export type Action =
       taskId: string;
       issueRef: string;
       question: string;
+    }
+  | { type: "exhaust"; issueRef: string; attemptsMade: number }
+  | {
+      type: "failAttempt";
+      runId: string;
+      issueRef: string;
+      prNumber: number;
+      armed: boolean;
+      reason: "review-cycles-exhausted";
+      /** The final review's findings — posted to the PR as the record */
+      reviewBody: string;
     };
 
 /**
@@ -248,6 +278,10 @@ export function passOutcomeSnapshot(now: Date, pass: PassOutcome): AutonomySnaps
     autonomyEnabledGlobal: true,
     attemptBudgetUsd: 0,
     maxAttempts: 0,
+    maxReviewCycles: 0,
+    todayAutonomousSpendUsd: 0,
+    dailyCapUsd: 0,
+    dailyCapAnnounced: true,
     allowedAuthors: [],
     slots: { total: 0, occupied: 0, occupants: [] },
     queuedInteractiveCount: 0,
@@ -358,6 +392,23 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
     }
 
     if (result.kind === "request-changes") {
+      // Cycle 1 is the initial implement+review; each request-changes buys
+      // one more. A verdict that would need a cycle past the bound fails the
+      // attempt — the findings still land on the PR, but no fix-up runs, and
+      // the failed run counts a strike. Checked before the container-gone
+      // escalation: the bound binds whether or not a fix-up is deliverable.
+      if (pending.reviewCycleCount + 1 >= snapshot.maxReviewCycles) {
+        actions.push({
+          type: "failAttempt",
+          runId: pending.runId,
+          issueRef: pending.issueRef,
+          prNumber: pending.prNumber,
+          armed: pending.armed,
+          reason: "review-cycles-exhausted",
+          reviewBody: result.body,
+        });
+        continue;
+      }
       if (pending.implementTaskId === null) {
         // The container that could apply the feedback is gone; the findings
         // escalate to a human rather than burning a fresh attempt here.
@@ -497,12 +548,22 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       );
       continue;
     }
+    if (candidate.hasActiveRun) continue;
+    // Three strikes: the ticket goes back to a human instead of looping. The
+    // executor's label swap (ready-for-agent -> ready-for-human) removes the
+    // issue from the candidate set, which is what makes this once. Emitted
+    // ahead of the author and blocker checks — routing a burnt ticket back
+    // to a human is bookkeeping, not pickup.
+    if (candidate.attemptsMade >= snapshot.maxAttempts) {
+      actions.push({
+        type: "exhaust",
+        issueRef: candidate.issueRef,
+        attemptsMade: candidate.attemptsMade,
+      });
+      continue;
+    }
     if (!isAuthorAllowed(candidate, snapshot.allowedAuthors)) continue;
     if (candidate.hasOpenBlocker) continue;
-    if (candidate.hasActiveRun) continue;
-    // Refuse a claim past the attempt budget even before #18's exhaust flow
-    // lands — an unattended claim-fail loop must be bounded from day one.
-    if (candidate.attemptsMade >= snapshot.maxAttempts) continue;
     if (snapshot.inFlightClaims.includes(candidate.issueRef)) continue;
     eligible.push({ candidate, project });
   }
@@ -516,6 +577,25 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
   );
 
   if (eligible.length === 0) return actions;
+
+  // The daily cap pauses pickup and nothing else: in-flight work above still
+  // ran, exhaust bookkeeping still routed, interactive tasks never counted.
+  // Spend is attributed to the day a run was claimed and the sum starts at
+  // local midnight, so the pause lifts with the new day. Announced once.
+  if (snapshot.todayAutonomousSpendUsd >= snapshot.dailyCapUsd) {
+    if (!snapshot.dailyCapAnnounced) {
+      actions.push({
+        type: "notify",
+        event: "daily-cap-reached",
+        payload: {
+          spentUsd: snapshot.todayAutonomousSpendUsd,
+          capUsd: snapshot.dailyCapUsd,
+        },
+      });
+    }
+    actions.push({ type: "pausePickup", reason: "daily-cap" });
+    return actions;
+  }
 
   // Priority order: in-flight work already holds its slot (it is counted in
   // `occupied`, and a fix-up turn delivered above decremented `slotsLeft`),
@@ -537,6 +617,9 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
   }
 
   for (const { candidate, project } of eligible.slice(0, claimableSlots)) {
+    // Directives are the ticket adjusting its own bounded numbers — parsed
+    // from the Workflow section only, already clamped to the ceilings.
+    const directives = parseTicketDirectives(candidate.body);
     actions.push({
       type: "claimIssue",
       issueRef: candidate.issueRef,
@@ -546,7 +629,8 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       issueBody: candidate.body,
       attempt: candidate.attemptsMade + 1,
       mode: "autonomous",
-      budgetUsd: snapshot.attemptBudgetUsd,
+      budgetUsd: directives.budget ?? snapshot.attemptBudgetUsd,
+      maxTurns: directives.maxTurns,
       workflow: selectWorkflow(candidate.body, candidate.labels),
     });
   }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -12,7 +12,12 @@ import { newId } from "../../ulid";
 import { getConfig, PLATFORM_REPO_URL } from "../../config";
 import { getOctokit, isGitHubConfigured } from "../../github/client";
 import { fetchFileFromDefaultBranch } from "../../github/contents";
-import { commentOnIssue, parseIssueRef } from "../../github/issues";
+import {
+  addLabelToIssue,
+  commentOnIssue,
+  parseIssueRef,
+  removeLabelFromIssue,
+} from "../../github/issues";
 import {
   armAutoMergeSquash,
   disarmAutoMerge,
@@ -23,12 +28,15 @@ import {
 } from "../../github/pull-requests";
 import { parseRepoFromGitUrl } from "../../github/repo";
 import {
+  notifyAttemptsExhausted,
+  notifyDailyCapReached,
   notifyGateConfigError,
   notifyReviewBlocked,
   notifySlotsSaturated,
 } from "../../discord/notifications";
 import { getCapacity } from "../capacity";
 import { occupiedSlots } from "../queue";
+import { startOfLocalDay, todayAutonomousSpendUsd } from "../spend";
 import { getActiveTasks, isParked, releaseParkedImplementTask } from "../turn-manager";
 import {
   decideNext,
@@ -47,12 +55,13 @@ import {
   parseGateConfig,
   type GateConfig,
 } from "./gates";
-import { ARMING_LABEL, labelNames, parseBlockedByRefs } from "./ticket";
+import { ARMING_LABEL, READY_FOR_HUMAN_LABEL, labelNames, parseBlockedByRefs } from "./ticket";
 import { buildImplementPrompt, buildReviewPrompt } from "./workflow";
-import { DEFAULT_ATTEMPT_BUDGET_USD } from "./budgets";
-
-/** Attempts per ticket before the reducer refuses further claims. */
-export const MAX_ATTEMPTS = 3;
+import {
+  DAILY_AUTONOMOUS_CAP_USD,
+  MAX_ATTEMPTS,
+  MAX_REVIEW_CYCLES_PER_ATTEMPT,
+} from "./budgets";
 
 const SWEEP_INTERVAL_MS = 30_000;
 
@@ -68,6 +77,9 @@ const ACTIVE_RUN_STATUSES = new Set([
 let sweepInterval: ReturnType<typeof setInterval> | null = null;
 let sweeping = false;
 let saturationAnnounced = false;
+// The local day (startOfLocalDay ms) whose cap pause was announced — keyed by
+// day rather than a boolean so the announcement re-arms itself at midnight.
+let dailyCapAnnouncedDay: number | null = null;
 const inFlightClaims = new Set<string>();
 // Run IDs whose gate-config failure the owner has already been told about —
 // once per failure, not once per sweep. Pruned as runs leave the pending set.
@@ -206,8 +218,14 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
   return {
     now,
     autonomyEnabledGlobal: config.autonomyEnabled,
-    attemptBudgetUsd: DEFAULT_ATTEMPT_BUDGET_USD,
+    // MAX_BUDGET_USD is the per-attempt default since Phase 5 (a ticket's
+    // budget: directive may raise a single attempt to the $75 ceiling)
+    attemptBudgetUsd: config.maxBudgetUsd,
     maxAttempts: MAX_ATTEMPTS,
+    maxReviewCycles: MAX_REVIEW_CYCLES_PER_ATTEMPT,
+    todayAutonomousSpendUsd: todayAutonomousSpendUsd(now),
+    dailyCapUsd: DAILY_AUTONOMOUS_CAP_USD,
+    dailyCapAnnounced: dailyCapAnnouncedDay === startOfLocalDay(now).getTime(),
     allowedAuthors: config.autonomyAllowedAuthors,
     slots: { total: capacity.slots, occupied: occupiedSlots(), occupants },
     queuedInteractiveCount: queuedTasks.filter((t) => t.kind === "interactive").length,
@@ -292,6 +310,7 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
         armed,
         result: run.reviewResult,
         implementTaskId: liveImplementTaskId(run.id),
+        reviewCycleCount: run.reviewCycleCount,
       });
       continue;
     }
@@ -610,6 +629,12 @@ async function executeActions(actions: Action[]): Promise<void> {
       case "finalizeRun":
         await executeFinalizeRun(action);
         break;
+      case "exhaust":
+        await executeExhaust(action);
+        break;
+      case "failAttempt":
+        await executeFailAttempt(action);
+        break;
       case "pausePickup":
         console.log(
           `[autonomy] Pickup paused (${action.reason})${action.detail ? `: ${action.detail}` : ""}`
@@ -621,6 +646,13 @@ async function executeActions(actions: Action[]): Promise<void> {
             `[autonomy] All ${action.payload.total} slot(s) busy: ${action.payload.occupants.join(", ")}`
           );
           await notifySlotsSaturated(getConfig().discordFleetChannelId, action.payload);
+        } else if (action.event === "daily-cap-reached") {
+          console.log(
+            `[autonomy] Daily cap reached ($${action.payload.spentUsd.toFixed(2)} / ` +
+              `$${action.payload.capUsd.toFixed(2)}) — pickup paused until local midnight`
+          );
+          dailyCapAnnouncedDay = startOfLocalDay(new Date()).getTime();
+          await notifyDailyCapReached(getConfig().discordFleetChannelId, action.payload);
         } else if (action.event === "gate-config-error") {
           await executeGateConfigError(action.payload);
         } else if (action.event === "verdict-unparseable") {
@@ -958,6 +990,116 @@ async function executeFinalizeRun(
 }
 
 /**
+ * Three failed attempts: the ticket goes back to a human. Labels first —
+ * `ready-for-human` added before `ready-for-agent` is removed, so the issue
+ * is never in neither queue, and the removal (which takes the issue out of
+ * the candidate set) is what makes this fire once. The last failed run
+ * becomes `exhausted`: the dashboard's needs-you bucket reads it, and a
+ * deliberate re-arm then finds two failed runs, granting exactly one fresh
+ * attempt instead of insta-exhausting.
+ */
+async function executeExhaust(action: Extract<Action, { type: "exhaust" }>): Promise<void> {
+  if (!(await addLabelToIssue(action.issueRef, READY_FOR_HUMAN_LABEL))) return;
+  if (!(await removeLabelFromIssue(action.issueRef, ARMING_LABEL))) return;
+
+  const failed = db
+    .select()
+    .from(runs)
+    .where(and(eq(runs.githubIssue, action.issueRef), eq(runs.status, "failed")))
+    .all()
+    .sort((a, b) => a.claimedAt.getTime() - b.claimedAt.getTime());
+
+  const last = failed[failed.length - 1];
+  if (last) {
+    db.update(runs).set({ status: "exhausted" }).where(eq(runs.id, last.id)).run();
+  }
+
+  const totalSpendUsd = failed.reduce((sum, r) => sum + r.totalCostUsd, 0);
+  const attemptLines = failed.map(
+    (r) =>
+      `- attempt ${r.attempt}: $${r.totalCostUsd.toFixed(2)} — ${r.failureReason ?? "failed"}`
+  );
+
+  console.log(
+    `[autonomy] ${action.issueRef} exhausted after ${action.attemptsMade} attempts — ready-for-human`
+  );
+  await commentOnIssue(
+    action.issueRef,
+    `All ${action.attemptsMade} autonomous attempts failed — swapping ` +
+      `\`${ARMING_LABEL}\` for \`${READY_FOR_HUMAN_LABEL}\`.\n\n` +
+      `${attemptLines.join("\n")}\n\n` +
+      `Total autonomous spend on this ticket: $${totalSpendUsd.toFixed(2)}.`
+  );
+
+  const project = last
+    ? db.select().from(projects).where(eq(projects.id, last.projectId)).get()
+    : undefined;
+  await notifyAttemptsExhausted(
+    project?.discordChannelId ?? getConfig().discordFleetChannelId,
+    { issueRef: action.issueRef, attempts: action.attemptsMade, totalSpendUsd }
+  );
+}
+
+/**
+ * An attempt that exhausted its review cycles: the final request-changes
+ * findings still land on the PR as the record, but no fix-up turn runs — the
+ * run fails, counting a strike toward exhaustion. Ordering fails safe:
+ * disarm before anything else (abort and retry next sweep if it fails), and
+ * the review post is best-effort — with auto-merge off and no approval
+ * posted, nothing can merge either way.
+ */
+async function executeFailAttempt(
+  action: Extract<Action, { type: "failAttempt" }>
+): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  if (action.armed) {
+    const disarmed = await disarmAutoMerge(ref.owner, ref.repo, action.prNumber);
+    if (!disarmed) return;
+  }
+
+  const posted = await postReviewAsReviewer(
+    ref.owner,
+    ref.repo,
+    action.prNumber,
+    "REQUEST_CHANGES",
+    action.reviewBody
+  );
+
+  const run = db.select().from(runs).where(eq(runs.id, action.runId)).get();
+  db.update(runs)
+    .set({
+      status: "failed",
+      failureReason: "review cycles exhausted",
+      reviewResult: null,
+      ...(posted ? { reviewVerdict: "request-changes" as const } : {}),
+      finishedAt: new Date(),
+    })
+    .where(eq(runs.id, action.runId))
+    .run();
+
+  await releaseImplementContainer(
+    action.runId,
+    "Review cycles exhausted — attempt failed, releasing container."
+  );
+
+  console.log(
+    `[autonomy] Run ${action.runId} failed: review cycles exhausted (${action.issueRef})`
+  );
+  await commentOnIssue(
+    action.issueRef,
+    `Run failed (attempt ${run?.attempt ?? "?"}/${MAX_ATTEMPTS}): review cycles ` +
+      `exhausted — ${MAX_REVIEW_CYCLES_PER_ATTEMPT} implement↔review cycles without ` +
+      `an approval. ` +
+      (posted
+        ? `The reviewer's final findings are on PR #${action.prNumber}.`
+        : `Posting the review to PR #${action.prNumber} failed; the reviewer's ` +
+          `final findings were:\n\n${action.reviewBody}`)
+  );
+}
+
+/**
  * An unparseable verdict fails closed: disarm, add human oversight, tell the
  * owner (once), and leave the stored result in place as the record. No
  * review is posted and nothing can merge until a human looks.
@@ -1053,8 +1195,10 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
         mode: action.mode,
         status: failure ? "failed" : "claimed",
         budgetUsd: action.budgetUsd,
+        maxTurns: action.maxTurns,
         claimedAt: now,
         finishedAt: failure ? now : null,
+        failureReason: failure ? `failed before start: ${failure}` : null,
       })
       .run();
 

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -1002,19 +1002,23 @@ async function executeExhaust(action: Extract<Action, { type: "exhaust" }>): Pro
   if (!(await addLabelToIssue(action.issueRef, READY_FOR_HUMAN_LABEL))) return;
   if (!(await removeLabelFromIssue(action.issueRef, ARMING_LABEL))) return;
 
-  const failed = db
+  const allRuns = db
     .select()
     .from(runs)
-    .where(and(eq(runs.githubIssue, action.issueRef), eq(runs.status, "failed")))
+    .where(eq(runs.githubIssue, action.issueRef))
     .all()
     .sort((a, b) => a.claimedAt.getTime() - b.claimedAt.getTime());
+  const failed = allRuns.filter((r) => r.status === "failed");
 
   const last = failed[failed.length - 1];
   if (last) {
     db.update(runs).set({ status: "exhausted" }).where(eq(runs.id, last.id)).run();
   }
 
-  const totalSpendUsd = failed.reduce((sum, r) => sum + r.totalCostUsd, 0);
+  // The strikes are the failed runs, but the ticket's bill is every run it
+  // ever had — interrupted and cancelled ones, and a prior exhausted run
+  // from before a human re-arm, still spent real money.
+  const totalSpendUsd = allRuns.reduce((sum, r) => sum + r.totalCostUsd, 0);
   const attemptLines = failed.map(
     (r) =>
       `- attempt ${r.attempt}: $${r.totalCostUsd.toFixed(2)} — ${r.failureReason ?? "failed"}`

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -3,6 +3,8 @@
  * Nothing here performs I/O; the sweep gathers, these functions interpret.
  */
 
+import { MAX_ATTEMPT_BUDGET_USD, MAX_TURNS_CEILING } from "./budgets";
+
 export const ARMING_LABEL = "ready-for-agent";
 export const INTERACTIVE_TRIGGER_LABEL = "interlude";
 
@@ -10,6 +12,80 @@ const WORKFLOW_LABEL_PREFIX = "workflow:";
 
 /** A `## Workflow` (or `### Workflow`) section heading in a ticket body. */
 const WORKFLOW_SECTION = /^#{2,3}\s+Workflow\s*$/im;
+
+/**
+ * The bounded directive set a ticket may carry in its Workflow section.
+ * Null means "not specified — use the default". Directives can only move
+ * bounded numbers or add human oversight; there is deliberately no key that
+ * touches gates, the reviewer, auto-merge or the daily cap, and unknown keys
+ * are ignored rather than interpreted.
+ */
+export interface TicketDirectives {
+  /** Per-attempt budget in USD, clamped to MAX_ATTEMPT_BUDGET_USD */
+  budget: number | null;
+  /** Per-exec turn limit, clamped to MAX_TURNS_CEILING */
+  maxTurns: number | null;
+  /** Checkpoint text — forces supervised mode (issue #20 wires this) */
+  checkpoint: string | null;
+  /** Named workflow — informational in v1 (selectWorkflow drives the pass) */
+  workflow: string | null;
+}
+
+/**
+ * Parse the bounded directive set from a ticket body. Only whole lines inside
+ * the ticket's Workflow section count — directive-shaped text in prose or
+ * inside code fences is data, not instructions, and issue bodies are
+ * semi-trusted input that must never widen its own authority.
+ */
+export function parseTicketDirectives(body: string): TicketDirectives {
+  const directives: TicketDirectives = {
+    budget: null,
+    maxTurns: null,
+    checkpoint: null,
+    workflow: null,
+  };
+
+  for (const line of workflowSectionLines(body)) {
+    const match = line.match(/^\s*(?:[-*]\s+)?([a-z-]+)\s*:\s*(.*)$/i);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    const value = match[2].trim();
+
+    if (key === "budget" && directives.budget === null) {
+      const amount = value.match(/^\$?(\d+(?:\.\d+)?)$/);
+      const parsed = amount ? parseFloat(amount[1]) : NaN;
+      if (parsed > 0) directives.budget = Math.min(parsed, MAX_ATTEMPT_BUDGET_USD);
+    } else if (key === "max-turns" && directives.maxTurns === null) {
+      const parsed = /^\d+$/.test(value) ? parseInt(value, 10) : NaN;
+      if (parsed > 0) directives.maxTurns = Math.min(parsed, MAX_TURNS_CEILING);
+    } else if (key === "checkpoint" && directives.checkpoint === null) {
+      directives.checkpoint = value;
+    } else if (key === "workflow" && directives.workflow === null) {
+      directives.workflow = value;
+    }
+  }
+
+  return directives;
+}
+
+/** The lines of the ticket's Workflow section, if it has one. */
+function workflowSectionLines(body: string): string[] {
+  const lines = body.split("\n");
+  const sectionLines: string[] = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    const heading = line.match(/^(#{2,3})\s+Workflow\s*$/i);
+    if (heading) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^#{1,3}\s/.test(line)) break;
+    if (inSection) sectionLines.push(line);
+  }
+
+  return sectionLines;
+}
 
 /** How the implement pass's workflow was selected for a ticket. */
 export type WorkflowSelection =

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -68,15 +68,24 @@ export function parseTicketDirectives(body: string): TicketDirectives {
   return directives;
 }
 
-/** The lines of the ticket's Workflow section, if it has one. */
+/**
+ * The lines of the ticket's Workflow section, if it has one. Code fences are
+ * tracked from the top of the body: a fenced "heading" cannot open the
+ * section and fenced lines inside it are examples, not directives.
+ */
 function workflowSectionLines(body: string): string[] {
-  const lines = body.split("\n");
   const sectionLines: string[] = [];
   let inSection = false;
+  let inFence = false;
 
-  for (const line of lines) {
-    const heading = line.match(/^(#{2,3})\s+Workflow\s*$/i);
-    if (heading) {
+  for (const line of body.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    if (!inSection && /^#{2,3}\s+Workflow\s*$/i.test(line)) {
       inSection = true;
       continue;
     }

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -86,7 +86,7 @@ function workflowSectionLines(body: string): string[] {
     }
     if (inFence) continue;
 
-    if (!inSection && /^#{2,3}\s+Workflow\s*$/i.test(line)) {
+    if (!inSection && WORKFLOW_SECTION.test(line)) {
       inSection = true;
       continue;
     }

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -6,6 +6,7 @@
 import { MAX_ATTEMPT_BUDGET_USD, MAX_TURNS_CEILING } from "./budgets";
 
 export const ARMING_LABEL = "ready-for-agent";
+export const READY_FOR_HUMAN_LABEL = "ready-for-human";
 export const INTERACTIVE_TRIGGER_LABEL = "interlude";
 
 const WORKFLOW_LABEL_PREFIX = "workflow:";

--- a/src/lib/orchestrator/output-parser.ts
+++ b/src/lib/orchestrator/output-parser.ts
@@ -20,6 +20,9 @@ export interface TurnResult {
   /** The turn's last assistant text message — what the blocked-marker
    * detector reads. Null when the turn produced no text at all. */
   finalMessage: string | null;
+  /** The result event's subtype ("success", "error_max_turns", ...) — how
+   * turn exhaustion is detected. Null when no result event arrived. */
+  subtype: string | null;
 }
 
 interface ContentBlock {
@@ -38,6 +41,7 @@ export function createOutputHandler(taskId: string) {
   let sessionId: string | null = null;
   let costUsd = 0;
   let finalMessage: string | null = null;
+  let subtype: string | null = null;
   let lastToolUseMessageId: string | null = null;
   let _onDone: (() => void) | null = null;
 
@@ -62,7 +66,7 @@ export function createOutputHandler(taskId: string) {
         this.parseLine(buffer.trim());
         buffer = "";
       }
-      return { sessionId, costUsd, finalMessage };
+      return { sessionId, costUsd, finalMessage, subtype };
     },
 
     parseLine(line: string): void {
@@ -179,6 +183,7 @@ export function createOutputHandler(taskId: string) {
 
       if (type === "result") {
         sessionId = (event.session_id as string) ?? null;
+        subtype = (event.subtype as string) ?? null;
         costUsd =
           (event.total_cost_usd as number) ??
           (event.cost_usd as number) ??

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -13,7 +13,7 @@ import {
 } from "../docker/container-manager";
 import { createOutputHandler, type TurnResult } from "./output-parser";
 import { parseReviewVerdict } from "./autonomy/verdict";
-import { DEFAULT_REVIEW_BUDGET_USD } from "./autonomy/budgets";
+import { DEFAULT_REVIEW_BUDGET_USD, MAX_ATTEMPTS } from "./autonomy/budgets";
 import { scanPorts } from "./port-scanner";
 import { getConfig } from "../config";
 import { getDocker } from "../docker/client";
@@ -175,6 +175,7 @@ export async function startTask(taskId: string): Promise<void> {
     // pass's raw stream is kept: the verdict is parsed from it.
     const turnResult = await runTurn(taskId, running, prompt, undefined, {
       maxBudgetUsd: isReviewPass ? DEFAULT_REVIEW_BUDGET_USD : run?.budgetUsd,
+      maxTurns: isReviewPass ? undefined : (run?.maxTurns ?? undefined),
       captureRaw: isReviewPass,
     });
 
@@ -198,6 +199,14 @@ export async function startTask(taskId: string): Promise<void> {
     await runPostTurnCommitAndPush(taskId, running);
 
     if (isImplementPass) {
+      // Exhaustion first (issue #18): a pass that ran out of budget or turns
+      // failed its attempt — the branch is already pushed, so the work
+      // survives for the next attempt, but nothing proceeds toward review.
+      const exhaustion = run ? attemptExhaustion(run, turnResult.costUsd, turnResult.subtype) : null;
+      if (exhaustion) {
+        await failImplementAttempt(taskId, run!.id, exhaustion);
+        return;
+      }
       // The pass's turn is over: park it blocked if its final message leads
       // with the BLOCKED marker — container kept alive, question escalated
       // to the owner (issue #19). Otherwise the initial turn is the whole
@@ -229,7 +238,11 @@ export async function startTask(taskId: string): Promise<void> {
           .where(eq(runs.id, task.runId))
           .run();
       } else {
-        finishRun(task.runId, "failed");
+        finishRun(
+          task.runId,
+          "failed",
+          `container error: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
     insertSystemMessage(
@@ -273,7 +286,7 @@ async function runTurn(
   running: RunningContainer,
   prompt: string,
   sessionId?: string,
-  opts?: { maxBudgetUsd?: number; captureRaw?: boolean }
+  opts?: { maxBudgetUsd?: number; maxTurns?: number; captureRaw?: boolean }
 ): Promise<TurnResult & { raw?: string }> {
   const handler = createOutputHandler(taskId);
   const rawChunks: Buffer[] = [];
@@ -283,6 +296,7 @@ async function runTurn(
     prompt,
     sessionId,
     maxBudgetUsd: opts?.maxBudgetUsd,
+    maxTurns: opts?.maxTurns,
   });
 
   // Race: wait for the exec stream to close OR the "result" event from Claude.
@@ -319,14 +333,24 @@ export async function processQueuedMessages(
     if (!task || (task.status !== "running" && task.status !== "blocked")) break;
 
     // Check budget — a run-owned task answers to its attempt budget, an
-    // interactive task to the configured default. Known gap (issue #18's
-    // budget-exhausted seam): completing a run-owned task here can strand an
-    // undelivered fix-up message, leaving the run `implementing` forever.
+    // interactive task to the configured default. Budget exhaustion on a
+    // run-owned task is a run-level outcome (issue #18): the attempt fails
+    // through the ledger, because quietly completing the task here would
+    // strand an undelivered fix-up message and leak the run in
+    // `implementing` forever.
     const run = task.runId
       ? db.select().from(runs).where(eq(runs.id, task.runId)).get()
       : undefined;
     const budgetUsd = run?.budgetUsd ?? config.maxBudgetUsd;
     if (task.totalCostUsd && task.totalCostUsd >= budgetUsd) {
+      if (run) {
+        await failImplementAttempt(
+          taskId,
+          run.id,
+          `budget exhausted ($${task.totalCostUsd.toFixed(2)} of $${budgetUsd.toFixed(2)})`
+        );
+        break;
+      }
       insertSystemMessage(
         taskId,
         `Budget limit reached ($${task.totalCostUsd.toFixed(2)} / $${budgetUsd.toFixed(2)})`
@@ -393,7 +417,10 @@ export async function processQueuedMessages(
       running,
       promptText,
       task.sessionId ?? undefined,
-      { maxBudgetUsd: run ? run.budgetUsd - (task.totalCostUsd ?? 0) : undefined }
+      {
+        maxBudgetUsd: run ? run.budgetUsd - (task.totalCostUsd ?? 0) : undefined,
+        maxTurns: run?.maxTurns ?? undefined,
+      }
     );
 
     // Update cumulative cost and session
@@ -410,6 +437,16 @@ export async function processQueuedMessages(
     await runPostTurnCommitAndPush(taskId, running);
 
     if (task.kind === "implement") {
+      // Exhaustion first (issue #18): a fix-up or answer turn that spent the
+      // attempt's remaining budget or turns fails the attempt through the
+      // ledger — the branch is already pushed, the work survives.
+      const exhaustion = run
+        ? attemptExhaustion(run, currentCost + turnResult.costUsd, turnResult.subtype)
+        : null;
+      if (exhaustion) {
+        await failImplementAttempt(taskId, run!.id, exhaustion);
+        break;
+      }
       // Park-or-proceed again: the resumed pass may hit another unresolved
       // decision and re-park blocked, or end its turn healthy — which leaves
       // it parked awaiting review. A pass that blocked before its PR was
@@ -540,7 +577,13 @@ export async function completeTask(taskId: string): Promise<void> {
     }
 
     updateTask(taskId, { status: "failed", containerStatus: null });
-    if (task.runId) finishRun(task.runId, "failed");
+    if (task.runId) {
+      finishRun(
+        task.runId,
+        "failed",
+        `container error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   } finally {
     activeTasks.delete(taskId);
     if (running && !getConfig().keepContainers) {
@@ -592,6 +635,71 @@ async function finishImplementPass(taskId: string): Promise<void> {
       task.githubIssue,
       `Implement pass complete -- PR #${task.pullRequestNumber} ready for review ($${cost})`
     );
+  }
+}
+
+/**
+ * Why an implement pass's turn left its attempt unable to continue, or null
+ * for a healthy turn. Budget is judged from accumulated cost (robust to CLI
+ * versions), turn exhaustion from the result event's subtype.
+ */
+function attemptExhaustion(
+  run: { budgetUsd: number },
+  totalCostUsd: number,
+  turnSubtype: string | null
+): string | null {
+  if (totalCostUsd >= run.budgetUsd) {
+    return `budget exhausted ($${totalCostUsd.toFixed(2)} of $${run.budgetUsd.toFixed(2)})`;
+  }
+  if (turnSubtype === "error_max_turns") return "turn limit reached";
+  return null;
+}
+
+/**
+ * Fail an implement attempt through the run ledger (issue #18): the run
+ * records the strike and its reason, the task fails, the owner learns why on
+ * the issue, and the container goes away. The branch was pushed after the
+ * turn, so the work survives for the next attempt; three strikes and the
+ * sweep routes the ticket back to a human.
+ */
+async function failImplementAttempt(
+  taskId: string,
+  runId: string,
+  reason: string
+): Promise<void> {
+  const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get();
+
+  insertSystemMessage(taskId, `Attempt failed: ${reason}`);
+  updateTask(taskId, { status: "failed", containerStatus: null });
+  syncRunCost(runId);
+  db.update(runs)
+    .set({
+      status: "failed",
+      failureReason: reason,
+      finishedAt: new Date(),
+      // Keep the PR on the ledger for the exhaust summary and dashboard
+      pullRequestNumber: task?.pullRequestNumber ?? run?.pullRequestNumber,
+      pullRequestUrl: task?.pullRequestUrl ?? run?.pullRequestUrl,
+      // A blocked run that dies exhausted is no longer waiting on anyone
+      blockedQuestion: null,
+    })
+    .where(eq(runs.id, runId))
+    .run();
+
+  if (task?.githubIssue) {
+    await commentOnIssue(
+      task.githubIssue,
+      `Run failed (attempt ${run?.attempt ?? "?"}/${MAX_ATTEMPTS}): ${reason}. ` +
+        `Work so far is pushed to \`${task.branch}\`.`
+    );
+  }
+
+  const entry = activeTasks.get(taskId);
+  activeTasks.delete(taskId);
+  if (entry && !getConfig().keepContainers) {
+    await removeContainer(entry.container);
+    updateTask(taskId, { containerId: null });
   }
 }
 
@@ -952,9 +1060,9 @@ function updateTask(
 }
 
 /** Terminalize a run: failed consumes an attempt, cancelled does not. */
-function finishRun(runId: string, status: "failed" | "cancelled"): void {
+function finishRun(runId: string, status: "failed" | "cancelled", reason?: string): void {
   db.update(runs)
-    .set({ status, finishedAt: new Date() })
+    .set({ status, finishedAt: new Date(), ...(reason ? { failureReason: reason } : {}) })
     .where(eq(runs.id, runId))
     .run();
 }


### PR DESCRIPTION
Closes #18

## What this does

Bounded spend and bounded persistence for the autonomous loop: a bad ticket costs a known amount, and a doomed one comes back to a human instead of looping.

- **`parseTicketDirectives`** (`src/lib/orchestrator/autonomy/ticket.ts`) — pure parser over the ticket's Workflow section for the bounded directive set: `budget` (clamped to $75), `max-turns` (clamped to 100), `checkpoint`, `workflow` (informational). Unknown keys ignored. Adversarial bodies proven inert by tests: directive-alikes in code fences, fenced Workflow headings, mid-line prose mentions, lines outside the section, and authority-widening keys (`gates`, `reviewer`, `daily-cap`, `auto-merge`, `attempts`) all do nothing.
- **Budget constants** consolidated in `src/lib/orchestrator/autonomy/budgets.ts`: $20 default per attempt, $75 directive ceiling, ~$5 review allowance, 3 attempts, 2 implement↔review cycles per attempt, $500/day cap. `MAX_ATTEMPTS` (sweep + fleet view) and `DAILY_AUTONOMOUS_CAP_USD` (fleet rows) now import from here instead of restating the numbers.
- **`MAX_BUDGET_USD` meaning change** ($5/task → $20/attempt, inherited by interactive tasks) documented in `.env.example`, the `AppConfig` docstring, and CLAUDE.md's Database section.
- **`decideNext`** — attempt accounting and cap handling in the pure reducer: three strikes emit `exhaust` (ahead of author/blocker checks — routing a burnt ticket home is bookkeeping, not pickup); a request-changes verdict past the cycle bound emits `failAttempt` (findings still posted, no fix-up runs); the daily cap emits `pausePickup` + a once-per-day `notify`, and pauses pickup only — verdicts still post, exhaust still routes, in-flight work still runs.
- **Executors** (`sweep.ts`): `executeExhaust` swaps `ready-for-agent` → `ready-for-human` (add before remove, so the issue is never in neither queue), marks the last failed run `exhausted`, comments a per-attempt summary with total spend, and notifies Discord. `executeFailAttempt` disarms first, posts the final review as the record, fails the run with a reason, releases the container.
- **Turn manager** — an implement pass that exhausts its budget (accumulated cost) or turns (`error_max_turns` subtype) fails its attempt through the run ledger: strike recorded with `failureReason`, issue commented, container torn down; the branch is already pushed so the work survives for the next attempt. Container errors now record their reason on the run too.
- **#17 handoff fixed** — budget exhaustion on a run-owned task in `processQueuedMessages` now fails the attempt through the ledger instead of quietly completing the task and stranding the run in `implementing` forever.
- **Daily cap** — `todayAutonomousSpendUsd` sums the runs ledger from local midnight, so interactive tasks (no run row) are exempt by construction and the pause lifts with the new day; the announcement flag is keyed by local day so it re-arms at midnight. Visible on the fleet dashboard, which now reads the same cap constant.
- Schema: `runs.maxTurns` + `runs.failureReason` (migration `drizzle/0010`).

## Notes for the reviewer

- **Moved main**: origin/main gained #49 (OAuth-token agent auth) mid-flight; rebase/merge aren't available in this harness, so commit 6eae095 imports the upstream file states and re-applies this branch's edits. The two-dot diff (`git diff origin/main`, what GitHub shows) is the pure feature diff.
- **Pre-existing lint failures**: `pnpm lint` fails on `custom-server.js`, `preview-pane.tsx`, and `output-parser.test.ts` — all three byte-identical to origin/main; not introduced or touched here. Tests (286) and `tsc --noEmit` are clean.
- **`workflow:tdd`**: tests were written at the two confirmed seams only (parser + reducer); executors and turn-manager wiring are deliberately untested per the ticket ("if a test needs Docker/GitHub/Discord/DB mocking, it is at the wrong seam").

## Self-review findings I disagreed with (and why)

- *`checkpoint` parsed but not acted on*: intended — #20 (HITL) wires `checkpoint:` → supervised run; this ticket only had to parse it. The reducer's claim path deliberately doesn't carry it yet.
- *Daily-cap announcement flag is in-memory, so a restart mid-day re-announces*: matches the pre-existing `saturationAnnounced` pattern; persisting it means a schema change for a rare duplicate embed. Restart semantics are #24's ticket.
- *Cap pause/announcement only emits when an eligible candidate exists*: deliberate (covered by a test) — "pickup paused" is noise when nothing wants pickup; the dashboard shows spend vs cap continuously either way.
- *Budget exhaustion detection misses a CLI halt that stops just under the limit (budget-specific result subtype not checked)*: the subtype string for budget halts isn't verifiable here, so detection stays cost-based ("robust to CLI versions"). Worst case is bounded: the pass proceeds to one review (~$5), and the next fix-up turn's accumulated-cost check fails the attempt through the ledger.
- *Spend attributed to a run's claim day*: documented in the reducer; drift is bounded to one attempt's budget at midnight.
- Minor duplication left as-is: the budget-exhausted message appears in both `attemptExhaustion` and the pre-turn check in `processQueuedMessages` (the refactor read worse than the duplication), and the `container error:` prefix in two catch sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
