### PR TITLE
Native executor: treat a CONFLICTING parked PR as needs-integration, not done (#54)

### DIFF
--- a/drizzle/0013_integration_count.sql
+++ b/drizzle/0013_integration_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `integration_count` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,566 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f7ab1732-f364-45e0-8eb7-2093fd129af9",
+  "prevId": "14fc3e07-a15a-41ae-853b-789e6bbbba37",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "integration_count": {
+          "name": "integration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triage_result": {
+          "name": "triage_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1786320000000,
       "tag": "0012_triage-result",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1786406400000,
+      "tag": "0013_integration_count",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/fleet/needs-you.tsx
+++ b/src/components/fleet/needs-you.tsx
@@ -5,6 +5,7 @@ import { Chip, Eyebrow } from "./fleet-bits";
 const CAUSE_LABEL: Record<NeedsYouItem["cause"], string> = {
   blocked: "blocked question",
   signoff: "sign-off",
+  conflict: "merge conflict",
   exhausted: "exhausted",
   cap: "cap pause",
   preflight: "preflight",
@@ -13,6 +14,7 @@ const CAUSE_LABEL: Record<NeedsYouItem["cause"], string> = {
 const CAUSE_TONE: Record<NeedsYouItem["cause"], "amber" | "red"> = {
   blocked: "amber",
   signoff: "amber",
+  conflict: "red",
   exhausted: "red",
   cap: "red",
   preflight: "amber",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -68,6 +68,11 @@ export const runs = sqliteTable("runs", {
     | { kind: "unparseable"; reason: string }
   >(),
   reviewCycleCount: int("review_cycle_count").notNull().default(0),
+  // Repair passes run to resolve a CONFLICTING PR (issue #54). Counted per
+  // conflict episode — reset to 0 once the PR is observed mergeable again, so
+  // a fresh conflict earns fresh repairs; past MAX_INTEGRATION_ATTEMPTS a
+  // still-conflicting PR escalates to a human. Never consumes an attempt.
+  integrationCount: int("integration_count").notNull().default(0),
   interruptionCount: int("interruption_count").notNull().default(0),
   blockedQuestion: text("blocked_question"),
   // A checkpoint: directive's text, stored at claim time. Non-null makes the
@@ -96,7 +101,7 @@ export const tasks = sqliteTable("tasks", {
     .default("queued"),
   githubIssue: text("github_issue"),
   kind: text("kind", {
-    enum: ["interactive", "implement", "review", "triage"],
+    enum: ["interactive", "implement", "review", "triage", "repair"],
   })
     .notNull()
     .default("interactive"),

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -339,6 +339,41 @@ export async function notifyReviewBlocked(
 }
 
 /**
+ * A parked PR still conflicts with the default branch after its automated
+ * integration repairs are spent (issue #54): a human must resolve the conflict
+ * and merge. Pushed once per stall — the dashboard's conflict needs-you entry
+ * carries it after that.
+ */
+export async function notifyIntegrationEscalation(
+  channelId: string | null,
+  payload: { issueRef: string; prNumber: number; integrationsMade: number }
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const repairs = `${payload.integrationsMade} automated repair${
+      payload.integrationsMade === 1 ? "" : "s"
+    }`;
+    const embed = new EmbedBuilder()
+      .setTitle(`Merge conflict needs you — nothing merged`)
+      .setDescription(
+        `${payload.issueRef} (PR #${payload.prNumber}) still conflicts with the ` +
+          `default branch after ${repairs}.\n\n` +
+          `Auto-merge is disarmed — resolve the conflict and merge.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send integration-escalation notification:`, err);
+  }
+}
+
+/**
  * Post an "agent finished a turn — your move" idle notification.
  * Returns the Discord message ID so it can become the task's current
  * interactive message (for ✅-to-complete and reply-to-continue).

--- a/src/lib/fleet/__tests__/digest.test.ts
+++ b/src/lib/fleet/__tests__/digest.test.ts
@@ -63,6 +63,7 @@ function makeRun(overrides: Partial<FleetRunRow> = {}): FleetRunRow {
     pullRequestNumber: null,
     pullRequestUrl: null,
     blockedQuestion: null,
+    integrationCount: 0,
     claimedAt: aug(1, 9),
     startedAt: aug(1, 9),
     finishedAt: null,

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -50,6 +50,7 @@ function makeRun(overrides: Partial<FleetRunRow> = {}): FleetRunRow {
     pullRequestNumber: null,
     pullRequestUrl: null,
     blockedQuestion: null,
+    integrationCount: 0,
     claimedAt: TODAY_9AM,
     startedAt: TODAY_9AM,
     finishedAt: null,
@@ -422,6 +423,61 @@ describe("buildFleetView — needs you", () => {
         },
       },
     ]);
+  });
+
+  it("raises a gated PR stalled on a merge conflict as a distinct red state (issue #54)", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            // Integration repairs spent (MAX_INTEGRATION_ATTEMPTS = 1) and
+            // still conflicting: not a plain sign-off.
+            integrationCount: 1,
+            pullRequestNumber: 55,
+            pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou).toEqual([
+      {
+        cause: "conflict",
+        severity: "red",
+        context: "lemons #34 · attempt 1/3",
+        body: "PR #55 still conflicts with the default branch — resolve and merge",
+        action: {
+          label: "Resolve PR #55",
+          href: "https://github.com/lennons301/lemons/pull/55",
+        },
+      },
+    ]);
+  });
+
+  it("keeps a repaired-and-mergeable gated PR as an ordinary sign-off", () => {
+    // A successful repair resets integrationCount to 0, so the run reads as a
+    // clean sign-off wait, not a conflict.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            integrationCount: 0,
+            pullRequestNumber: 55,
+            pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou.map((i) => i.cause)).toEqual(["signoff"]);
   });
 
   it("raises an exhausted ticket with a link to its issue", () => {

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -318,32 +318,31 @@ export function buildFleetView(rows: FleetRows): FleetView {
   // repairs are spent (issue #54) is stalled on a merge conflict — a distinct,
   // red, "resolve it" state rather than silence or an ordinary sign-off.
   for (const run of rows.runs.filter((r) => r.status === "gated")) {
-    const stalledOnConflict = run.integrationCount >= MAX_INTEGRATION_ATTEMPTS;
     const pr = run.pullRequestNumber;
-    needsYou.push({
-      cause: stalledOnConflict ? "conflict" : "signoff",
-      severity: stalledOnConflict ? "red" : "amber",
-      context: runContext(run),
-      body: stalledOnConflict
-        ? pr
+    const link = (label: string): NeedsYouItem["action"] =>
+      run.pullRequestUrl ? { label, href: run.pullRequestUrl } : null;
+
+    if (run.integrationCount >= MAX_INTEGRATION_ATTEMPTS) {
+      needsYou.push({
+        cause: "conflict",
+        severity: "red",
+        context: runContext(run),
+        body: pr
           ? `PR #${pr} still conflicts with the default branch — resolve and merge`
-          : "PR still conflicts with the default branch — resolve and merge"
-        : pr
+          : "PR still conflicts with the default branch — resolve and merge",
+        action: link(pr ? `Resolve PR #${pr}` : "Resolve PR"),
+      });
+    } else {
+      needsYou.push({
+        cause: "signoff",
+        severity: "amber",
+        context: runContext(run),
+        body: pr
           ? `PR #${pr} waits for your sign-off`
           : "PR waits for your sign-off",
-      action: run.pullRequestUrl
-        ? {
-            label: stalledOnConflict
-              ? pr
-                ? `Resolve PR #${pr}`
-                : "Resolve PR"
-              : pr
-                ? `Review PR #${pr}`
-                : "Review PR",
-            href: run.pullRequestUrl,
-          }
-        : null,
-    });
+        action: link(pr ? `Review PR #${pr}` : "Review PR"),
+      });
+    }
   }
 
   // An exhausted ticket needs a human until either they re-arm it (a newer

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -5,7 +5,10 @@
  * never disagree about the state of the fleet.
  */
 
-import { MAX_ATTEMPTS } from "../orchestrator/autonomy/budgets";
+import {
+  MAX_ATTEMPTS,
+  MAX_INTEGRATION_ATTEMPTS,
+} from "../orchestrator/autonomy/budgets";
 
 export interface FleetRows {
   /** Current time — passed in, never read inside */
@@ -55,6 +58,10 @@ export interface FleetRunRow {
   pullRequestNumber: number | null;
   pullRequestUrl: string | null;
   blockedQuestion: string | null;
+  /** Integration repairs spent this conflict episode (issue #54): a gated run
+   * at or past MAX_INTEGRATION_ATTEMPTS is a stalled merge conflict, not a
+   * plain sign-off */
+  integrationCount: number;
   claimedAt: Date;
   startedAt: Date | null;
   finishedAt: Date | null;
@@ -64,7 +71,7 @@ export interface FleetTaskRow {
   id: string;
   projectId: string;
   runId: string | null;
-  kind: "interactive" | "implement" | "review" | "triage";
+  kind: "interactive" | "implement" | "review" | "triage" | "repair";
   title: string;
   status: "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
   containerStatus: "setup" | "running" | "idle" | "completing" | null;
@@ -84,6 +91,7 @@ export { MAX_ATTEMPTS };
 export type NeedsYouCause =
   | "blocked"
   | "signoff"
+  | "conflict"
   | "exhausted"
   | "cap"
   | "preflight";
@@ -306,19 +314,32 @@ export function buildFleetView(rows: FleetRows): FleetView {
     });
   }
 
+  // A gated run is normally a clean sign-off wait, but one whose integration
+  // repairs are spent (issue #54) is stalled on a merge conflict — a distinct,
+  // red, "resolve it" state rather than silence or an ordinary sign-off.
   for (const run of rows.runs.filter((r) => r.status === "gated")) {
+    const stalledOnConflict = run.integrationCount >= MAX_INTEGRATION_ATTEMPTS;
+    const pr = run.pullRequestNumber;
     needsYou.push({
-      cause: "signoff",
-      severity: "amber",
+      cause: stalledOnConflict ? "conflict" : "signoff",
+      severity: stalledOnConflict ? "red" : "amber",
       context: runContext(run),
-      body: run.pullRequestNumber
-        ? `PR #${run.pullRequestNumber} waits for your sign-off`
-        : "PR waits for your sign-off",
+      body: stalledOnConflict
+        ? pr
+          ? `PR #${pr} still conflicts with the default branch — resolve and merge`
+          : "PR still conflicts with the default branch — resolve and merge"
+        : pr
+          ? `PR #${pr} waits for your sign-off`
+          : "PR waits for your sign-off",
       action: run.pullRequestUrl
         ? {
-            label: run.pullRequestNumber
-              ? `Review PR #${run.pullRequestNumber}`
-              : "Review PR",
+            label: stalledOnConflict
+              ? pr
+                ? `Resolve PR #${pr}`
+                : "Resolve PR"
+              : pr
+                ? `Review PR #${pr}`
+                : "Review PR",
             href: run.pullRequestUrl,
           }
         : null,

--- a/src/lib/github/pull-requests.ts
+++ b/src/lib/github/pull-requests.ts
@@ -52,15 +52,28 @@ export async function createDraftPr(options: CreatePrOptions): Promise<PrResult 
 }
 
 /**
- * The slice of PR state gate evaluation and run settlement depend on. Null
- * on any API failure — the caller skips the PR this sweep and retries on
- * the next.
+ * Whether a PR can merge into its base cleanly. GitHub computes mergeability
+ * lazily, so the first read after a push returns `unknown` (REST `mergeable:
+ * null`) until the background check settles — callers re-poll rather than
+ * treat `unknown` as a verdict (issue #54). `conflicting` is a settled "no".
+ */
+export type MergeableState = "mergeable" | "conflicting" | "unknown";
+
+/**
+ * The slice of PR state gate evaluation, run settlement and integration
+ * (issue #54) depend on. Null on any API failure — the caller skips the PR
+ * this sweep and retries on the next.
  */
 export async function getPrState(
   owner: string,
   repo: string,
   prNumber: number
-): Promise<{ open: boolean; merged: boolean; autoMergeArmed: boolean } | null> {
+): Promise<{
+  open: boolean;
+  merged: boolean;
+  autoMergeArmed: boolean;
+  mergeable: MergeableState;
+} | null> {
   if (!isGitHubConfigured()) return null;
 
   try {
@@ -70,10 +83,20 @@ export async function getPrState(
       repo,
       pull_number: prNumber,
     });
+    // REST `mergeable`: true = clean, false = conflicts, null = not yet
+    // computed. Map null to `unknown` so a still-computing check is re-polled
+    // rather than mistaken for a clean merge.
+    const mergeable: MergeableState =
+      pr.mergeable === true
+        ? "mergeable"
+        : pr.mergeable === false
+          ? "conflicting"
+          : "unknown";
     return {
       open: pr.state === "open",
       merged: pr.merged === true,
       autoMergeArmed: pr.auto_merge != null,
+      mergeable,
     };
   } catch (err) {
     console.error(`[github] Failed to read PR #${prNumber} state:`, err);

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -9,6 +9,7 @@ import {
   type AutonomySnapshot,
   type AwaitingReview,
   type CandidateIssue,
+  type ConflictingPr,
   type PassOutcome,
   type PendingGateEvaluation,
   type PendingTriage,
@@ -58,6 +59,7 @@ function makeSnapshot(overrides: Partial<AutonomySnapshot> = {}): AutonomySnapsh
     maxAttempts: 3,
     maxInterruptions: 5,
     maxReviewCycles: 2,
+    maxIntegrationAttempts: 1,
     todayAutonomousSpendUsd: 0,
     dailyCapUsd: 500,
     dailyCapAnnounced: false,
@@ -77,10 +79,28 @@ function makeSnapshot(overrides: Partial<AutonomySnapshot> = {}): AutonomySnapsh
     pendingVerdicts: [],
     settledPrs: [],
     announcedVerdictErrors: [],
+    conflictingPrs: [],
+    resolvedConflicts: [],
+    queuedRepairCount: 0,
+    announcedIntegrationEscalations: [],
     triageCandidates: [],
     pendingTriageResults: [],
     queuedTriageCount: 0,
     announcedTriageErrors: [],
+    ...overrides,
+  };
+}
+
+function makeConflictingPr(
+  overrides: Partial<ConflictingPr> = {}
+): ConflictingPr {
+  return {
+    runId: "run-1",
+    issueRef: "acme/widgets#7",
+    prNumber: 41,
+    armed: false,
+    integrationsMade: 0,
+    hasRepairTask: false,
     ...overrides,
   };
 }
@@ -1440,6 +1460,122 @@ describe("decideNext — settling reviewed PRs", () => {
         outcome: "closed",
       },
     ]);
+  });
+});
+
+describe("decideNext — CONFLICTING parked PRs (issue #54)", () => {
+  it("repairs a conflicting PR with repairs still available", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        conflictingPrs: [makeConflictingPr({ integrationsMade: 0 })],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "repairPr",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        integration: 1,
+      },
+    ]);
+  });
+
+  it("does not queue a second repair while one is in flight", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        conflictingPrs: [
+          makeConflictingPr({ integrationsMade: 0, hasRepairTask: true }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("escalates once repairs are spent and the PR still conflicts", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        maxIntegrationAttempts: 1,
+        conflictingPrs: [
+          makeConflictingPr({ armed: true, integrationsMade: 1 }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "escalateConflict",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        armed: true,
+        integrationsMade: 1,
+      },
+    ]);
+  });
+
+  it("announces the escalation only once", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        maxIntegrationAttempts: 1,
+        conflictingPrs: [makeConflictingPr({ integrationsMade: 1 })],
+        announcedIntegrationEscalations: ["run-1"],
+      })
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("resets the counter when a repaired PR is mergeable again", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        resolvedConflicts: [{ runId: "run-1", issueRef: "acme/widgets#7" }],
+      })
+    );
+
+    expect(actions).toEqual([
+      { type: "clearIntegration", runId: "run-1", issueRef: "acme/widgets#7" },
+    ]);
+  });
+
+  it("never repairs or escalates a run that just blocked on a question", () => {
+    // A run driven by its BLOCKED question is not also dragged into
+    // integration — the pass outcome owns it.
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        completedPasses: [
+          makePass({ finalMessage: "BLOCKED: which database?" }),
+        ],
+        conflictingPrs: [makeConflictingPr({ integrationsMade: 1 })],
+        maxIntegrationAttempts: 1,
+      })
+    );
+
+    expect(actions.some((a) => a.type === "repairPr")).toBe(false);
+    expect(actions.some((a) => a.type === "escalateConflict")).toBe(false);
+    expect(actions.some((a) => a.type === "escalate")).toBe(true);
+  });
+
+  it("a queued repair reserves a slot away from new claims", () => {
+    // One slot, one repair already queued: no room to claim a fresh ticket.
+    const actions = decideNext(
+      makeSnapshot({
+        slots: { total: 1, occupied: 0, occupants: [] },
+        queuedRepairCount: 1,
+        candidates: [makeCandidate()],
+      })
+    );
+
+    expect(actions.some((a) => a.type === "claimIssue")).toBe(false);
+    expect(actions).toContainEqual({ type: "pausePickup", reason: "no-slots" });
   });
 });
 

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -24,6 +24,19 @@ export const DEFAULT_REVIEW_BUDGET_USD = 5;
  * implementing a ticket. */
 export const DEFAULT_TRIAGE_BUDGET_USD = 2;
 
+/** Budget for one repair pass (issue #54): merging the default branch into a
+ * conflicting PR branch is a small mechanical turn, so it carries its own
+ * modest allowance rather than the implement attempt's full budget. */
+export const DEFAULT_REPAIR_BUDGET_USD = 5;
+
+/** Repair passes run to integrate a CONFLICTING parked PR before it escalates
+ * to a human (issue #54). One automated merge of the default branch either
+ * clears the conflict or it is a genuine content clash needing human
+ * judgement, which a second identical attempt would not resolve — so the
+ * bound is one. Counted per conflict episode (reset once the PR is mergeable
+ * again) and, unlike an attempt, never charged against MAX_ATTEMPTS. */
+export const MAX_INTEGRATION_ATTEMPTS = 1;
+
 /** Per-exec turn cap for a triage pass: read the issue against the repo's
  * context, judge, exit. Not raisable — triage reads semi-trusted input and
  * has no directive surface. */

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -167,6 +167,39 @@ export interface SettledPr {
   merged: boolean;
 }
 
+/**
+ * A parked run (reviewing/gated) whose open PR the tracker reports as
+ * CONFLICTING (issue #54): a human merge elsewhere moved the default branch
+ * under it. Left alone this is an invisible stall, so the reducer drives an
+ * integration repair or, once repairs are spent, escalates to a human. A PR
+ * whose mergeability is still `unknown` never lands here — it is re-polled,
+ * never treated as a verdict.
+ */
+export interface ConflictingPr {
+  runId: string;
+  /** "owner/repo#n" */
+  issueRef: string;
+  prNumber: number;
+  /** Auto-merge armed (reviewing) vs gated — the executor disarms on escalate */
+  armed: boolean;
+  /** Repair passes already run this conflict episode (runs.integrationCount) */
+  integrationsMade: number;
+  /** A repair task already queued or running for this run (idempotency) */
+  hasRepairTask: boolean;
+}
+
+/**
+ * A parked run whose PR the tracker now reports as mergeable again after a
+ * prior conflict (integrationCount > 0). The episode is over: its repair
+ * counter resets so a future, unrelated conflict earns its own repairs
+ * instead of escalating on a stale count.
+ */
+export interface ResolvedConflict {
+  runId: string;
+  /** "owner/repo#n" */
+  issueRef: string;
+}
+
 export interface AutonomySnapshot {
   now: Date;
   autonomyEnabledGlobal: boolean;
@@ -177,6 +210,9 @@ export interface AutonomySnapshot {
   maxInterruptions: number;
   /** Implement↔review cycles allowed within one attempt */
   maxReviewCycles: number;
+  /** Repair passes allowed per conflict episode before a still-CONFLICTING
+   * parked PR escalates to a human */
+  maxIntegrationAttempts: number;
   /** Autonomous spend since local midnight — a sum over the runs ledger, so
    * interactive tasks (which have no run) are exempt by construction */
   todayAutonomousSpendUsd: number;
@@ -217,6 +253,14 @@ export interface AutonomySnapshot {
   settledPrs: SettledPr[];
   /** Run IDs whose verdict failure was already announced (once per failure) */
   announcedVerdictErrors: string[];
+  /** Parked runs whose open PR is CONFLICTING — repaired or escalated */
+  conflictingPrs: ConflictingPr[];
+  /** Parked runs whose PR is mergeable again after a conflict — counter reset */
+  resolvedConflicts: ResolvedConflict[];
+  /** Repair tasks sitting in the queue — each has a slot spoken for */
+  queuedRepairCount: number;
+  /** Run IDs whose conflict escalation was already announced (once per stall) */
+  announcedIntegrationEscalations: string[];
   /** Open issues labelled `needs-triage` with no triage pass yet */
   triageCandidates: TriageCandidate[];
   /** Finished triage passes whose stored exits await application */
@@ -311,6 +355,25 @@ export type Action =
       outcome: "merged" | "closed";
     }
   | {
+      type: "repairPr";
+      runId: string;
+      issueRef: string;
+      prNumber: number;
+      /** Which repair this is (integrationsMade + 1) — for the issue comment */
+      integration: number;
+    }
+  | {
+      type: "escalateConflict";
+      runId: string;
+      issueRef: string;
+      prNumber: number;
+      /** Auto-merge armed — disarm before handing to a human */
+      armed: boolean;
+      /** Repairs spent before giving up — named in the escalation */
+      integrationsMade: number;
+    }
+  | { type: "clearIntegration"; runId: string; issueRef: string }
+  | {
       type: "escalate";
       reason: "blocked";
       runId: string;
@@ -389,6 +452,7 @@ export function passOutcomeSnapshot(now: Date, pass: PassOutcome): AutonomySnaps
     maxAttempts: 0,
     maxInterruptions: 0,
     maxReviewCycles: 0,
+    maxIntegrationAttempts: 0,
     todayAutonomousSpendUsd: 0,
     dailyCapUsd: 0,
     dailyCapAnnounced: true,
@@ -408,6 +472,10 @@ export function passOutcomeSnapshot(now: Date, pass: PassOutcome): AutonomySnaps
     pendingVerdicts: [],
     settledPrs: [],
     announcedVerdictErrors: [],
+    conflictingPrs: [],
+    resolvedConflicts: [],
+    queuedRepairCount: 0,
+    announcedIntegrationEscalations: [],
     triageCandidates: [],
     pendingTriageResults: [],
     queuedTriageCount: 0,
@@ -473,6 +541,53 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       issueRef: settled.issueRef,
       prNumber: settled.prNumber,
       outcome: settled.merged ? "merged" : "closed",
+    });
+  }
+
+  // Parked PRs the tracker reports CONFLICTING (issue #54): a human merge
+  // elsewhere moved the default branch under a reviewing/gated run. Left
+  // unnoticed this is an invisible stall, so each conflict drives an
+  // integration repair — a fresh container that merges the default branch in
+  // (merge only) and lets the normal gate + review machinery re-run on push.
+  // A repair never consumes an attempt; once repairs are spent and the PR is
+  // still CONFLICTING the run escalates to a human, announced once. A PR whose
+  // mergeability is still `unknown` never reaches this list — it is re-polled.
+  let repairsQueuedThisSweep = 0;
+  for (const conflicting of snapshot.conflictingPrs) {
+    if (blockedRunIds.has(conflicting.runId)) continue;
+    if (conflicting.integrationsMade >= snapshot.maxIntegrationAttempts) {
+      if (!snapshot.announcedIntegrationEscalations.includes(conflicting.runId)) {
+        actions.push({
+          type: "escalateConflict",
+          runId: conflicting.runId,
+          issueRef: conflicting.issueRef,
+          prNumber: conflicting.prNumber,
+          armed: conflicting.armed,
+          integrationsMade: conflicting.integrationsMade,
+        });
+      }
+      continue;
+    }
+    if (conflicting.hasRepairTask) continue; // a repair is already in flight
+    repairsQueuedThisSweep++;
+    actions.push({
+      type: "repairPr",
+      runId: conflicting.runId,
+      issueRef: conflicting.issueRef,
+      prNumber: conflicting.prNumber,
+      integration: conflicting.integrationsMade + 1,
+    });
+  }
+
+  // A parked run whose PR is mergeable again after a conflict: end the episode
+  // so a later, unrelated conflict earns its own repairs rather than being
+  // judged against a stale count.
+  for (const resolved of snapshot.resolvedConflicts) {
+    if (blockedRunIds.has(resolved.runId)) continue;
+    actions.push({
+      type: "clearIntegration",
+      runId: resolved.runId,
+      issueRef: resolved.issueRef,
     });
   }
 
@@ -839,8 +954,9 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
   // Priority order: in-flight work already holds its slot (it is counted in
   // `occupied`, and a fix-up turn delivered above decremented `slotsLeft`),
   // a queued interactive task reserves the next free slot, an
-  // already-claimed implement task or a queued review pass reserves the slot
-  // it is waiting for, and only what remains may go to new autonomous claims.
+  // already-claimed implement task or a queued review, repair or triage pass
+  // reserves the slot it is waiting for, and only what remains may go to new
+  // autonomous claims.
   const claimableSlots = Math.max(
     0,
     slotsLeft -
@@ -848,6 +964,8 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       snapshot.queuedImplementCount -
       snapshot.queuedReviewCount -
       reviewsQueuedThisSweep -
+      snapshot.queuedRepairCount -
+      repairsQueuedThisSweep -
       snapshot.queuedTriageCount -
       triagesQueuedThisSweep
   );

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -1468,18 +1468,13 @@ async function executeRepairPr(action: Extract<Action, { type: "repairPr" }>): P
   // on this run (a reviewing run's implement pass) so nothing double-books.
   await releaseImplementContainer(action.runId, "Repairing a merge conflict in a fresh container.");
 
+  // Queue the repair task first: it is the idempotency anchor (a queued/running
+  // repair task keeps the next sweep from double-queuing) and startTask flips
+  // the run to `implementing` when it begins, so even if the run update below
+  // never lands the repair still runs and recovers the state. The PR is carried
+  // on the task so the pass pushes to the existing PR (no second draft) and
+  // parks awaiting review rather than completing outright.
   const now = new Date();
-  db.update(runs)
-    .set({
-      status: "implementing",
-      integrationCount: run.integrationCount + 1,
-      reviewVerdict: null,
-      reviewResult: null,
-      gateCategories: [],
-    })
-    .where(eq(runs.id, action.runId))
-    .run();
-
   const taskId = newId();
   db.insert(tasks)
     .values({
@@ -1492,13 +1487,24 @@ async function executeRepairPr(action: Extract<Action, { type: "repairPr" }>): P
       runId: run.id,
       githubIssue: action.issueRef,
       branch: `agent/issue-${ref.number}`,
-      // Carry the PR so the pass pushes to the existing PR (no second draft)
-      // and parks awaiting review rather than completing outright.
       pullRequestNumber: run.pullRequestNumber,
       pullRequestUrl: run.pullRequestUrl,
       createdAt: now,
       updatedAt: now,
     })
+    .run();
+
+  // Move the run out of the reviewable set now so the review pipeline does not
+  // also act on it, and count the repair (never an attempt).
+  db.update(runs)
+    .set({
+      status: "implementing",
+      integrationCount: run.integrationCount + 1,
+      reviewVerdict: null,
+      reviewResult: null,
+      gateCategories: [],
+    })
+    .where(eq(runs.id, action.runId))
     .run();
 
   console.log(

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -7,7 +7,7 @@
 
 import { db } from "@/db";
 import { messages, projects, runs, tasks } from "@/db/schema";
-import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import { newId } from "../../ulid";
 import { getConfig, PLATFORM_REPO_URL } from "../../config";
 import { getOctokit, isGitHubConfigured } from "../../github/client";
@@ -31,6 +31,7 @@ import {
   notifyAttemptsExhausted,
   notifyDailyCapReached,
   notifyGateConfigError,
+  notifyIntegrationEscalation,
   notifyReviewBlocked,
   notifySlotsSaturated,
   notifyTriageRecommendation,
@@ -46,9 +47,11 @@ import {
   type AutonomySnapshot,
   type AwaitingReview,
   type CandidateIssue,
+  type ConflictingPr,
   type PendingGateEvaluation,
   type PendingTriage,
   type PendingVerdict,
+  type ResolvedConflict,
   type SettledPr,
   type TriageCandidate,
 } from "./decide";
@@ -67,10 +70,16 @@ import {
   labelNames,
   parseBlockedByRefs,
 } from "./ticket";
-import { buildImplementPrompt, buildReviewPrompt, buildTriagePrompt } from "./workflow";
+import {
+  buildImplementPrompt,
+  buildRepairPrompt,
+  buildReviewPrompt,
+  buildTriagePrompt,
+} from "./workflow";
 import {
   DAILY_AUTONOMOUS_CAP_USD,
   MAX_ATTEMPTS,
+  MAX_INTEGRATION_ATTEMPTS,
   MAX_INTERRUPTIONS_PER_TICKET,
   MAX_REVIEW_CYCLES_PER_ATTEMPT,
   MAX_TRIAGE_PASSES_PER_ISSUE,
@@ -104,6 +113,10 @@ const announcedGateConfigErrors = new Set<string>();
 // not post (executor-level, e.g. REVIEWER_GH_TOKEN missing).
 const announcedVerdictErrors = new Set<string>();
 const announcedReviewPostFailures = new Set<string>();
+// Run IDs whose merge-conflict escalation (issue #54) the owner has already
+// been told about — once per stall, not once per sweep. Pruned as runs leave
+// the conflicting set (repaired, resolved by a human, or the PR closed).
+const announcedIntegrationEscalations = new Set<string>();
 // Triage-task IDs whose unparseable exit the owner has already been told
 // about — once per failure, not once per sweep. Pruned as issues leave the
 // needs-triage set.
@@ -322,6 +335,7 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     maxAttempts: MAX_ATTEMPTS,
     maxInterruptions: MAX_INTERRUPTIONS_PER_TICKET,
     maxReviewCycles: MAX_REVIEW_CYCLES_PER_ATTEMPT,
+    maxIntegrationAttempts: MAX_INTEGRATION_ATTEMPTS,
     todayAutonomousSpendUsd: todayAutonomousSpendUsd(now),
     dailyCapUsd: DAILY_AUTONOMOUS_CAP_USD,
     dailyCapAnnounced: dailyCapAnnouncedDay === startOfLocalDay(now).getTime(),
@@ -349,6 +363,10 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     pendingVerdicts: reviewState.pendingVerdicts,
     settledPrs: reviewState.settledPrs,
     announcedVerdictErrors: [...announcedVerdictErrors],
+    conflictingPrs: reviewState.conflictingPrs,
+    resolvedConflicts: reviewState.resolvedConflicts,
+    queuedRepairCount: queuedTasks.filter((t) => t.kind === "repair").length,
+    announcedIntegrationEscalations: [...announcedIntegrationEscalations],
     triageCandidates,
     pendingTriageResults,
     queuedTriageCount: queuedTasks.filter((t) => t.kind === "triage").length,
@@ -367,10 +385,14 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
   awaitingReview: AwaitingReview[];
   pendingVerdicts: PendingVerdict[];
   settledPrs: SettledPr[];
+  conflictingPrs: ConflictingPr[];
+  resolvedConflicts: ResolvedConflict[];
 }> {
   const awaitingReview: AwaitingReview[] = [];
   const pendingVerdicts: PendingVerdict[] = [];
   const settledPrs: SettledPr[] = [];
+  const conflictingPrs: ConflictingPr[] = [];
+  const resolvedConflicts: ResolvedConflict[] = [];
 
   const reviewable = allRuns.filter(
     (r) =>
@@ -384,6 +406,15 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
   }
   for (const runId of [...announcedReviewPostFailures]) {
     if (!reviewable.some((r) => r.id === runId)) announcedReviewPostFailures.delete(runId);
+  }
+  // The conflict escalation is likewise re-announced only if the run leaves
+  // the reviewing/gated set and returns — a run being repaired is
+  // `implementing`, so this prunes as soon as a repair or a human's fix moves
+  // the PR back to mergeable (or closes it).
+  for (const runId of [...announcedIntegrationEscalations]) {
+    if (!reviewable.some((r) => r.id === runId)) {
+      announcedIntegrationEscalations.delete(runId);
+    }
   }
 
   for (const run of reviewable) {
@@ -404,6 +435,40 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
     }
 
     const armed = run.status === "reviewing";
+
+    // Integration (issue #54): a parked PR the tracker reports CONFLICTING is
+    // repaired or escalated ahead of the review pipeline — reviewing a PR that
+    // cannot merge is wasted work, and the repair re-triggers review on its
+    // push. `unknown` mergeability is re-polled next sweep, never a verdict.
+    if (pr.mergeable === "conflicting") {
+      const hasRepairTask =
+        db
+          .select({ id: tasks.id })
+          .from(tasks)
+          .where(
+            and(
+              eq(tasks.runId, run.id),
+              eq(tasks.kind, "repair"),
+              inArray(tasks.status, ["queued", "running"])
+            )
+          )
+          .get() != null;
+      conflictingPrs.push({
+        runId: run.id,
+        issueRef: run.githubIssue,
+        prNumber: run.pullRequestNumber!,
+        armed,
+        integrationsMade: run.integrationCount,
+        hasRepairTask,
+      });
+      continue;
+    }
+    // A repaired PR that is mergeable again ends its conflict episode: the
+    // reset lets a later, unrelated conflict earn its own repairs. It still
+    // proceeds through the normal pipeline below.
+    if (pr.mergeable === "mergeable" && run.integrationCount > 0) {
+      resolvedConflicts.push({ runId: run.id, issueRef: run.githubIssue });
+    }
 
     if (run.reviewResult != null) {
       pendingVerdicts.push({
@@ -443,15 +508,23 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
     });
   }
 
-  return { awaitingReview, pendingVerdicts, settledPrs };
+  return { awaitingReview, pendingVerdicts, settledPrs, conflictingPrs, resolvedConflicts };
 }
 
-/** The implement task a run owns (a run has at most one implement pass). */
-function implementTaskOf(runId: string) {
+/**
+ * A run's current working pass: its implement pass, or the integration-repair
+ * pass (issue #54) that supersedes it once a conflict is being merged out. The
+ * most recently created of the two is the live one, so gate evaluation, fix-up
+ * delivery and container release all follow it rather than a stale earlier
+ * pass (a repaired run has both an old, completed implement task and a live
+ * repair task).
+ */
+function workingTaskOf(runId: string) {
   return db
     .select({ id: tasks.id, status: tasks.status, containerStatus: tasks.containerStatus })
     .from(tasks)
-    .where(and(eq(tasks.runId, runId), eq(tasks.kind, "implement")))
+    .where(and(eq(tasks.runId, runId), inArray(tasks.kind, ["implement", "repair"])))
+    .orderBy(desc(tasks.createdAt))
     .get();
 }
 
@@ -463,13 +536,13 @@ function implementTaskOf(runId: string) {
  * diff is still moving — evaluating gates now would arm a stale decision.
  */
 function implementPassSettled(runId: string): boolean {
-  const implementTask = implementTaskOf(runId);
-  if (!implementTask) return false;
+  const workingTask = workingTaskOf(runId);
+  if (!workingTask) return false;
 
   const settled =
-    implementTask.status === "running"
-      ? implementTask.containerStatus === "idle"
-      : implementTask.status === "completed" || implementTask.status === "failed";
+    workingTask.status === "running"
+      ? workingTask.containerStatus === "idle"
+      : workingTask.status === "completed" || workingTask.status === "failed";
   if (!settled) return false;
 
   const undelivered = db
@@ -477,7 +550,7 @@ function implementPassSettled(runId: string): boolean {
     .from(messages)
     .where(
       and(
-        eq(messages.taskId, implementTask.id),
+        eq(messages.taskId, workingTask.id),
         eq(messages.role, "user"),
         isNull(messages.deliveredAt)
       )
@@ -486,12 +559,12 @@ function implementPassSettled(runId: string): boolean {
   return undelivered == null;
 }
 
-/** The run's implement task, if its container is still alive to take a
- * fix-up turn. */
+/** The run's working task (implement or repair), if its container is still
+ * alive to take a fix-up turn. */
 function liveImplementTaskId(runId: string): string | null {
-  const implementTask = implementTaskOf(runId);
-  if (!implementTask || implementTask.status !== "running") return null;
-  return getActiveTasks().has(implementTask.id) ? implementTask.id : null;
+  const workingTask = workingTaskOf(runId);
+  if (!workingTask || workingTask.status !== "running") return null;
+  return getActiveTasks().has(workingTask.id) ? workingTask.id : null;
 }
 
 /** How one gate-config source read went: usable config, a real config
@@ -743,6 +816,15 @@ async function executeActions(actions: Action[]): Promise<void> {
         break;
       case "finalizeRun":
         await executeFinalizeRun(action);
+        break;
+      case "repairPr":
+        await executeRepairPr(action);
+        break;
+      case "escalateConflict":
+        await executeEscalateConflict(action);
+        break;
+      case "clearIntegration":
+        executeClearIntegration(action);
         break;
       case "exhaust":
         await executeExhaust(action);
@@ -1344,6 +1426,159 @@ async function executeFinalizeRun(
 }
 
 /**
+ * A CONFLICTING parked PR (issue #54): queue an integration-repair pass in a
+ * fresh container and move the run back to `implementing` so the normal gate
+ * evaluation and review pass re-run once the repair pushes. The repair counts
+ * against the integration bound, never an attempt. Idempotency is the run's
+ * status flip: once it is `implementing` it leaves the reviewable set, so no
+ * second repair is queued while this one runs.
+ */
+async function executeRepairPr(action: Extract<Action, { type: "repairPr" }>): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  const run = db.select().from(runs).where(eq(runs.id, action.runId)).get();
+  // A stale action: only a parked run still awaiting its merge is repaired.
+  if (!run || (run.status !== "reviewing" && run.status !== "gated")) return;
+  if (run.pullRequestNumber == null) return;
+
+  // The default branch to merge in. A read failure skips this sweep with no
+  // mutation; the PR is still CONFLICTING next sweep and the repair retries.
+  let baseBranch: string;
+  let prompt: string;
+  try {
+    const octokit = await getOctokit();
+    const { data: repo } = await octokit.rest.repos.get({
+      owner: ref.owner,
+      repo: ref.repo,
+    });
+    baseBranch = repo.default_branch;
+    prompt = buildRepairPrompt({
+      repo: `${ref.owner}/${ref.repo}`,
+      issueNumber: ref.number,
+      prNumber: run.pullRequestNumber,
+      baseBranch,
+    });
+  } catch (err) {
+    console.error(`[autonomy] Could not prepare repair for ${action.issueRef}:`, err);
+    return;
+  }
+
+  // The repair runs in a fresh container; release any container still parked
+  // on this run (a reviewing run's implement pass) so nothing double-books.
+  await releaseImplementContainer(action.runId, "Repairing a merge conflict in a fresh container.");
+
+  const now = new Date();
+  db.update(runs)
+    .set({
+      status: "implementing",
+      integrationCount: run.integrationCount + 1,
+      reviewVerdict: null,
+      reviewResult: null,
+      gateCategories: [],
+    })
+    .where(eq(runs.id, action.runId))
+    .run();
+
+  const taskId = newId();
+  db.insert(tasks)
+    .values({
+      id: taskId,
+      projectId: run.projectId,
+      title: `Integration repair — PR #${run.pullRequestNumber}`,
+      description: prompt,
+      status: "queued",
+      kind: "repair",
+      runId: run.id,
+      githubIssue: action.issueRef,
+      branch: `agent/issue-${ref.number}`,
+      // Carry the PR so the pass pushes to the existing PR (no second draft)
+      // and parks awaiting review rather than completing outright.
+      pullRequestNumber: run.pullRequestNumber,
+      pullRequestUrl: run.pullRequestUrl,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  console.log(
+    `[autonomy] Repair ${action.integration} for ${action.issueRef} PR #${run.pullRequestNumber} -> task ${taskId}`
+  );
+  await commentOnIssue(
+    action.issueRef,
+    `PR #${run.pullRequestNumber} conflicts with the default branch — starting an ` +
+      `integration repair (merge \`${baseBranch}\` in, no rebase or force-push). ` +
+      `Gate evaluation and review re-run on the push.`
+  );
+}
+
+/**
+ * A PR still CONFLICTING after its repairs are spent (issue #54): hand it to a
+ * human. Disarm (if armed), label it `human-signoff`, land the run in `gated`
+ * and release its container. The run's spent integrationCount is what the
+ * dashboard reads as the distinct conflict needs-you entry — this is a visible
+ * stall, not silence. Mutations run before the announcement, so a failure
+ * leaves it un-announced and the next sweep retries the whole step.
+ */
+async function executeEscalateConflict(
+  action: Extract<Action, { type: "escalateConflict" }>
+): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  if (action.armed) {
+    const disarmed = await disarmAutoMerge(ref.owner, ref.repo, action.prNumber);
+    if (!disarmed) return;
+  }
+  const labeled = await labelPr(ref.owner, ref.repo, action.prNumber, HUMAN_SIGNOFF_LABEL);
+  if (!labeled) return;
+
+  db.update(runs)
+    .set({ status: "gated", reviewResult: null })
+    .where(eq(runs.id, action.runId))
+    .run();
+  await releaseImplementContainer(
+    action.runId,
+    "Merge conflict needs a human — releasing container."
+  );
+
+  announcedIntegrationEscalations.add(action.runId);
+  const repairs = `${action.integrationsMade} automated repair${
+    action.integrationsMade === 1 ? "" : "s"
+  }`;
+  console.error(
+    `[autonomy] Integration repair exhausted for ${action.issueRef} PR #${action.prNumber} — needs a human`
+  );
+  await commentOnIssue(
+    action.issueRef,
+    `PR #${action.prNumber} still conflicts with the default branch after ${repairs}. ` +
+      `Auto-merge is disarmed and it is labelled \`${HUMAN_SIGNOFF_LABEL}\` — please resolve ` +
+      `the conflict and merge this one.`
+  );
+  await notifyIntegrationEscalation(getConfig().discordFleetChannelId, {
+    issueRef: action.issueRef,
+    prNumber: action.prNumber,
+    integrationsMade: action.integrationsMade,
+  });
+}
+
+/**
+ * A repaired PR that is mergeable again: close out the conflict episode by
+ * resetting the run's integration counter, so a later, unrelated conflict is
+ * judged on its own repairs rather than a stale count.
+ */
+function executeClearIntegration(
+  action: Extract<Action, { type: "clearIntegration" }>
+): void {
+  db.update(runs)
+    .set({ integrationCount: 0 })
+    .where(eq(runs.id, action.runId))
+    .run();
+  announcedIntegrationEscalations.delete(action.runId);
+  console.log(`[autonomy] ${action.issueRef} is mergeable again — integration counter reset`);
+}
+
+/**
  * A burnt ticket goes back to a human: three failed attempts, or the
  * interruption bound (a ticket whose runs keep dying to restarts must not
  * re-claim forever on the no-attempt-consumed exemption). Labels first —
@@ -1539,11 +1774,12 @@ async function executeVerdictUnparseable(payload: {
   });
 }
 
-/** Release a run's parked implement container once no further turn can use it. */
+/** Release a run's parked working container (implement or repair) once no
+ * further turn can use it. */
 async function releaseImplementContainer(runId: string, note: string): Promise<void> {
-  const implementTask = implementTaskOf(runId);
-  if (implementTask?.status === "running") {
-    await releaseParkedImplementTask(implementTask.id, note);
+  const workingTask = workingTaskOf(runId);
+  if (workingTask?.status === "running") {
+    await releaseParkedImplementTask(workingTask.id, note);
   }
 }
 

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -187,6 +187,50 @@ export function buildTriagePrompt(ticket: TriageTicket): string {
   ].join("\n");
 }
 
+export interface RepairTicket {
+  /** "owner/repo" */
+  repo: string;
+  issueNumber: number;
+  prNumber: number;
+  /** The PR's base — the default branch to merge in */
+  baseBranch: string;
+}
+
+/**
+ * The full prompt for an integration repair pass (issue #54). The default
+ * branch moved under a parked PR and it now conflicts; this pass merges the
+ * base branch into the PR branch — merge only, never rebase or force-push, so
+ * the PR's own review history stays intact — resolves any conflicts, and ends.
+ * It does no feature work: its single job is to make the PR mergeable again,
+ * after which the normal gate + review machinery re-runs on the push.
+ */
+export function buildRepairPrompt(ticket: RepairTicket): string {
+  return [
+    `You are an autonomous integration-repair pass for PR #${ticket.prNumber} ` +
+      `of ${ticket.repo}, which implements GitHub issue #${ticket.issueNumber}. ` +
+      `No human is watching this run and follow-up questions are not possible.`,
+    ``,
+    `The default branch has moved and the PR now conflicts with it. Your only ` +
+      `job is to make the PR mergeable again — do no feature work.`,
+    ``,
+    `Operating rules:`,
+    `- You are on the PR branch agent/issue-${ticket.issueNumber}, already ` +
+      `checked out at /workspace/repo with its existing commits.`,
+    `- Bring in the default branch by MERGING it — run ` +
+      "`git fetch origin && git merge origin/" + ticket.baseBranch + "`. " +
+      `Never rebase and never force-push: the PR's commits and its review ` +
+      `history must be preserved.`,
+    `- Resolve every merge conflict, keeping both sides' intent. When in doubt ` +
+      `prefer the PR branch's feature changes over the incoming default-branch ` +
+      `edits, but never leave conflict markers.`,
+    `- Run the repo's tests and lint after resolving, and do not finish with ` +
+      `either failing. Commit the merge with a descriptive message.`,
+    `- Do not change anything the conflict did not require. Add no new features, ` +
+      `open no new files unrelated to the resolution.`,
+    `- End with a short summary of what conflicted and how you resolved it.`,
+  ].join("\n");
+}
+
 /**
  * The full prompt for an autonomous implement pass. The ticket body is
  * supplied as the spec, framed as data between markers — it can describe the

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -15,6 +15,7 @@ import { createOutputHandler, type TurnResult } from "./output-parser";
 import { parseReviewVerdict } from "./autonomy/verdict";
 import { parseTriageExit } from "./autonomy/triage";
 import {
+  DEFAULT_REPAIR_BUDGET_USD,
   DEFAULT_REVIEW_BUDGET_USD,
   DEFAULT_TRIAGE_BUDGET_USD,
   MAX_ATTEMPTS,
@@ -35,7 +36,7 @@ const activeTasks = new Map<
   {
     container: RunningContainer;
     state: "setup" | "running" | "idle" | "completing";
-    kind: "interactive" | "implement" | "review" | "triage";
+    kind: "interactive" | "implement" | "review" | "triage" | "repair";
   }
 >();
 
@@ -85,15 +86,21 @@ export async function startTask(taskId: string): Promise<void> {
   const isImplementPass = task.kind === "implement";
   const isReviewPass = task.kind === "review";
   const isTriagePass = task.kind === "triage";
-  const isAutonomousPass = isImplementPass || isReviewPass || isTriagePass;
+  // An integration-repair pass (issue #54) is an implement-shaped pass on an
+  // existing PR branch: it checks the branch out, merges the default branch
+  // in, pushes, and parks awaiting review exactly like an implement pass —
+  // but it is never an attempt, so it skips attempt-exhaustion accounting.
+  const isRepairPass = task.kind === "repair";
+  const isImplementShaped = isImplementPass || isRepairPass;
+  const isAutonomousPass = isImplementShaped || isReviewPass || isTriagePass;
   const issueNumber = task.githubIssue ? parseIssueRef(task.githubIssue)?.number : undefined;
-  if (isImplementPass && !issueNumber) {
-    throw new Error(`Implement task ${taskId} has no parsable GitHub issue ref`);
+  if (isImplementShaped && !issueNumber) {
+    throw new Error(`${task.kind} task ${taskId} has no parsable GitHub issue ref`);
   }
   if (isReviewPass && !task.branch) {
     throw new Error(`Review task ${taskId} has no branch to check out`);
   }
-  const branch = isImplementPass
+  const branch = isImplementShaped
     ? `agent/issue-${issueNumber}`
     : isReviewPass
       ? task.branch!
@@ -114,11 +121,13 @@ export async function startTask(taskId: string): Promise<void> {
   updateTask(taskId, { status: "running", branch, containerStatus: "setup" });
   insertSystemMessage(taskId, `Provisioning agent container...${proj.dopplerToken ? " (Doppler configured)" : ""}`);
 
-  // Only the implement pass moves the run to `implementing` — a review pass
-  // starting must not drag a `reviewing`/`gated` run backwards.
-  if (run && isImplementPass) {
+  // Only an implement-shaped pass moves the run to `implementing` — a review
+  // pass starting must not drag a `reviewing`/`gated` run backwards. A repair
+  // pass keeps the run's original startedAt so the dashboard's elapsed time
+  // does not jump when a conflict is repaired mid-life.
+  if (run && isImplementShaped) {
     db.update(runs)
-      .set({ status: "implementing", startedAt: new Date() })
+      .set({ status: "implementing", startedAt: run.startedAt ?? new Date() })
       .where(eq(runs.id, run.id))
       .run();
   }
@@ -148,8 +157,10 @@ export async function startTask(taskId: string): Promise<void> {
       gitUrl: proj.gitUrl,
       branch,
       dopplerToken:
-        isReviewPass || isTriagePass ? undefined : (proj.dopplerToken ?? undefined),
-      checkoutExisting: isReviewPass,
+        isReviewPass || isTriagePass || isRepairPass
+          ? undefined
+          : (proj.dopplerToken ?? undefined),
+      checkoutExisting: isReviewPass || isRepairPass,
     });
     activeTasks.set(taskId, { container: running, state: "setup", kind: task.kind });
 
@@ -188,8 +199,14 @@ export async function startTask(taskId: string): Promise<void> {
         ? DEFAULT_REVIEW_BUDGET_USD
         : isTriagePass
           ? DEFAULT_TRIAGE_BUDGET_USD
-          : run?.budgetUsd,
-      maxTurns: isTriagePass ? TRIAGE_MAX_TURNS : isReviewPass ? undefined : (run?.maxTurns ?? undefined),
+          : isRepairPass
+            ? DEFAULT_REPAIR_BUDGET_USD
+            : run?.budgetUsd,
+      maxTurns: isTriagePass
+        ? TRIAGE_MAX_TURNS
+        : isReviewPass || isRepairPass
+          ? undefined
+          : (run?.maxTurns ?? undefined),
       captureRaw: isReviewPass || isTriagePass,
     });
 
@@ -219,14 +236,18 @@ export async function startTask(taskId: string): Promise<void> {
     // Commit and push after turn completes
     await runPostTurnCommitAndPush(taskId, running);
 
-    if (isImplementPass) {
-      // Exhaustion first (issue #18): a pass that ran out of budget or turns
-      // failed its attempt — the branch is already pushed, so the work
-      // survives for the next attempt, but nothing proceeds toward review.
-      const exhaustion = run ? attemptExhaustion(run, turnResult.costUsd, turnResult.subtype) : null;
-      if (exhaustion) {
-        await failImplementAttempt(taskId, run!.id, exhaustion);
-        return;
+    if (isImplementShaped) {
+      // Exhaustion first (issue #18) — but only for a real implement attempt.
+      // A repair pass (issue #54) is never an attempt, so a repair that spent
+      // its budget without clearing the conflict still parks: the sweep's
+      // conflict check then escalates the still-CONFLICTING PR to a human,
+      // rather than the repair burning a strike.
+      if (isImplementPass) {
+        const exhaustion = run ? attemptExhaustion(run, turnResult.costUsd, turnResult.subtype) : null;
+        if (exhaustion) {
+          await failImplementAttempt(taskId, run!.id, exhaustion);
+          return;
+        }
       }
       // The pass's turn is over: park it blocked if its final message leads
       // with the BLOCKED marker — container kept alive, question escalated
@@ -477,7 +498,10 @@ export async function processQueuedMessages(
     // Commit and push after each turn
     await runPostTurnCommitAndPush(taskId, running);
 
-    if (task.kind === "implement") {
+    if (task.kind === "implement" || task.kind === "repair") {
+      // A repair container that later receives a fix-up turn (issue #54) is
+      // continuing the attempt's review cycle, so from here it behaves exactly
+      // like an implement pass — exhaustion included.
       // Exhaustion first (issue #18): a fix-up or answer turn that spent the
       // attempt's remaining budget or turns fails the attempt through the
       // ledger — the branch is already pushed, the work survives.

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -149,17 +149,18 @@ export async function startTask(taskId: string): Promise<void> {
   let running: RunningContainer | null = null;
 
   try {
-    // Create container. Review and triage passes receive no credential
-    // beyond the App token their setup uses for cloning — not even the
-    // project's Doppler secrets: they read code, they don't run the app.
+    // Create container. Review and triage passes receive no credential beyond
+    // the App token their setup uses for cloning — not even the project's
+    // Doppler secrets: they read code, they don't run the app. A repair pass
+    // is implement-shaped — it merges, pushes, and runs the repo's tests and
+    // lint — so it gets the same Doppler secrets an implement pass does, or a
+    // test that needs them would behave differently than under implement.
     running = await createWorkspaceContainer({
       taskId,
       gitUrl: proj.gitUrl,
       branch,
       dopplerToken:
-        isReviewPass || isTriagePass || isRepairPass
-          ? undefined
-          : (proj.dopplerToken ?? undefined),
+        isReviewPass || isTriagePass ? undefined : (proj.dopplerToken ?? undefined),
       checkoutExisting: isReviewPass || isRepairPass,
     });
     activeTasks.set(taskId, { container: running, state: "setup", kind: task.kind });


### PR DESCRIPTION
Closes #54

Mirrors platform#14's mergeability policy in interlude's native executor. Until now the autonomy loop only read `merged`/`closed` PR state (`getPrState`) and never `mergeable`, so every human merge of a gated PR could flip other parked runs' PRs to `CONFLICTING` with nothing noticing — an invisible, unattended stall (observed 3× in one day during Phase 5 delivery).

## What changed

- **`getPrState` returns a `mergeable` state** (`mergeable` / `conflicting` / `unknown`). `unknown` (GitHub still computing) is re-polled next sweep, never treated as a verdict.
- **Reducer (`decideNext`) drives conflicts.** The snapshot gains each parked (`reviewing`/`gated`) run's conflict state. A `CONFLICTING` PR emits `repairPr`; once repairs are spent it emits `escalateConflict`; a PR that is mergeable again emits `clearIntegration`. All pure — the sweep gathers the state, the reducer decides.
- **Repair pass.** The executor queues a fresh-container `repair` task (new `tasks.kind`) that checks out the existing PR branch and merges the default branch in — **merge only, never rebase or force-push** — then the run returns to `implementing` so the *normal* gate re-evaluation + review pass re-run on the push.
- **Repair never consumes an attempt.** Bounded by `MAX_INTEGRATION_ATTEMPTS` (1), counted in a new `runs.integrationCount` column, per conflict *episode* (reset to 0 once the PR is mergeable again, so a later unrelated conflict earns its own repair). A repair pass skips attempt-exhaustion accounting.
- **Escalation.** A PR still conflicting after its repairs are spent is handed to a human: auto-merge disarmed, PR labelled `human-signoff`, one Discord ping, and a **distinct red "merge conflict" needs-you entry** on the fleet dashboard — not silence.

## Validation

- `pnpm test` — 375 pass (9 new: reducer conflict/escalate/resolve/idempotency/slot-accounting, fleet-view conflict vs sign-off).
- `pnpm lint` — clean on every changed file (the repo's 16 pre-existing baseline errors are all in files this PR does not touch).
- Production `tsc --noEmit` — clean.
- Migration `0013_integration_count` generated via drizzle-kit; journal timestamp follows the repo's fixed-spacing convention (verified by the runs-ledger migration-ordering test).

## Self-review notes (`/code-review` against `origin/main`)

Both axes came back clean; two deliberate interpretations worth flagging for the fresh-eyes reviewer:

- **"escalates to `ready-for-human`"** is realized as the run landing `gated` + PR `human-signoff` + auto-merge disarmed + the red needs-you entry + Discord ping — the same mechanism the existing escalate/unparseable-verdict paths use — **not** by swapping the issue's `ready-for-agent`→`ready-for-human` label. The PR is already implemented and reviewed; the human's task is to resolve the conflict and merge, a PR-level action. Crucially, the dashboard's needs-you reads run state (not issue labels), so this realization is what actually satisfies the "+ a needs-you entry" requirement. The spec-axis review judged this satisfies the spec.
- **`unknown` mergeability** is excluded from both the conflict and resolved sets and re-polled each sweep, but the run still proceeds through the normal review/arm pipeline rather than pausing — mergeability is orthogonal to reviewability, and auto-merge itself blocks an un-mergeable PR.
- Like the existing `announced*` sets, `announcedIntegrationEscalations` is in-memory, so an orchestrator restart may re-post the escalation once — consistent with the existing verdict-error announcements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)