### PR TITLE
Phase 5: supervised mode via the checkpoint directive

### DIFF
--- a/drizzle/0011_chemical_kinsey_walden.sql
+++ b/drizzle/0011_chemical_kinsey_walden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `checkpoint` text;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,551 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e9518119-3f3c-4c53-a1a9-645ea4d967e9",
+  "prevId": "b5f62fa3-804e-4772-a5bb-22cbca3fe65e",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786147200000,
       "tag": "0010_large_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1786233600000,
+      "tag": "0011_chemical_kinsey_walden",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -70,6 +70,10 @@ export const runs = sqliteTable("runs", {
   reviewCycleCount: int("review_cycle_count").notNull().default(0),
   interruptionCount: int("interruption_count").notNull().default(0),
   blockedQuestion: text("blocked_question"),
+  // A checkpoint: directive's text, stored at claim time. Non-null makes the
+  // run supervised: its gate decision is forced to human-signoff regardless
+  // of glob matches, and the text names the decision waiting for the owner.
+  checkpoint: text("checkpoint"),
   // Why a failed attempt failed (budget/turn exhaustion, container error,
   // review cycles) — human-readable, surfaced in the exhaust summary
   failureReason: text("failure_reason"),

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -143,6 +143,7 @@ describe("decideNext — claiming", () => {
         attempt: 1,
         mode: "autonomous",
         budgetUsd: 20,
+        checkpoint: null,
         maxTurns: null,
         workflow: { source: "default" },
       },
@@ -194,6 +195,27 @@ describe("decideNext — claiming", () => {
     const actions = decideNext(makeSnapshot());
 
     expect(claims(actions)[0]).toMatchObject({ budgetUsd: 20, maxTurns: null });
+  });
+
+  it("claims a checkpoint ticket as a supervised run, carrying the checkpoint text", () => {
+    const body = "Spec.\n\n## Workflow\n\ncheckpoint: confirm the schema change with me\n";
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ body })] })
+    );
+
+    expect(claims(actions)[0]).toMatchObject({
+      mode: "supervised",
+      checkpoint: "confirm the schema change with me",
+    });
+  });
+
+  it("claims an ordinary ticket as an autonomous run with no checkpoint", () => {
+    const actions = decideNext(makeSnapshot());
+
+    expect(claims(actions)[0]).toMatchObject({
+      mode: "autonomous",
+      checkpoint: null,
+    });
   });
 });
 

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -847,6 +847,61 @@ describe("decideNext — gate evaluation of a finished implement pass", () => {
     ]);
   });
 
+  it("records matched categories on a supervised gate alongside the checkpoint", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({
+            checkpoint: "confirm the schema change with me",
+            changedPaths: ["src/components/Button.tsx"],
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "gatePr",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        categories: ["visual-ui"],
+        checkpoint: "confirm the schema change with me",
+      },
+    ]);
+  });
+
+  it("supervises on a bare checkpoint directive — empty text is still a checkpoint", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [makePending({ checkpoint: "" })],
+      })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual(["gatePr"]);
+  });
+
+  it("fails closed on broken config even for a supervised run — config errors outrank the checkpoint", () => {
+    // The checkpoint's outcome (gated) does not depend on config, but the
+    // config failure is real and the owner must still hear about it; the run
+    // gates on the sweep after the config is fixed.
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({
+            checkpoint: "confirm the schema change with me",
+            gateConfig: { ok: false, reason: "invalid YAML" },
+          }),
+        ],
+      })
+    );
+
+    expect(actions.map((a) => a.type)).toEqual(["notify"]);
+  });
+
   it("gate decisions do not consume claimable slots", () => {
     // Gate evaluation is orchestrator work, not container work — a pending
     // decision must not block the last free slot from a new claim.

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -115,6 +115,7 @@ function makePending(
     issueRef: "acme/widgets#7",
     prNumber: 41,
     changedPaths: ["src/lib/util.ts"],
+    checkpoint: null,
     gateConfig: {
       ok: true,
       estate: { "visual-ui": ["**/components/**"] },
@@ -740,6 +741,7 @@ describe("decideNext — gate evaluation of a finished implement pass", () => {
         issueRef: "acme/widgets#7",
         prNumber: 41,
         categories: ["infrastructure", "visual-ui"],
+        checkpoint: null,
       },
     ]);
   });
@@ -808,6 +810,7 @@ describe("decideNext — gate evaluation of a finished implement pass", () => {
         issueRef: "acme/widgets#9",
         prNumber: 44,
         categories: ["visual-ui"],
+        checkpoint: null,
       },
     ]);
   });
@@ -819,6 +822,29 @@ describe("decideNext — gate evaluation of a finished implement pass", () => {
     );
 
     expect(actions.map((a) => a.type)).toEqual(["armAutoMerge", "claimIssue"]);
+  });
+
+  it("gates a supervised PR even when no glob matched, carrying the checkpoint", () => {
+    // makePending's changed paths match no gate — an autonomous run would arm
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingGateEvaluations: [
+          makePending({ checkpoint: "confirm the schema change with me" }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "gatePr",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        categories: [],
+        checkpoint: "confirm the schema change with me",
+      },
+    ]);
   });
 
   it("gate decisions do not consume claimable slots", () => {

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -188,8 +188,13 @@ export type Action =
       issueTitle: string;
       issueBody: string;
       attempt: number;
-      mode: "autonomous";
+      /** A checkpoint: directive makes the run supervised — forced
+       * human-signoff at the gate decision, never auto-merge */
+      mode: "autonomous" | "supervised";
       budgetUsd: number;
+      /** The checkpoint's text — the decision waiting for the owner; null
+       * for an ordinary autonomous run */
+      checkpoint: string | null;
       /** Per-exec turn limit from a max-turns directive; null = the default */
       maxTurns: number | null;
       workflow: WorkflowSelection;
@@ -628,8 +633,9 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       issueTitle: candidate.title,
       issueBody: candidate.body,
       attempt: candidate.attemptsMade + 1,
-      mode: "autonomous",
+      mode: directives.checkpoint !== null ? "supervised" : "autonomous",
       budgetUsd: directives.budget ?? snapshot.attemptBudgetUsd,
+      checkpoint: directives.checkpoint,
       maxTurns: directives.maxTurns,
       workflow: selectWorkflow(candidate.body, candidate.labels),
     });

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -61,6 +61,9 @@ export interface PendingGateEvaluation {
   prNumber: number;
   /** Paths the PR changes, from the GitHub API */
   changedPaths: string[];
+  /** The run's checkpoint text, stored at claim time; non-null means the run
+   * is supervised and must gate regardless of what the globs match */
+  checkpoint: string | null;
   gateConfig:
     | { ok: true; estate: GateConfig; extension: GateConfig }
     | { ok: false; reason: string };
@@ -216,6 +219,9 @@ export type Action =
       issueRef: string;
       prNumber: number;
       categories: string[];
+      /** The supervised run's checkpoint text, carried so the notification
+       * names the decision that is waiting; null for a glob-matched gate */
+      checkpoint: string | null;
     }
   | { type: "armAutoMerge"; runId: string; issueRef: string; prNumber: number }
   | {
@@ -504,13 +510,18 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       pending.gateConfig.extension,
       pending.changedPaths
     );
-    if (categories.length > 0) {
+    // The supervised branch (issue #20): a checkpoint: directive forces
+    // human-signoff whatever the globs said — the matched categories are
+    // still recorded, but auto-merge is never armed. Supervised is a mode,
+    // not a status: the outcome is the ordinary gated path.
+    if (categories.length > 0 || pending.checkpoint !== null) {
       actions.push({
         type: "gatePr",
         runId: pending.runId,
         issueRef: pending.issueRef,
         prNumber: pending.prNumber,
         categories,
+        checkpoint: pending.checkpoint,
       });
     } else {
       actions.push({

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -530,6 +530,7 @@ async function gatherPendingGateEvaluations(
       issueRef: run.githubIssue,
       prNumber: run.pullRequestNumber!,
       changedPaths,
+      checkpoint: run.checkpoint,
       gateConfig,
     });
   }
@@ -1199,6 +1200,7 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
         mode: action.mode,
         status: failure ? "failed" : "claimed",
         budgetUsd: action.budgetUsd,
+        checkpoint: action.checkpoint,
         maxTurns: action.maxTurns,
         claimedAt: now,
         finishedAt: failure ? now : null,

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -669,7 +669,9 @@ async function executeActions(actions: Action[]): Promise<void> {
  * matched categories on the run, and say so on the issue. The label goes on
  * first — if it fails, the run stays pending and the next sweep retries.
  * Moving to `gated` clears any previous cycle's verdict: the review pass
- * that follows judges the PR as it now stands.
+ * that follows judges the PR as it now stands. A supervised run's comment
+ * leads with the checkpoint — the decision the owner is being waited on —
+ * rather than the (possibly empty) gate categories.
  */
 async function executeGatePr(action: Extract<Action, { type: "gatePr" }>): Promise<void> {
   const ref = parseIssueRef(action.issueRef);
@@ -688,9 +690,30 @@ async function executeGatePr(action: Extract<Action, { type: "gatePr" }>): Promi
     .where(eq(runs.id, action.runId))
     .run();
 
+  const gatedBy = [
+    ...(action.checkpoint !== null ? ["checkpoint"] : []),
+    ...action.categories,
+  ];
   console.log(
-    `[autonomy] Gated ${action.issueRef} PR #${action.prNumber}: ${action.categories.join(", ")}`
+    `[autonomy] Gated ${action.issueRef} PR #${action.prNumber}: ${gatedBy.join(", ")}`
   );
+
+  if (action.checkpoint !== null) {
+    const lines = [
+      `Checkpoint: this ticket runs supervised — PR #${action.prNumber} is labelled ` +
+        `\`${HUMAN_SIGNOFF_LABEL}\` with auto-merge left disarmed, regardless of gate ` +
+        `matches. A human approves and merges this one.`,
+    ];
+    if (action.checkpoint.trim()) {
+      lines.push(`The decision waiting:\n\n> ${action.checkpoint.trim()}`);
+    }
+    if (action.categories.length > 0) {
+      lines.push(`It also touches **${action.categories.join(", ")}**.`);
+    }
+    await commentOnIssue(action.issueRef, lines.join("\n\n"));
+    return;
+  }
+
   await commentOnIssue(
     action.issueRef,
     `Review gates: PR #${action.prNumber} touches **${action.categories.join(", ")}** — ` +


### PR DESCRIPTION
Closes #20

A `checkpoint:` directive (parsed from the ticket's Workflow section since #18) now puts the whole run in supervised mode: the work happens, the PR opens, and the gate decision is forced to `human-signoff` with auto-merge never armed — reusing the gated path rather than adding any lifecycle state.

## What changed

- **`decideNext` claim branch** — a candidate whose body carries `checkpoint:` is claimed with `mode: "supervised"` and the checkpoint text on the action; ordinary tickets claim exactly as before (`mode: "autonomous"`, `checkpoint: null`).
- **`decideNext` gate branch (the confirmed seam)** — a pending gate evaluation whose run has a checkpoint emits `gatePr` regardless of whether any glob matched, and never `armAutoMerge`. Matched categories are still evaluated and recorded alongside the checkpoint.
- **`runs.checkpoint`** — new nullable text column (migration 0011) stores the directive's text at claim time, so the gate decision reads the claim-time parse rather than re-reading a body that may have been edited since. The migration journal entry is hand-stamped past the future-dated 0010, per the journal guard test's instruction.
- **Notification** — the gate comment on the issue leads with the checkpoint: it states the run is supervised, quotes the decision waiting (when the ticket gave one), and notes any gate categories the PR also touches. The fleet dashboard's supervised mode chip lights up for free via the pre-existing `runs.mode` enum.

## Tests

TDD at the ticket's confirmed seam (`decideNext`), no Docker/GitHub/Discord/DB mocking: supervised claim carries mode + text, checkpoint with no glob match gates instead of arming, matched categories ride alongside the checkpoint, an empty-text checkpoint still supervises, and a broken gate config still fails closed. 292 tests pass; typecheck clean. (`pnpm lint` reports 17 pre-existing problems, all in files this branch doesn't touch.)

## Design decision worth reviewing

**Config errors outrank the checkpoint.** When the gate config is missing/unparseable, a supervised run follows the existing fail-closed path — owner notified once, run stays pending, nothing armed — rather than gating immediately with empty categories. A strict reading of "forced to `human-signoff` regardless" could expect the gate to win; I chose config-error-first because the announcement's wording stays accurate, the categories get recorded once the config is fixed, and no safety is lost either way (auto-merge is never armed before a gate decision). Pinned by the "config errors outrank the checkpoint" test — easy to flip if the reviewer disagrees.

## Review findings not acted on

Self-review (two-axis, vs origin/main) found no standards violations; four judgement-call smells I'm deliberately leaving:

- `mode` and `checkpoint` travel together on the claim action though mode is derivable — kept because `runs.mode` is a real pre-existing column the executor persists, and deriving it executor-side would move a policy decision out of the pure reducer.
- `checkpoint: string | null` is a tri-state primitive (`null` / `""` / text) — kept to match `TicketDirectives.checkpoint` from #18 rather than minting a one-field type.
- The two `executeGatePr` comment branches share a sentence shape, and the `!== null` predicate recurs — both too small to abstract without hurting the wording/readability.

Note: this PR touches `src/db/schema.ts`, `drizzle/**` and `src/lib/orchestrator/autonomy/**`, all gated paths in `docs/agents/review-gates.yaml` — it should itself carry `human-signoff` and never auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)