### PR TITLE
Fleet dashboard: terminal-status tasks can render as running sessions (stale container_status)

### DIFF
--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -710,6 +710,44 @@ describe("buildFleetView — running", () => {
     ]);
   });
 
+  it("picks a run's live pass as its face, ignoring a finished pass with a stale container_status", () => {
+    // Issue #46, sibling path: currentTaskOf must not surface a terminal task
+    // as a run's current face just because it still carries container_status.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [makeRun({ id: "r1", projectId: "p1", status: "reviewing" })],
+        tasks: [
+          // Ordered first, so a naive `.find` would return it.
+          makeTask({
+            id: "t-stale",
+            projectId: "p1",
+            runId: "r1",
+            kind: "implement",
+            title: "Old finished pass",
+            status: "completed",
+            containerStatus: "idle",
+            createdAt: new Date(2026, 7, 1, 8, 0, 0),
+          }),
+          makeTask({
+            id: "t-live",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Live review pass",
+            status: "running",
+            containerStatus: "running",
+            createdAt: TODAY_9AM,
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toHaveLength(1);
+    expect(view.running[0].taskId).toBe("t-live");
+    expect(view.running[0].title).toBe("Live review pass");
+  });
+
   it("excludes finished runs and containerless interactive tasks from running", () => {
     const view = buildFleetView(
       baseRows({

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -172,6 +172,29 @@ describe("buildFleetView — slots", () => {
     expect(view.slots.used).toBe(0);
   });
 
+  it("never counts a terminal-status task as a slot occupant, even with a stale container_status", () => {
+    // Issue #46: a task cancelled months ago still carried
+    // container_status='idle' and rendered as a running interactive session.
+    // Terminal status wins over a stale container column.
+    for (const status of ["cancelled", "completed", "failed"] as const) {
+      const view = buildFleetView(
+        baseRows({
+          projects: [makeProject({ id: "p1", name: "interlude" })],
+          tasks: [
+            makeTask({ projectId: "p1", status, containerStatus: "idle" }),
+          ],
+        })
+      );
+
+      expect(view.slots.used).toBe(0);
+      expect(view.slots.segments).toEqual([
+        { occupant: "free" },
+        { occupant: "free" },
+      ]);
+      expect(view.running).toEqual([]);
+    }
+  });
+
   it("reports saturation with what it is attributable to", () => {
     const view = buildFleetView(
       baseRows({

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -190,6 +190,14 @@ function issueUrl(githubIssue: string): string | null {
 const RECENT_WINDOW_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** A task in one of these statuses is finished — it can hold no slot and
+ * renders as no active session, regardless of a stale container_status. */
+const TERMINAL_TASK_STATUSES = new Set<FleetTaskRow["status"]>([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
 export function buildFleetView(rows: FleetRows): FleetView {
   const projectById = new Map(rows.projects.map((p) => [p.id, p]));
   const runById = new Map(rows.runs.map((r) => [r.id, r]));
@@ -201,8 +209,14 @@ export function buildFleetView(rows: FleetRows): FleetView {
   // container status. A parked autonomous container (an implement pass
   // idling while its PR is reviewed, issue #17) stays alive but runs no
   // agent and holds no slot; an idle interactive session does hold its slot.
+  //
+  // A task in a terminal status is never an active session, whatever
+  // container_status says: cancellation and completion should null the column,
+  // but a stale value (issue #46: a task cancelled months ago still carrying
+  // container_status='idle') must not resurrect it as a running session here.
   const occupants = rows.tasks.filter(
     (t) =>
+      !TERMINAL_TASK_STATUSES.has(t.status) &&
       t.containerStatus !== null &&
       !(t.kind !== "interactive" && t.containerStatus === "idle")
   );

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -247,13 +247,18 @@ export function buildFleetView(rows: FleetRows): FleetView {
   const capPaused = todayUsd >= rows.dailyCapUsd;
 
   // A run's face in the UI is its latest task — the live container if one
-  // exists, otherwise the most recently created pass.
+  // exists, otherwise the most recently created pass. A finished pass with a
+  // stale container_status is not "live" (issue #46), so the same terminal
+  // guard applies here as in the occupants filter.
   const tasksOfRun = (runId: string) =>
     rows.tasks.filter((t) => t.runId === runId);
   const currentTaskOf = (runId: string) => {
     const owned = tasksOfRun(runId);
     return (
-      owned.find((t) => t.containerStatus !== null) ??
+      owned.find(
+        (t) =>
+          t.containerStatus !== null && !TERMINAL_TASK_STATUSES.has(t.status)
+      ) ??
       owned.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
       null
     );

--- a/src/lib/orchestrator/init.ts
+++ b/src/lib/orchestrator/init.ts
@@ -58,9 +58,11 @@ async function markInterruptedRuns(): Promise<void> {
 
     // A queued task of an interrupted run (say, its review pass) must not
     // start against an abandoned attempt — the re-claim queues its own.
+    // Clear container_status alongside the terminal status so the row can
+    // never later read as a live session (issue #46).
     await db
       .update(tasks)
-      .set({ status: "cancelled", updatedAt: now })
+      .set({ status: "cancelled", containerStatus: null, updatedAt: now })
       .where(and(eq(tasks.runId, run.id), eq(tasks.status, "queued")));
 
     console.log(


### PR DESCRIPTION
Closes #46

## What happened

On the dashboard's first production viewing a task **cancelled on 2026-03-18** appeared as a running interactive session — 136 days stale. The task row had `status='cancelled'` but `container_status='idle'`: `buildFleetView`'s occupant filter keyed only off `container_status` and never consulted the task's own status.

## Fix — both sides

**1. Read model (the durable defense, the pure table-testable seam).**
- `buildFleetView` now excludes any task in a terminal status (`completed` / `cancelled` / `failed`) from `occupants`, regardless of `container_status`. This is the single seam feeding slot accounting (`slots.used` / `segments` / `saturated`) and the interactive session cards, and it is shared by the dashboard **and** the daily digest, so both are covered.
- New test asserts a cancelled/completed/failed task carrying a stale `container_status='idle'` counts as no occupant and no running card — it fails without the guard across all three statuses.

**2. Lifecycle — clear `container_status` on terminal transitions.**
- The runtime cancel / complete / fail paths (`cancelTask`, `teardownTaskContainer`, the fail paths in `turn-manager.ts`) **already** null `container_status`, so the class of bug can no longer be produced at runtime; the stale prod row is a March-era legacy artifact.
- The one terminal-status write that didn't clear the column was the restart-recovery sweep cancelling a run's *queued* tasks (`init.ts`). Queued tasks carry no container, so this is a provable no-op today — I made it consistent anyway so every terminal-status write nulls the column, but the real protection here comes from part 1 and the pre-existing runtime paths, not this line.

## Self-review (`/code-review` against `origin/main`)

Ran the code-review skill with issue #46 as the spec. It raised two findings; I acted on the substantive one:
- **`currentTaskOf` (acted on):** the untouched sibling of the fixed filter — it picked a run's "current face" by non-null `container_status` alone, so a finished pass with a stale `container_status` could surface as the run's running-card title / recent-item / blocked-question link instead of the live pass. Same stale-data lie on a different surface. Applied the terminal guard there too, with a test that a live review pass wins over an earlier completed pass holding `container_status='idle'`.
- **`init.ts` no-op (acknowledged, not removed):** the review correctly noted the added `containerStatus: null` is a no-op for queued tasks. Kept as a stated uniform invariant (every terminal-status write nulls the column) and called out honestly above — the runtime paths are what actually clear the column.

## Validation

- `pnpm test` — 365 passed (2 new fleet-view tests)
- `pnpm lint` — clean on all changed files (main carries pre-existing lint errors unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)