### PR TITLE
Narrow the agent container's host Claude directory mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
-# Auth — one of these is required:
-# Option 1 (preferred): long-lived token from `claude setup-token`, injected into
-#   agent containers at exec. Production stores it in Doppler (interlude/prd).
+# Agent Claude auth — one of these is required. Both reach the agent
+# container as an exec-scoped env var; nothing is mounted from the host.
+# Option 1 (preferred): long-lived token from `claude setup-token`, injected
+#   into agent containers at exec. Production stores it in Doppler (interlude/prd).
 # CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
-# Option 2 (legacy fallback): mounted credentials file — auto-detected from
-#   ~/.claude/.credentials.json, or see CLAUDE_CREDENTIALS_PATH below
-# Option 3: ANTHROPIC_API_KEY=sk-ant-...
+# Option 2: ANTHROPIC_API_KEY=sk-ant-...
+# (The legacy mounted ~/.claude credentials file was removed in issue #28.)
 
 # Optional
 GIT_USER_NAME=Interlude Agent
@@ -33,7 +33,6 @@ MAX_BUDGET_USD=20.00
 #   same config for the reverse proxy. Never hand-set DOMAIN in the VPS .env
 #   (issue #25). Set it here only for local (non-Doppler) subdomain testing.
 # DOMAIN=interlude.dev
-# CLAUDE_CREDENTIALS_PATH=/home/deploy/.claude/.credentials.json  # legacy fallback: host path mounted into agent containers (not the app container); removed once CLAUDE_CODE_OAUTH_TOKEN is verified on the VPS (#48)
 
 # GitHub App — REQUIRED for git (clone/push) and for issue sync + PR creation.
 # The agent authenticates git using a short-lived App installation token; there is no PAT to rotate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Interlude is a self-hosted, agent-first development platform. You dispatch tasks
 - GitHub App is REQUIRED for git auth — agent containers clone/push using short-lived App installation tokens (no PAT). Issue sync + PR features still degrade gracefully if webhook/installation are partially configured.
 - Reviewer identity: the review pass returns a structured verdict and the **orchestrator** posts the PR review using `REVIEWER_GH_TOKEN`; the PAT never enters an agent container (issue #17). Its canonical home is Doppler `platform/prd`, and it is **mirrored** into `interlude/prd` because the orchestrator's service token is scoped to one config — **rotation must update both places**.
 - Git credential helper in agent containers reads a per-exec `GIT_AUTH_TOKEN` (minted fresh from the App); no token is persisted in `.git/config`.
+- Agent containers get **no host bind mount** (issue #28): everything they need is granted deliberately and exec-scoped — the `interlude` Docker network, a fresh `GIT_AUTH_TOKEN`, and Claude auth via `CLAUDE_CODE_OAUTH_TOKEN`. There is no host `~/.claude` mount, so a container cannot read or write the host user's Claude config/history/credentials, and the image's own `/home/node/.claude` (plugins, etc.) survives unshadowed. The rationale lives at the mount site in `src/lib/docker/container-manager.ts` — read it before adding any `Bind`.
 - Webhook endpoint: `POST /api/webhooks/github`
 - GitHub library: `src/lib/github/` (client, webhooks, issues, pull-requests)
 - Discord bot (optional; degrades gracefully when unconfigured) maps each project to one channel via `!link <project>` / `!unlink`; new channel messages create tasks, replies deliver follow-ups
@@ -64,7 +65,7 @@ pnpm lint         # Run ESLint
 Local dev runs the orchestrator via `doppler run -- pnpm dev` — orchestrator secrets live in the Doppler `interlude/dev` config, not a `.env`. Two things Compose provides on the VPS that you must set up by hand locally:
 
 - **Agent-container network:** run `docker network create interlude` once. Agent containers attach to the `interlude` network, which Compose creates on the VPS but `pnpm dev` does not — without it, task runs fail with "network interlude not found".
-- **Claude auth for agent containers:** set `CLAUDE_CODE_OAUTH_TOKEN` (in `interlude/dev`) to a token minted with `claude setup-token` — otherwise the agent errors with "Not logged in". The legacy fallback still works while both mechanisms exist: set `CLAUDE_CREDENTIALS_PATH` to your host `~/.claude/.credentials.json` to mount credentials into agent containers instead (slated for removal once the token path is verified on the VPS — #48).
+- **Claude auth for agent containers:** set `CLAUDE_CODE_OAUTH_TOKEN` (in `interlude/dev`) to a token minted with `claude setup-token` — otherwise the agent errors with "Not logged in". This env token (or `ANTHROPIC_API_KEY`) is the only way Claude auth reaches an agent container; the legacy `CLAUDE_CREDENTIALS_PATH` credentials-file mount was removed in issue #28 (see the "no host mount" convention below).
 
 ## Current Status: Phase 4 done and verified on VPS; Phase 5 next
 

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -10,11 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g @anthropic-ai/claude-code
 
-# Use the existing node user (uid 1000) which matches the deploy user on the host,
-# so mounted credential files retain correct ownership after token refresh
+# Run as the existing node user (uid 1000), which also matches the deploy
+# user on the host — kept aligned so any future host bind mount stays
+# uid-consistent (issue #28 removed the last one: the host ~/.claude mount).
 RUN mkdir -p /workspace && chown node:node /workspace
 
-# Pre-accept permissions bypass for headless operation
+# Image-owned Claude directory. Nothing is mounted over it now (#28), so
+# anything installed here (e.g. plugins) survives at runtime. Pre-accept the
+# permissions bypass for headless operation.
 RUN mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
 RUN echo '{"bypassPermissionsModeAccepted": true}' > /home/node/.claude.json && chown node:node /home/node/.claude.json
 

--- a/docs/plans/2026-03-12-vps-deployment.md
+++ b/docs/plans/2026-03-12-vps-deployment.md
@@ -324,6 +324,8 @@ Notes on the design:
 - Docker socket mounted for agent container management via dockerode
 - `HOSTNAME=0.0.0.0` ensures Next.js listens on all interfaces inside the container
 
+> **Superseded by #28 (2026-08-03).** The `CLAUDE_CREDENTIALS_PATH` mount described in this section no longer exists. Agent-container Claude auth is now the exec-scoped `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) — see `src/lib/docker/container-manager.ts` and CLAUDE.md's "no host bind mount" convention. The rest of this section is kept as a point-in-time record.
+
 **Critical: `CLAUDE_CREDENTIALS_PATH` must be set to the host path in `.env` on the VPS.** Here's why:
 1. Compose mounts the host file into the app container at `/home/node/.claude/.credentials.json`
 2. `config.ts` reads `CLAUDE_CREDENTIALS_PATH` from env — this value becomes `config.claudeCredentialsPath`

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,16 +1,10 @@
-import path from "path";
-import fs from "fs";
 import { DEFAULT_ATTEMPT_BUDGET_USD } from "./orchestrator/autonomy/budgets";
 
 export interface AppConfig {
-  /** Anthropic API key (optional if using OAuth credentials) */
+  /** Anthropic API key (optional if using CLAUDE_CODE_OAUTH_TOKEN) */
   anthropicApiKey: string | null;
-  /** Long-lived OAuth token from `claude setup-token`, injected into agent containers at exec (preferred over the mounted credentials file) */
+  /** Long-lived OAuth token from `claude setup-token`, injected into agent containers at exec — the sole subscription-auth path (#28) */
   claudeCodeOauthToken: string | null;
-  /** Path to Claude OAuth credentials file inside this container */
-  claudeCredentialsPath: string | null;
-  /** Host path for mounting credentials into agent containers */
-  claudeCredentialsHostPath: string | null;
   gitUserName: string;
   gitUserEmail: string;
   keepContainers: boolean;
@@ -70,41 +64,20 @@ export function getConfig(): AppConfig {
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY ?? null;
   const claudeCodeOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN ?? null;
 
-  // Find Claude credentials file — check the container mount path first,
-  // then fall back to CLAUDE_CREDENTIALS_PATH or $HOME default
-  const candidatePaths = [
-    "/home/node/.claude/.credentials.json",
-    process.env.CLAUDE_CREDENTIALS_PATH,
-    path.join(process.env.HOME ?? "/root", ".claude", ".credentials.json"),
-  ].filter(Boolean) as string[];
-
-  const credentialsPath = candidatePaths.find((p) => fs.existsSync(p)) ?? candidatePaths[0];
-
-  const claudeCredentialsPath =
-    fs.existsSync(credentialsPath) ? credentialsPath : null;
-
-  if (
-    !anthropicApiKey &&
-    !claudeCodeOauthToken &&
-    !claudeCredentialsPath &&
-    !process.env.CLAUDE_CREDENTIALS_PATH
-  ) {
+  // Agent-container Claude auth is exec-scoped: CLAUDE_CODE_OAUTH_TOKEN (from
+  // `claude setup-token`), with ANTHROPIC_API_KEY as an alternative. The old
+  // mounted-credentials-file path was retired with the host `~/.claude` mount
+  // (#28), so there is nothing to detect on disk here.
+  if (!anthropicApiKey && !claudeCodeOauthToken) {
     console.warn(
-      "Warning: No auth configured. Set CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`), " +
-        "ANTHROPIC_API_KEY, CLAUDE_CREDENTIALS_PATH, or ensure ~/.claude/.credentials.json exists."
+      "Warning: No agent Claude auth configured. Set CLAUDE_CODE_OAUTH_TOKEN " +
+        "(from `claude setup-token`) or ANTHROPIC_API_KEY."
     );
   }
-
-  // The host path is used to mount credentials into agent containers.
-  // It comes directly from the env var — the app container itself may not
-  // be able to see the file (it's a host path, not a container path).
-  const claudeCredentialsHostPath = process.env.CLAUDE_CREDENTIALS_PATH ?? null;
 
   _config = {
     anthropicApiKey,
     claudeCodeOauthToken,
-    claudeCredentialsPath,
-    claudeCredentialsHostPath,
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",
     gitUserEmail: process.env.GIT_USER_EMAIL ?? "agent@interlude.dev",
     keepContainers: process.env.KEEP_CONTAINERS === "true",

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -1,9 +1,43 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   buildSetupScript,
   buildPushScript,
   buildTurnEnv,
+  createWorkspaceContainer,
 } from "../container-manager";
+
+// Capture the options passed to docker.createContainer so we can assert on the
+// HostConfig the orchestrator asks Docker for.
+const { createContainerSpy } = vi.hoisted(() => ({
+  createContainerSpy: vi.fn(async () => ({ id: "container-under-test" })),
+}));
+
+vi.mock("@/lib/docker/client", () => ({
+  getDocker: () => ({ createContainer: createContainerSpy }),
+}));
+vi.mock("@/lib/docker/image-builder", () => ({
+  ensureImage: vi.fn(async () => {}),
+  getImageName: () => "interlude-agent:test",
+}));
+vi.mock("@/lib/orchestrator/capacity", () => ({
+  getCapacity: vi.fn(async () => ({
+    slots: 2,
+    perAgentMemory: 1200 * 1024 * 1024,
+    cpuQuota: 1_000_000_000,
+  })),
+}));
+vi.mock("@/lib/github/client", () => ({
+  getInstallationToken: vi.fn(async () => "ghs_installation"),
+}));
+vi.mock("@/lib/config", () => ({
+  PLATFORM_REPO_URL: "https://github.com/lennons301/platform.git",
+  getConfig: () => ({
+    anthropicApiKey: null,
+    claudeCodeOauthToken: "sk-ant-oat01-test",
+    gitUserName: "Interlude Agent",
+    gitUserEmail: "agent@interlude.dev",
+  }),
+}));
 
 describe("buildSetupScript", () => {
   const script = buildSetupScript("https://github.com/lennons301/platform.git");
@@ -80,5 +114,28 @@ describe("buildPushScript", () => {
   it("does not embed any token", () => {
     expect(script).not.toContain("GIT_TOKEN");
     expect(script).not.toContain("GIT_AUTH_TOKEN");
+  });
+});
+
+describe("createWorkspaceContainer", () => {
+  beforeEach(() => {
+    createContainerSpy.mockClear();
+  });
+
+  // Regression guard for issue #28: agent containers must not bind-mount
+  // anything from the host — the old rw `~/.claude` mount is gone and must
+  // stay gone. Auth reaches the container only via exec-scoped env tokens.
+  it("grants no host bind mount", async () => {
+    await createWorkspaceContainer({
+      taskId: "01J000000000000000000TASK",
+      gitUrl: "https://github.com/lennons301/interlude.git",
+      branch: "agent/issue-28",
+    });
+
+    expect(createContainerSpy).toHaveBeenCalledTimes(1);
+    const opts = createContainerSpy.mock.calls[0][0] as {
+      HostConfig?: { Binds?: unknown };
+    };
+    expect(opts.HostConfig?.Binds).toBeUndefined();
   });
 });

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -30,8 +30,9 @@ export function buildSetupScript(platformRepoUrl: string, checkoutExisting = fal
 /**
  * Env for a Claude turn exec. Auth is exec-scoped, mirroring GIT_AUTH_TOKEN:
  * the long-lived setup-token never lands in the container's persistent env.
- * The CLI prefers CLAUDE_CODE_OAUTH_TOKEN over the mounted credentials file,
- * which stays as a fallback until the token path is verified on the VPS (#48).
+ * CLAUDE_CODE_OAUTH_TOKEN is the sole subscription-auth path — the mounted
+ * host credentials file it once fell back to was removed with the host
+ * `~/.claude` mount (#28); ANTHROPIC_API_KEY remains an alternative.
  */
 export function buildTurnEnv(options: {
   prompt: string;
@@ -109,15 +110,17 @@ export async function createWorkspaceContainer(
     env.push(`DOPPLER_TOKEN=${options.dopplerToken}`);
   }
 
-  const binds: string[] = [];
-  if (config.claudeCredentialsHostPath) {
-    const hostClaudeDir = config.claudeCredentialsHostPath.replace(
-      /\/.credentials\.json$/,
-      ""
-    );
-    binds.push(`${hostClaudeDir}:/home/node/.claude:rw`);
-  }
-
+  // What an agent container is granted from the host — deliberately, and
+  // nothing else (issue #28):
+  //   - the `interlude` Docker network (for preview routing), and
+  //   - a fresh, short-lived GitHub App token per exec (GIT_AUTH_TOKEN).
+  // Claude auth arrives the same exec-scoped way, as CLAUDE_CODE_OAUTH_TOKEN
+  // in buildTurnEnv — it is the VPS-verified live path (#48). There is NO
+  // bind mount: the container never sees the host's `~/.claude`, so it cannot
+  // read or write the host user's Claude config, history, project state or
+  // credentials, and whatever the image installs under /home/node/.claude
+  // (e.g. plugins) is no longer shadowed at runtime. Before adding any Bind
+  // here, weigh it against that: a mount is host reach that outlives the run.
   const containerName = `interlude-task-${options.taskId}-${Date.now()}`;
   // DNS-safe subdomain derived from task ID (last 8 chars of ULID, lowercased)
   const previewSubdomain = `task-${options.taskId.slice(-8).toLowerCase()}`;
@@ -132,7 +135,6 @@ export async function createWorkspaceContainer(
     WorkingDir: "/workspace",
     HostConfig: {
       NetworkMode: "interlude",
-      Binds: binds.length > 0 ? binds : undefined,
       // Hard caps: a runaway agent fails its own task, never the platform.
       // MemorySwap = Memory disables swap, so the cap bites immediately.
       Memory: capacity.perAgentMemory,

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -4,11 +4,11 @@
  * A `workflow:<skill>` label is honoured by injecting the skill's actual
  * content into the pass prompt — not by merely naming it. The content is
  * vendored in this repo under docs/agents/workflows/ and read by the
- * orchestrator, never from anything an agent container can write to: the
- * host `~/.claude` mount is rw inside every agent container, so sourcing
- * executable instructions from there would let one run poison the next.
- * A selection that cannot be resolved throws — the run fails loudly rather
- * than silently falling back to the agent's judgement.
+ * orchestrator, never from an agent container's filesystem: that filesystem
+ * is ephemeral and per-run, so sourcing executable instructions from it
+ * would let one run poison the next. A selection that cannot be resolved
+ * throws — the run fails loudly rather than silently falling back to the
+ * agent's judgement.
  */
 
 import path from "path";


### PR DESCRIPTION
Closes #28

## What changed

Agent containers no longer bind-mount the host's `~/.claude` directory. Every agent container previously mounted the **entire** host Claude directory read-write over `/home/node/.claude`, giving unattended runs write access to the host user's Claude config, history, project state and credentials file — and shadowing anything the image installs there.

Now that `CLAUDE_CODE_OAUTH_TOKEN` is the VPS-verified live auth path (#48), the credentials-file mount it fell back to is simply removed (per this ticket's 2026-08-02 comment and #48's deferred cleanup). Claude auth reaches the container by the narrowest means — an exec-scoped env token minted fresh each turn — with no host directory reachable at all.

- `container-manager.ts`: dropped the `binds`/`HostConfig.Binds` mount; added a rationale comment at the mount site.
- `config.ts`: removed the now-dead `claudeCredentialsHostPath` / `claudeCredentialsPath` fields, the `CLAUDE_CREDENTIALS_PATH` reading, and the on-disk credential-file detection ladder. The auth warning now checks `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`.
- Docs: CLAUDE.md gains a "no host bind mount" convention; `.env.example`, `Dockerfile.agent` and `workflow.ts` had stale rw-mount rationales refreshed; the historical VPS-deploy plan section is marked superseded.
- Test: a regression guard asserting `createWorkspaceContainer` requests a `HostConfig` with no `Binds`.

## Acceptance criteria

- [x] **No write to host Claude config/history/state** — no mount exists; the container cannot reach `~/.claude`.
- [x] **Credentials by the narrowest means, across refresh, uid-1000 preserved** — auth is the exec-scoped `CLAUDE_CODE_OAUTH_TOKEN`; there is no file to keep uid-owned across a refresh, and `Dockerfile.agent` documents the uid-1000 alignment for any future mount.
- [x] **Image-installed content survives** — nothing mounts over `/home/node/.claude`, so image content (plugins, etc.) is no longer shadowed.
- [ ] **Interactive + autonomous both authenticate on the VPS** — this criterion is **not satisfiable from a code diff**; it needs a live VPS run. The change rests on `CLAUDE_CODE_OAUTH_TOKEN` already being VPS-verified by #48, so the risk is low, but an operator should confirm one interactive task and one autonomous run authenticate and complete before this is considered fully done.
- [x] **Written down where the next person will see it** — rationale at the mount site in `container-manager.ts`, plus the CLAUDE.md convention and `.env.example`.

## Self-review (`/code-review` vs `origin/main`, issue #28 as spec)

Both axes came back clean — no hard standards violations, no correctness defects, all code-satisfiable ACs met. I acted on the two actionable findings: added the no-bind-mount regression test (Spec axis flagged the gap) and the superseded note on the historical VPS plan (Standards axis flagged stale guidance). The remaining historical mentions of `CLAUDE_CREDENTIALS_PATH` in dated plan/spec docs are left as point-in-time records; the live operator runbook is clean.

Validation: `pnpm test` → 364 passing; `pnpm lint` clean on all changed files (16 pre-existing repo-wide errors are unrelated and untouched); `tsc --noEmit` clean.
