### PR TITLE
Fleet dashboard: stop the recent ledger overflowing and cropping the run-day text

### DIFF
--- a/src/components/fleet/recent-ledger.tsx
+++ b/src/components/fleet/recent-ledger.tsx
@@ -17,7 +17,7 @@ export function RecentLedger({ view, now }: { view: FleetView; now: Date }) {
           nothing completed this week
         </p>
       ) : (
-        <table className="w-full border-collapse text-sm">
+        <table className="w-full table-fixed border-collapse text-sm">
           <tbody>
             {items.map((item, i) => (
               <tr key={i} className="border-t border-fl-line first:border-t-0">
@@ -45,11 +45,11 @@ export function RecentLedger({ view, now }: { view: FleetView; now: Date }) {
                   >
                     {item.title}
                   </span>
-                  <span className="font-plex-mono text-[11px] text-fl-ink-3">
+                  <span className="block truncate font-plex-mono text-[11px] text-fl-ink-3">
                     {item.projectName}
                   </span>
                 </td>
-                <td className="py-2 pr-2 text-right align-top font-plex-mono text-[12px] tabular-nums text-fl-ink-2">
+                <td className="w-16 py-2 pr-2 text-right align-top font-plex-mono text-[12px] tabular-nums text-fl-ink-2">
                   <Money usd={item.costUsd} />
                 </td>
                 <td className="w-10 py-2 text-right align-top font-plex-mono text-[11px] text-fl-ink-3">

--- a/src/components/fleet/recent-ledger.tsx
+++ b/src/components/fleet/recent-ledger.tsx
@@ -21,7 +21,7 @@ export function RecentLedger({ view, now }: { view: FleetView; now: Date }) {
           <tbody>
             {items.map((item, i) => (
               <tr key={i} className="border-t border-fl-line first:border-t-0">
-                <td className="w-12 py-2 pr-2 align-top font-plex-mono text-[12px]">
+                <td className="w-14 py-2 pr-2 align-top font-plex-mono text-[12px]">
                   {item.prUrl ? (
                     <a
                       href={item.prUrl}


### PR DESCRIPTION
Closes #47

## Problem

On the fleet dashboard's **Recent** section, a long completion title caused a minor horizontal overflow at ~390px (phone), cropping the rightmost columns — visibly the run-day text (`today` / `yest` / weekday).

## Root cause

The ledger `<table>` used the default **auto** `table-layout`. In auto layout the browser sizes each column to its content's min-content width, and the title cell's `truncate` (`white-space: nowrap`) has a min-content width equal to the *full untruncated title*. So `truncate` never clipped — the column grew, the table exceeded its card, and the rightmost columns ran off the edge. `truncate` on a table cell only clips once the column has a bounded width.

## Fix (within the #21 design language)

> _"wide content scrolls or truncates deliberately inside its card; the page never crops meaning silently."_

- Switch the ledger table to **`table-fixed`** so column widths derive from the table width, not content.
- Give the **cost** column a fixed width (`w-16`) so the **title** column absorbs the remainder and its existing `truncate` finally clips with an ellipsis — deliberate truncation instead of silent cropping.
- Truncate the **project-name** span too, so a long single-word project can't spill inside the now-bounded title cell.
- Widen the **PR** column (`w-12` → `w-14`): `table-fixed` turns that width from a soft minimum into a hard cap, and `#{prNumber}` is a single unbreakable token, so this keeps a future 5-digit PR number inside its own bounds.

At 390px the fixed columns sum to 160px, leaving the title ~198px to truncate into; the untouched 40px day column comfortably fits `today` (its widest value). Verified at the desktop 320px right rail too (title ~160px).

## Validation

- `pnpm test` — 366/366 pass.
- `pnpm lint` on the changed file — clean.
- CSS layout reasoned through at 390px and the 320px desktop rail. (No component/DOM test infra in this repo — tests target the pure `buildFleetView` read model — and Playwright wasn't runnable in this non-interactive session, so verification is by construction rather than screenshot.)

## Self-review notes (`/code-review`, fixed point `origin/main`)

Both axes came back clean. Two observations, both acted on:
- The **PR-column hard-cap** regression that `table-fixed` introduces — hardened (`w-14`), second commit.
- The **project-name `truncate`** is slightly beyond the literal ask (which names the day text), but it's defensive truncation squarely inside the "truncate deliberately inside its card" design line — kept intentionally.

A fresh-eyes `ticket-reviewer` remains the approving gate.