### PR TITLE
Phase 5: pilot enablement and runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,21 @@ GITHUB_APP_INSTALLATION_ID=12345678
 # Discord Bot (optional — enables task notifications + dispatch from Discord)
 # DISCORD_BOT_TOKEN=your-bot-token
 # DISCORD_APPLICATION_ID=your-application-id
+# DISCORD_GUILD_ID=your-guild-id  # server id, used to deep-link into project channels
+# DISCORD_FLEET_CHANNEL_ID — fleet events (slot saturation, digest) and the
+#   fallback channel for a blocked agent's question when its project has no
+#   linked channel. Without it, those land only on the dashboard / task chat.
+# DISCORD_FLEET_CHANNEL_ID=your-channel-id
+
+# Autonomy (Phase 5 — autonomous ticket-loop). Off by default; see docs/runbook.md.
+# Global kill switch: BOTH this and a project's own toggle must be on for pickup.
+# Read once at boot, so a change needs an orchestrator restart.
+# AUTONOMY_ENABLED=false
+# Extra GitHub logins (comma-separated) allowed to author claimable issues.
+# The repo owner is always allowed; this is defence in depth behind the
+# human-only ready-for-agent labelling rule.
+# AUTONOMY_ALLOWED_AUTHORS=someone,another
+# Reviewer machine-account PAT — the orchestrator posts PR reviews with it and
+# it NEVER enters an agent container. Canonical home is Doppler platform/prd,
+# mirrored into interlude/prd (rotation must update both).
+# REVIEWER_GH_TOKEN=github_pat_...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,7 @@ Phase 5's loop. Phase 5 itself ships only the fleet dashboard.
 - Phase 2a plan: `docs/plans/2026-03-11-phase2a-agent-orchestrator.md`
 - VPS deployment spec: `docs/specs/2026-03-12-vps-deployment-design.md`
 - Phase 5 spec: `docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md`
+- Operator runbook (Phase 5 autonomy): `docs/runbook.md`
 - Overall design: see `docs/plans/2026-03-10-remote-agent-dev-environment-design.md` (external)
 
 ## Platform Context

--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@ src/
   lib/           — Shared utilities
   components/    — React components
 docs/
+  runbook.md     — Operator runbook for the autonomous ticket-loop
   specs/         — Design specifications
   plans/         — Implementation plans
+  agents/        — Agent-facing pass definitions and gate config
 ```
+
+## Operating the autonomous loop
+
+Running agents unattended? See the [operator runbook](docs/runbook.md) — how to
+enable autonomy per project, arm a ticket, watch the fleet, pause pickup, answer a
+blocked agent, find PRs waiting for sign-off, and cancel a run.
 
 ## License
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,252 @@
+# Autonomy runbook
+
+How to live with Interlude's autonomous ticket-loop (Phase 5). This is the
+operator's guide — the handful of things the owner actually does once the loop
+is on. It is deliberately short; the full design is in
+[`docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md`](specs/2026-07-30-phase5-autonomous-ticket-loop-design.md).
+
+Autonomy is **additive**. Interactive chat + live preview (dispatch a task, watch
+it, follow up) is unchanged and is never gated by anything in this document.
+
+---
+
+## The one rule
+
+**Applying the `ready-for-agent` label is the launch button.** It means "an agent
+may implement this and merge it unattended." **Only a human ever applies it.**
+
+The orchestrator never applies `ready-for-agent` itself — not from triage, not
+from anywhere. Triage can only *recommend* it (it applies advisory labels like
+`needs-info` / `ready-for-human` and pings you); arming is your click. As defence
+in depth, the loop also ignores an armed issue unless its author is the repo owner
+or on the `AUTONOMY_ALLOWED_AUTHORS` allow-list. Priority is expressed purely by
+*when* you arm work — oldest-armed-first, no priority field anywhere.
+
+---
+
+## Turning it on (pilot enablement)
+
+Autonomy is off by default at two levels, and **both** must be on for pickup:
+
+1. **Global kill switch** — `AUTONOMY_ENABLED` (env, from Doppler `interlude/prd`).
+2. **Per-project toggle** — `projects.autonomyEnabled` (off by default; enabled
+   deliberately, per project, never in bulk).
+
+A project is only claimable when both are on **and** its preflight passes.
+
+### Preflight: is a repo safe to run unattended?
+
+Before any of a repo's tickets can be claimed, its preflight must pass. Preflight
+checks four things and, on failure, names exactly what is missing:
+
+| Check | What it verifies | Fix if it fails |
+| --- | --- | --- |
+| GitHub App installed | the App installation can see the repo (clone/push + API) | install the Interlude GitHub App on the repo |
+| Branch protection | the default branch has branch protection | add branch protection (also needs the App's *Administration: read* permission to verify) |
+| Reviewer is a collaborator | the `REVIEWER_GH_TOKEN` machine account can review PRs | add the reviewer account as a collaborator (`scripts/setup-reviewer.sh` in the migration) |
+| `human-signoff` label exists | gated PRs can be labelled for sign-off | `gh label create human-signoff -R <owner>/<repo>` |
+
+The reducer **fails closed**: a repo whose preflight has never run, or is failing,
+is as ineligible as one with autonomy off. Nothing is claimed until preflight
+passes, so a half-configured repo can never be run against by accident.
+
+Preflight is recomputed (a) immediately when you enable autonomy on a project,
+and (b) periodically (every few minutes) for enabled projects, so drift — e.g.
+branch protection being removed — is caught without a manual step.
+
+### Enable a project (deliberate, one at a time)
+
+Find the project's id, then flip the toggle. Enabling runs preflight
+synchronously and returns the result:
+
+```bash
+# List projects to get the id (ULID) and current preflight status
+curl -s http://localhost:3000/api/projects | jq '.[] | {id, name, githubRepo, autonomyEnabled, preflightStatus, preflightReason}'
+
+# Enable autonomy on one project — this runs preflight now
+curl -s -X PATCH http://localhost:3000/api/projects/<id> \
+  -H 'content-type: application/json' \
+  -d '{"autonomyEnabled": true}' \
+  | jq '{autonomyEnabled, preflightStatus, preflightReason}'
+```
+
+If the response shows `"preflightStatus": "failing"`, `preflightReason` names what
+to fix. Fix it, then re-run the PATCH (or wait for the periodic refresh) until it
+reads `"passing"`. A failing preflight on an enabled project also shows up in the
+dashboard's **needs you** panel.
+
+### Flip the global switch
+
+Set `AUTONOMY_ENABLED=true` in Doppler `interlude/prd` and restart the
+orchestrator (config is read once at boot). On boot you'll see
+`[autonomy] Reconciliation sweep every 30s`; if it's off you'll see
+`Autonomous pickup disabled (AUTONOMY_ENABLED != true)`.
+
+### Pilot repos and the first workload
+
+The pilots are **interlude**, **lemons** and **last-person-standing**. Verify
+preflight passes for all three before arming anything.
+
+The **first autonomous workload is interlude's own UI-upgrade backlog** — the
+shakedown bites the platform, not a real project. Arm those UI tickets one at a
+time (they are natural `checkpoint:` candidates — see *Supervised runs* below).
+lemons and last-person-standing are already on the ticket-loop and validate the
+"existing ticket-loop repo, zero changes" path.
+
+---
+
+## The handful of things you do
+
+### 1. Arm a ticket
+
+Apply the **`ready-for-agent`** label to a fully-specified issue. That's it — see
+*The one rule* above.
+
+- **Fast path:** the `issues.labeled` webhook (`POST /api/webhooks/github`) kicks
+  a sweep immediately.
+- **Backbone:** a reconciliation sweep runs every 30s (and on boot) and lists
+  open `ready-for-agent` issues per enabled project, so a missed webhook is at
+  most 30s of latency.
+- Claiming does **not** strip the label; the merge closes the issue via the PR's
+  `Closes #n`. An issue with an open blocker (`Blocked by: #N` in the body, or a
+  native GitHub dependency) is skipped until the blocker closes.
+
+An armed ticket needs no further action from you unless the agent gets blocked,
+the PR is gated, or all three attempts fail (you'll hear about each — below).
+
+### 2. Watch the fleet
+
+The **dashboard is the home page** (`/`). It streams live over SSE and shows:
+
+- **slots** — total vs used, and what occupies each (autonomous / interactive).
+- **needs you** — blocked questions, `human-signoff` PRs, exhausted tickets, a
+  daily-cap pause, and failing preflights, each with a link.
+- **running** — each active run's ticket, attempt (n/3), turn, spend vs budget,
+  and phase (implement ▸ review ▸ merge).
+- **recent** — the last 7 days of completions.
+- **spend** — today's autonomous spend vs the $500/day cap.
+
+Discord is **push-only**: it tells you *when to look* (claimed, blocked question,
+sign-off needed, attempts exhausted, cap pause, slots saturated, daily digest).
+Autonomous success is deliberately silent — it shows on the dashboard. There is
+no `!status` command; the dashboard answers "what's happening".
+
+### 3. Pause pickup
+
+Pausing only stops autonomous **pickup**. In-flight runs finish, and interactive
+chat/preview is never affected.
+
+- **Globally (kill switch):** set `AUTONOMY_ENABLED=false` in Doppler
+  `interlude/prd` and restart. The sweep stops; no new claims anywhere.
+- **Per project:** disable the toggle —
+
+  ```bash
+  curl -s -X PATCH http://localhost:3000/api/projects/<id> \
+    -H 'content-type: application/json' -d '{"autonomyEnabled": false}'
+  ```
+
+  Other projects keep running. The sweep logs `Pickup paused (autonomy-off-project)`
+  for that repo.
+
+### 4. Answer a blocked agent from Discord
+
+When an agent hits a decision the ticket doesn't settle, it emits
+`BLOCKED: <question>` as the first line of its turn. The orchestrator parks the
+run (status `blocked`, container kept alive but **holding no slot**) and posts the
+question to the project's linked Discord channel — or, if the project has none, to
+the fleet channel (`DISCORD_FLEET_CHANNEL_ID`).
+
+**Reply to that Discord message.** Your reply becomes the run's next turn (the
+Phase 4 idle-and-reply plumbing carries it): the run un-parks and continues. If
+the project has no Discord channel and no fleet channel is configured, the
+question still appears on the task's chat page in the UI, where you can answer it.
+
+### 5. Find PRs waiting for sign-off
+
+A PR gets the **`human-signoff`** label (and auto-merge is left disarmed) when it
+touches a gated path, when the ticket carried a `checkpoint:` directive, or when
+the reviewer escalated. It then waits for you.
+
+- **Dashboard:** the *needs you* panel's sign-off items link straight to each PR.
+- **From the CLI:** `gh pr list --label human-signoff --state open -R <owner>/<repo>`
+  (or search `is:pr is:open label:human-signoff`).
+
+Review it and merge (or push changes) yourself. What trips a gate for this repo is
+in [`docs/agents/review-gates.yaml`](agents/review-gates.yaml) (additive on top of
+the estate defaults): infrastructure, the agent sandbox, credentials, the DB
+schema/migrations, and the autonomy control surface itself.
+
+### 6. Cancel a run to free a slot
+
+To reclaim a slot from a running task:
+
+- **API:** `POST /api/tasks/<taskId>/cancel` (only accepts a task in `running`).
+- **Discord:** reply `cancel` to the task's message (the bot reacts 🛑).
+
+Cancelling stops and removes the container and frees the slot on the next poll.
+An owner-cancelled run does **not** consume one of the ticket's three attempts.
+(A *blocked* run is parked and holds no slot, so it isn't occupying capacity —
+answer it, or leave it; it doesn't need cancelling to free a slot.)
+
+---
+
+## Reference
+
+### Budgets, attempts, caps
+
+- **$20** per attempt (default). A ticket's `budget:` directive can raise a single
+  attempt to at most **$75**; issue text can't exceed that ceiling.
+- Review passes carry their own **~$5**; triage a small allowance with a low turn cap.
+- **3 attempts**, then the loop swaps `ready-for-agent` for **`ready-for-human`**,
+  comments a summary and pings Discord.
+- **$500/day** estate-wide autonomous cap pauses pickup (announced once, shown on
+  the dashboard, resets at local midnight). Interactive work is exempt by
+  construction (it has no run).
+
+### Supervised runs (`checkpoint:`)
+
+A `checkpoint: <text>` directive in a ticket's Workflow section runs the implement
+pass normally but then forces `human-signoff` regardless of gate matches, carrying
+`<text>` as the note for what needs your decision. Use it for
+agent-doable-but-risky work you want to eyeball before merge.
+
+### Capacity / slots
+
+Slots derive at boot from the Docker daemon's CPU and memory
+(`floor((memTotal − reserve) / perAgentMB)`, capped by CPU, min 1). A CX22 (4 GB,
+2 vCPU) yields **2**. A VPS resize is picked up on restart with no config change.
+Override with `CAPACITY_SLOTS`; per-agent memory with `AGENT_MEMORY_MB` (default
+1200 MiB, also the slot divisor). Every container has hard memory/CPU limits.
+
+### Key environment variables (Doppler `interlude/prd`)
+
+| Var | Meaning |
+| --- | --- |
+| `AUTONOMY_ENABLED` | Global kill switch. Must equal `true`. Read once at boot — restart to change. |
+| `AUTONOMY_ALLOWED_AUTHORS` | Extra logins (comma-separated) allowed to author claimable issues. The repo owner is always allowed. |
+| `REVIEWER_GH_TOKEN` | Reviewer machine account PAT. Orchestrator-only — **never** enters a container. Canonical home is `platform/prd`, mirrored into `interlude/prd`; rotation updates both. |
+| `DISCORD_FLEET_CHANNEL_ID` | Channel for fleet events + fallback for blocked questions when a project has no linked channel. |
+| `MAX_BUDGET_USD` | Per-attempt default budget ($20). |
+| `CAPACITY_SLOTS`, `AGENT_MEMORY_MB` | Override derived capacity — only when the derivation is wrong. |
+
+### Labels
+
+`ready-for-agent` (arm — human only) · `ready-for-human` (needs a human /
+attempts exhausted) · `needs-triage` (triage queue) · `needs-info` · `wontfix` ·
+`human-signoff` (PR gated, awaits sign-off) · `interlude` (interactive-task
+trigger) · `workflow:<skill>` (per-ticket workflow selector).
+
+---
+
+## When something's off
+
+- **Nothing is being claimed.** Check, in order: `AUTONOMY_ENABLED=true` and the
+  orchestrator restarted; the project's `autonomyEnabled` is true; its
+  `preflightStatus` is `passing` (a failing/never-run preflight blocks pickup —
+  read `preflightReason`); the issue has `ready-for-agent`, no open blocker, no
+  active run, and an allow-listed author; the daily cap isn't paused; a slot is free.
+- **Preflight won't pass.** Read `preflightReason` — it names the missing piece.
+  "no branch protection" can also mean the App lacks *Administration: read*; "not a
+  collaborator" can mean `REVIEWER_GH_TOKEN` is unset or its account isn't on the repo.
+- **A gated PR never merges.** That's by design — `human-signoff` means it waits
+  for you. Merge it yourself.

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { projects } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { refreshProjectPreflight } from "@/lib/orchestrator/autonomy/preflight";
 
 export async function GET(
   _request: Request,
@@ -25,11 +26,12 @@ export async function PATCH(
 ) {
   const { id } = await params;
   const body = await request.json();
-  const { name, gitUrl, githubRepo, dopplerToken } = body as {
+  const { name, gitUrl, githubRepo, dopplerToken, autonomyEnabled } = body as {
     name?: string;
     gitUrl?: string;
     githubRepo?: string | null;
     dopplerToken?: string | null;
+    autonomyEnabled?: boolean;
   };
 
   const project = db.select().from(projects).where(eq(projects.id, id)).get();
@@ -42,9 +44,23 @@ export async function PATCH(
   if (gitUrl !== undefined) updates.gitUrl = gitUrl;
   if (githubRepo !== undefined) updates.githubRepo = githubRepo;
   if (dopplerToken !== undefined) updates.dopplerToken = dopplerToken;
+  // Enabling autonomy is the deliberate per-project switch (default off). It is
+  // never flipped on implicitly — only when the caller sends the flag.
+  if (autonomyEnabled !== undefined) updates.autonomyEnabled = autonomyEnabled;
 
   if (Object.keys(updates).length > 0) {
     db.update(projects).set(updates).where(eq(projects.id, id)).run();
+  }
+
+  // Enabling autonomy runs preflight now, so the owner immediately sees whether
+  // the repo is ready (and, if not, what is missing) rather than waiting for
+  // the next periodic refresh. Fail-closed: nothing gets claimed until it passes.
+  if (autonomyEnabled === true) {
+    try {
+      await refreshProjectPreflight(id);
+    } catch (err) {
+      console.error(`[projects] Preflight refresh failed for ${id}:`, err);
+    }
   }
 
   const updated = db.select().from(projects).where(eq(projects.id, id)).get();

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -45,8 +45,17 @@ export async function PATCH(
   if (githubRepo !== undefined) updates.githubRepo = githubRepo;
   if (dopplerToken !== undefined) updates.dopplerToken = dopplerToken;
   // Enabling autonomy is the deliberate per-project switch (default off). It is
-  // never flipped on implicitly — only when the caller sends the flag.
-  if (autonomyEnabled !== undefined) updates.autonomyEnabled = autonomyEnabled;
+  // never flipped on implicitly — only when the caller sends an explicit
+  // boolean, so a stray truthy string can't arm a project.
+  if (autonomyEnabled !== undefined) {
+    if (typeof autonomyEnabled !== "boolean") {
+      return NextResponse.json(
+        { error: "autonomyEnabled must be a boolean" },
+        { status: 400 }
+      );
+    }
+    updates.autonomyEnabled = autonomyEnabled;
+  }
 
   if (Object.keys(updates).length > 0) {
     db.update(projects).set(updates).where(eq(projects.id, id)).run();

--- a/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { evaluatePreflight, type PreflightChecks } from "../preflight";
+import { HUMAN_SIGNOFF_LABEL } from "../gates";
+
+// The check-to-status/reason mapping is the whole safety property here: a repo
+// is only "passing" when every requirement holds, and a failure must name what
+// is missing. computePreflight's GitHub I/O is a thin shell over this; the pure
+// function is what gets exhaustive coverage.
+
+const ALL_PASS: PreflightChecks = {
+  repoConfigured: true,
+  appInstalled: true,
+  branchProtected: true,
+  reviewerIsCollaborator: true,
+  signoffLabelExists: true,
+};
+
+describe("evaluatePreflight", () => {
+  it("passes with no reason when every check holds", () => {
+    expect(evaluatePreflight(ALL_PASS)).toEqual({ status: "passing", reason: null });
+  });
+
+  it("fails on an unconfigured repo, ignoring downstream noise", () => {
+    // A repo with nothing else set must not read as 'App missing' — the reason
+    // is the prerequisite that actually blocks the owner.
+    const result = evaluatePreflight({
+      repoConfigured: false,
+      appInstalled: false,
+      branchProtected: false,
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe("no GitHub repo configured (needs gitUrl and githubRepo)");
+  });
+
+  it("short-circuits to the App reason when the App is missing", () => {
+    // Prerequisite failure hides the checks that couldn't be gathered anyway.
+    const result = evaluatePreflight({
+      ...ALL_PASS,
+      appInstalled: false,
+      branchProtected: false,
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe("the GitHub App is not installed on the repository");
+  });
+
+  it("names a missing branch protection", () => {
+    const result = evaluatePreflight({ ...ALL_PASS, branchProtected: false });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe("no branch protection on the default branch");
+  });
+
+  it("names a reviewer that is not a collaborator", () => {
+    const result = evaluatePreflight({ ...ALL_PASS, reviewerIsCollaborator: false });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe("the reviewer account is not a collaborator");
+  });
+
+  it("names a missing human-signoff label", () => {
+    const result = evaluatePreflight({ ...ALL_PASS, signoffLabelExists: false });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
+  });
+
+  it("accumulates every independent failure into one reason", () => {
+    const result = evaluatePreflight({
+      repoConfigured: true,
+      appInstalled: true,
+      branchProtected: false,
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe(
+      `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing`
+    );
+  });
+});

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -1,0 +1,238 @@
+/**
+ * Autonomy preflight (issue #26) — the deterministic answer to "is this repo
+ * safe to run unattended against?". A project must pass every check before the
+ * reducer will claim any of its tickets (decide.ts fails closed on a
+ * never-checked or failing preflight), so this is the gate that turns the loop
+ * on for a repo.
+ *
+ * The mapping from check results to a stored status + human-readable reason is
+ * a pure function (`evaluatePreflight`) so it is table-testable with no I/O;
+ * `computePreflight` is the thin GitHub-API shell that gathers the booleans.
+ * The reason names what is missing, which is what the dashboard's "needs you"
+ * bucket and the pause log surface to the owner.
+ */
+
+import { db } from "@/db";
+import { projects } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { Octokit } from "octokit";
+import { getConfig } from "../../config";
+import { getOctokit, isGitHubConfigured } from "../../github/client";
+import { HUMAN_SIGNOFF_LABEL } from "./gates";
+
+/** Every requirement autonomy depends on, as plain booleans. */
+export interface PreflightChecks {
+  /** Project has both a gitUrl and an owner/repo githubRepo */
+  repoConfigured: boolean;
+  /** The GitHub App installation can see the repo (clone/push + API) */
+  appInstalled: boolean;
+  /** The default branch has branch protection */
+  branchProtected: boolean;
+  /** The reviewer machine account is a collaborator on the repo */
+  reviewerIsCollaborator: boolean;
+  /** The `human-signoff` label exists so gated PRs can be labelled */
+  signoffLabelExists: boolean;
+}
+
+export interface PreflightResult {
+  status: "passing" | "failing";
+  /** null when passing; names what is missing when failing */
+  reason: string | null;
+}
+
+/** How often the periodic refresh re-checks autonomy-enabled projects. */
+const PREFLIGHT_REFRESH_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Pure: map gathered checks to a stored status and a reason that names what is
+ * missing. `repoConfigured` and `appInstalled` are prerequisites — without them
+ * the remaining checks cannot even be gathered, so a failure there short-circuits
+ * to a single clear reason rather than a misleading list. The other three are
+ * independent and accumulate, so the owner fixes everything in one pass.
+ */
+export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
+  if (!checks.repoConfigured) {
+    return { status: "failing", reason: "no GitHub repo configured (needs gitUrl and githubRepo)" };
+  }
+  if (!checks.appInstalled) {
+    return { status: "failing", reason: "the GitHub App is not installed on the repository" };
+  }
+
+  const missing: string[] = [];
+  if (!checks.branchProtected) missing.push("no branch protection on the default branch");
+  if (!checks.reviewerIsCollaborator) missing.push("the reviewer account is not a collaborator");
+  if (!checks.signoffLabelExists) missing.push(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
+
+  return missing.length === 0
+    ? { status: "passing", reason: null }
+    : { status: "failing", reason: missing.join("; ") };
+}
+
+type ProjectRow = typeof projects.$inferSelect;
+
+/** Did an Octokit call fail with an HTTP 404 (as opposed to a real error)? */
+function isNotFound(err: unknown): boolean {
+  return typeof err === "object" && err !== null && (err as { status?: number }).status === 404;
+}
+
+/** Resolve the reviewer machine account's login from REVIEWER_GH_TOKEN. */
+async function reviewerLogin(): Promise<string | null> {
+  const token = getConfig().reviewerGithubToken;
+  if (!token) return null;
+  try {
+    const reviewer = new Octokit({ auth: token });
+    const { data } = await reviewer.rest.users.getAuthenticated();
+    return data.login;
+  } catch (err) {
+    console.error("[preflight] Could not resolve reviewer login from REVIEWER_GH_TOKEN:", err);
+    return null;
+  }
+}
+
+/**
+ * Gather the four autonomy checks for a project via the GitHub API. Every
+ * network failure resolves a check to `false` (fail closed) so an unreachable
+ * or under-permissioned repo never reads as ready. Downstream checks are only
+ * attempted once the App is confirmed installed, since they all need the
+ * installation token.
+ */
+export async function computePreflight(project: ProjectRow): Promise<PreflightResult> {
+  const repoConfigured = !!project.gitUrl && !!project.githubRepo;
+  const [owner, repo] = (project.githubRepo ?? "").split("/");
+  if (!repoConfigured || !owner || !repo) {
+    return evaluatePreflight({
+      repoConfigured: false,
+      appInstalled: false,
+      branchProtected: false,
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+  }
+
+  const octokit = await getOctokit();
+
+  // App installed — a repos.get through the installation token both proves the
+  // App can see the repo and yields the default branch for the next check.
+  let appInstalled = false;
+  let defaultBranch = "main";
+  try {
+    const { data } = await octokit.rest.repos.get({ owner, repo });
+    appInstalled = true;
+    defaultBranch = data.default_branch;
+  } catch (err) {
+    if (!isNotFound(err)) {
+      console.error(`[preflight] repos.get failed for ${owner}/${repo}:`, err);
+    }
+  }
+
+  if (!appInstalled) {
+    return evaluatePreflight({
+      repoConfigured: true,
+      appInstalled: false,
+      branchProtected: false,
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+  }
+
+  const [branchProtected, reviewerIsCollaborator, signoffLabelExists] = await Promise.all([
+    octokit.rest.repos
+      .getBranchProtection({ owner, repo, branch: defaultBranch })
+      .then(() => true)
+      .catch((err) => {
+        if (!isNotFound(err)) {
+          console.error(`[preflight] getBranchProtection failed for ${owner}/${repo}:`, err);
+        }
+        return false;
+      }),
+    reviewerLogin().then((login) =>
+      login
+        ? octokit.rest.repos
+            .checkCollaborator({ owner, repo, username: login })
+            .then(() => true)
+            .catch(() => false)
+        : false
+    ),
+    octokit.rest.issues
+      .getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
+      .then(() => true)
+      .catch(() => false),
+  ]);
+
+  return evaluatePreflight({
+    repoConfigured: true,
+    appInstalled: true,
+    branchProtected,
+    reviewerIsCollaborator,
+    signoffLabelExists,
+  });
+}
+
+/** Compute a project's preflight and persist the status + reason. */
+async function storePreflight(project: ProjectRow): Promise<PreflightResult> {
+  const result = await computePreflight(project);
+  db.update(projects)
+    .set({ preflightStatus: result.status, preflightReason: result.reason })
+    .where(eq(projects.id, project.id))
+    .run();
+  return result;
+}
+
+/**
+ * Compute and store a single project's preflight. Returns the result, or null
+ * if GitHub is not configured (nothing to check against) or the project is
+ * gone. Callers use the return value to surface the outcome immediately (the
+ * autonomy toggle) or ignore it (the periodic refresh, which only writes).
+ */
+export async function refreshProjectPreflight(projectId: string): Promise<PreflightResult | null> {
+  if (!isGitHubConfigured()) return null;
+  const project = db.select().from(projects).where(eq(projects.id, projectId)).get();
+  if (!project) return null;
+  return storePreflight(project);
+}
+
+/**
+ * Refresh preflight for every autonomy-enabled project. Dormant projects are
+ * skipped — the reducer and the dashboard only care about preflight where
+ * autonomy is on, so there is no point spending API calls elsewhere.
+ */
+export async function refreshAllPreflights(): Promise<void> {
+  if (!isGitHubConfigured()) return;
+  const rows = db.select().from(projects).where(eq(projects.autonomyEnabled, true)).all();
+  for (const project of rows) {
+    try {
+      await storePreflight(project);
+    } catch (err) {
+      console.error(`[preflight] Refresh failed for ${project.githubRepo}:`, err);
+    }
+  }
+}
+
+let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the periodic preflight refresh: one run now, then every few minutes.
+ * Keeps stored status honest as repo settings drift (e.g. branch protection
+ * removed) without waiting for the next toggle.
+ */
+export function startPreflightRefresh(): void {
+  if (refreshInterval) return;
+  if (!isGitHubConfigured()) return;
+  console.log(
+    `[preflight] Refreshing enabled projects every ${PREFLIGHT_REFRESH_INTERVAL_MS / 60_000}m`
+  );
+  void refreshAllPreflights().catch((err) =>
+    console.error("[preflight] Initial refresh failed:", err)
+  );
+  refreshInterval = setInterval(
+    () => void refreshAllPreflights().catch((err) => console.error("[preflight] Refresh failed:", err)),
+    PREFLIGHT_REFRESH_INTERVAL_MS
+  );
+}
+
+export function stopPreflightRefresh(): void {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+}

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -75,6 +75,24 @@ function isNotFound(err: unknown): boolean {
   return typeof err === "object" && err !== null && (err as { status?: number }).status === 404;
 }
 
+/**
+ * Run one boolean check against the GitHub API: a 404 means the thing genuinely
+ * isn't there (check false); any other error is a real failure worth logging,
+ * and still resolves false so preflight fails closed rather than passing on a
+ * transient blip.
+ */
+async function apiCheck(label: string, fn: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await fn();
+    return true;
+  } catch (err) {
+    if (!isNotFound(err)) {
+      console.error(`[preflight] ${label} failed:`, err);
+    }
+    return false;
+  }
+}
+
 /** Resolve the reviewer machine account's login from REVIEWER_GH_TOKEN. */
 async function reviewerLogin(): Promise<string | null> {
   const token = getConfig().reviewerGithubToken;
@@ -87,6 +105,19 @@ async function reviewerLogin(): Promise<string | null> {
     console.error("[preflight] Could not resolve reviewer login from REVIEWER_GH_TOKEN:", err);
     return null;
   }
+}
+
+/** Is the reviewer machine account a collaborator on the repo? */
+async function isReviewerCollaborator(
+  octokit: Awaited<ReturnType<typeof getOctokit>>,
+  owner: string,
+  repo: string
+): Promise<boolean> {
+  const login = await reviewerLogin();
+  if (!login) return false;
+  return apiCheck(`checkCollaborator ${owner}/${repo}`, () =>
+    octokit.rest.repos.checkCollaborator({ owner, repo, username: login })
+  );
 }
 
 /**
@@ -136,27 +167,13 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
   }
 
   const [branchProtected, reviewerIsCollaborator, signoffLabelExists] = await Promise.all([
-    octokit.rest.repos
-      .getBranchProtection({ owner, repo, branch: defaultBranch })
-      .then(() => true)
-      .catch((err) => {
-        if (!isNotFound(err)) {
-          console.error(`[preflight] getBranchProtection failed for ${owner}/${repo}:`, err);
-        }
-        return false;
-      }),
-    reviewerLogin().then((login) =>
-      login
-        ? octokit.rest.repos
-            .checkCollaborator({ owner, repo, username: login })
-            .then(() => true)
-            .catch(() => false)
-        : false
+    apiCheck(`getBranchProtection ${owner}/${repo}`, () =>
+      octokit.rest.repos.getBranchProtection({ owner, repo, branch: defaultBranch })
     ),
-    octokit.rest.issues
-      .getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
-      .then(() => true)
-      .catch(() => false),
+    isReviewerCollaborator(octokit, owner, repo),
+    apiCheck(`getLabel ${owner}/${repo}`, () =>
+      octokit.rest.issues.getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
+    ),
   ]);
 
   return evaluatePreflight({

--- a/src/lib/orchestrator/init.ts
+++ b/src/lib/orchestrator/init.ts
@@ -6,6 +6,7 @@ import { getDocker, isDockerAvailable } from "../docker/client";
 import { startQueue } from "./queue";
 import { getCapacity } from "./capacity";
 import { startAutonomySweeps } from "./autonomy/sweep";
+import { startPreflightRefresh } from "./autonomy/preflight";
 import { startDailyDigest } from "./digest-schedule";
 import { getConfig } from "../config";
 import { isGitHubConfigured } from "../github/client";
@@ -151,6 +152,13 @@ export async function initOrchestrator(): Promise<void> {
         "[autonomy] Autonomous pickup disabled" +
           (getConfig().autonomyEnabled ? " (GitHub App not configured)" : " (AUTONOMY_ENABLED != true)")
       );
+    }
+
+    // Keep preflight fresh for autonomy-enabled projects independently of the
+    // global kill switch, so the dashboard names what's missing while pilots
+    // are being set up (and catches drift like branch protection being removed).
+    if (isGitHubConfigured()) {
+      startPreflightRefresh();
     }
 
     // Run the reaper every 5 minutes to catch any leaked containers


### PR DESCRIPTION
Closes #26

Turns the Phase 5 autonomous loop on — deliberately — and writes down how to live with it.

## Why there is code here, not just a runbook

Before this PR, Phase 5 autonomy was **inert**: the reducer fails closed unless a project's `preflightStatus === "passing"` (`decide.ts`), but nothing in the codebase ever *computed* or *wrote* `preflightStatus`/`preflightReason`, and the projects `PATCH` route could not set `autonomyEnabled`. So no ticket could ever be claimed and no project could be enabled except by a raw DB write. AC1 ("preflight passes … naming what is missing") and AC2 ("autonomy is enabled per project deliberately") are unsatisfiable without exactly these two mechanisms, so the enablement ticket is their home.

## What's included

- **Preflight computation** (`src/lib/orchestrator/autonomy/preflight.ts`): a pure `evaluatePreflight` (check booleans → `passing`/`failing` + a reason that *names what's missing*) plus a thin, fail-closed GitHub-API shell that checks: App installed, default-branch protection, reviewer-is-collaborator, and the `human-signoff` label exists. Refreshed **on the deliberate toggle** and **periodically** (5 min, for enabled projects) so drift is caught.
- **Deliberate per-project autonomy toggle**: `PATCH /api/projects/[id]` accepts `autonomyEnabled` (rejects non-booleans; default stays off). Enabling runs preflight synchronously so readiness — and any missing piece — surfaces immediately.
- **The operator runbook** (`docs/runbook.md`): the human-only `ready-for-agent` launch button; turning it on (preflight the pilots, enable per project, the global switch); and the six actions — arm a ticket, watch the fleet, pause pickup (global + per-project), answer a blocked agent from Discord, find `human-signoff` PRs, cancel a run to free a slot. Names the pilots (interlude, lemons, last-person-standing) and interlude's UI-upgrade backlog as the first workload.
- Surfaces the previously-undocumented Phase 5 env vars in `.env.example`; links the runbook from `README.md` and `CLAUDE.md`.

## Which acceptance criteria are operational (owner-executed on the VPS)

The mechanism + runbook are delivered here. Three ACs are live-only end-states that need prod GitHub App + reviewer credentials and can't be executed from a worktree — the runbook drives them:

- **AC1** actually *passing* preflight against the three real repos → owner runs the enable step per repo and reads the reason on any failure.
- **AC2 / AC4** enabling autonomy on the live projects and arming the real UI-upgrade backlog → owner action, documented.

## Validation

- 363 tests pass (7 new, table-driven, for the pure `evaluatePreflight` mapping + short-circuit); `tsc --noEmit` clean; ESLint clean on all changed files.
- Self-reviewed with `/code-review` (origin/main, spec = #26). Spec axis: all five ACs satisfied, nothing missing, no over-reach; every runbook claim cross-checked against the code. Standards axis: no hard violations — acted on its judgement calls (uniform 404-vs-error logging via a shared `apiCheck`, extracted `isReviewerCollaborator`, boolean validation on the toggle).

## Note for the reviewer

This PR touches `src/lib/orchestrator/autonomy/**`, which trips the repo's `autonomy-control` review gate — so it must get `human-signoff` and cannot auto-merge. That is correct per policy (the runbook documents this very gate); flagging so arming isn't expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
