### PR TITLE
Serialise deploys with a concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Serialise deploys: each push to main triggers its own run, and two concurrent
+# `docker compose down → build → up` sequences on the 2 vCPU / 4 GB VPS starve
+# the box (incident 2026-08-01, issue #40 — prod and even sshd stopped
+# answering). Queue rather than cancel: killing a mid-flight deploy could
+# strand the stack half-torn-down between `down` and `up`.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #40

## What

Adds a workflow-level `concurrency` group to `.github/workflows/deploy.yml`
so only one Deploy run executes at a time:

```yaml
concurrency:
  group: deploy-production
  cancel-in-progress: false
```

## Why

Incident 2026-08-01 ~20:17 UTC: PRs #38 and #39 merged 17s apart. With no
concurrency group, each push started its own Deploy run, so two
`docker compose down → build → up` sequences ran simultaneously on the
2 vCPU / 4 GB CX22. Two parallel Next.js builds starved the box — prod
served nothing (HTTP 000) and even sshd stopped answering.

`cancel-in-progress: false` **queues** the second deploy rather than
killing the first mid-flight, which could strand the stack half-torn-down
between `down` and `up`.

Placed at workflow level (not job level) so the intent — one deploy at a
time, whatever the job graph — holds even if a job is ever added, and so
`workflow_dispatch` runs serialise against `push` runs too.

## Scope

Exactly the one-line fix the ticket specified. The related-but-separate
ideas the ticket flagged (Phase 6 deploy drain mode; a prebuilt image
registry to remove build load from the box) are deliberately out of scope
here.

## Reviewer notes

- `.github/workflows/**` is a gated path (estate default), so this PR is
  expected to get `human-signoff` rather than auto-merge.
- Self-review via `/code-review` (Standards + Spec axes) came back clean.
- Behaviour note, not a defect: with `cancel-in-progress: false` GitHub
  keeps only one *pending* run per group. In a burst of 3+ near-simultaneous
  merges, an older queued run is superseded by the newest (latest commit
  wins) — the desired "finish current, then deploy newest, never kill
  mid-flight" behaviour, and exactly what the ticket asked for.

## Validation

Change is CI-config only (no application code). Verified the
`concurrency` block is present and correctly indented; no `pnpm`
lint/build path exercises `.github/workflows/**`, and the repo configures
no yamllint/actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)