### PR TITLE
Autonomous retry collides with the previous attempt's remote branch (non-fast-forward) — adopt agent/issue-N if it exists

### DIFF
--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -63,13 +63,32 @@ describe("buildSetupScript", () => {
     expect(script).toContain('if [ -n "$DOPPLER_TOKEN" ]');
   });
 
+  it("creates a fresh branch by default", () => {
+    expect(script).toContain('git checkout -b "$GIT_BRANCH"');
+    expect(script).not.toContain("rev-parse");
+  });
+
   it("checks out the existing remote branch for a review pass", () => {
     const reviewScript = buildSetupScript(
       "https://github.com/lennons301/platform.git",
-      true
+      "existing"
     );
     expect(reviewScript).toContain('git checkout "$GIT_BRANCH"');
-    expect(reviewScript).not.toContain('git checkout -b');
+    expect(reviewScript).not.toContain("git checkout -b");
+  });
+
+  it("adopts an existing agent/issue branch on retry, else creates it (issue #72)", () => {
+    const adoptScript = buildSetupScript(
+      "https://github.com/lennons301/platform.git",
+      "adopt"
+    );
+    // Continue a previous attempt's remote branch when it exists...
+    expect(adoptScript).toContain(
+      'git rev-parse --verify --quiet "refs/remotes/origin/$GIT_BRANCH"'
+    );
+    expect(adoptScript).toContain('git checkout "$GIT_BRANCH"');
+    // ...otherwise branch fresh (first attempt).
+    expect(adoptScript).toContain('git checkout -b "$GIT_BRANCH"');
   });
 });
 

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -6,15 +6,44 @@ import { getInstallationToken } from "../github/client";
 import { getCapacity } from "../orchestrator/capacity";
 
 /**
+ * How setup gets onto `$GIT_BRANCH`:
+ *  - `create`  — make a fresh branch off the default (triage/interactive use a
+ *    unique per-task name that never exists on the remote).
+ *  - `existing` — check out a branch that must already exist on the remote (a
+ *    review or repair pass inspecting the PR branch).
+ *  - `adopt` — continue the branch if a previous attempt already pushed it,
+ *    else create it fresh. An autonomous retry runs in a brand-new container,
+ *    so without this it would branch off the default, redo the work, and have
+ *    its push rejected non-fast-forward against attempt 1's remote branch
+ *    (issue #72). Adopting continues the same branch — matching the laptop
+ *    runner's persistent worktree, and preserving the PR that points at it.
+ */
+export type BranchCheckoutMode = "create" | "existing" | "adopt";
+
+function checkoutCommand(mode: BranchCheckoutMode): string {
+  switch (mode) {
+    case "existing":
+      return 'git checkout "$GIT_BRANCH"';
+    case "adopt":
+      // `git rev-parse` resolves the remote-tracking ref that a full clone
+      // fetches for every remote branch; when it exists, plain `git checkout`
+      // DWIMs a local branch tracking it, otherwise branch off the default.
+      return 'if git rev-parse --verify --quiet "refs/remotes/origin/$GIT_BRANCH" >/dev/null; then git checkout "$GIT_BRANCH"; else git checkout -b "$GIT_BRANCH"; fi';
+    case "create":
+      return 'git checkout -b "$GIT_BRANCH"';
+  }
+}
+
+/**
  * Bash run at container setup: install an env-based git credential helper
  * (token supplied at exec time via GIT_AUTH_TOKEN), clone the repo with a
- * secret-free URL, clone the platform repo (best-effort), check out the task
- * branch, and pull Doppler secrets if a token is present.
- *
- * `checkoutExisting` checks out a branch that already exists on the remote
- * (a review pass inspecting the PR branch) instead of creating a fresh one.
+ * secret-free URL, clone the platform repo (best-effort), get onto the task
+ * branch (see `BranchCheckoutMode`), and pull Doppler secrets if present.
  */
-export function buildSetupScript(platformRepoUrl: string, checkoutExisting = false): string {
+export function buildSetupScript(
+  platformRepoUrl: string,
+  checkout: BranchCheckoutMode = "create"
+): string {
   return [
     'git config --global user.name "$GIT_USER_NAME"',
     'git config --global user.email "$GIT_USER_EMAIL"',
@@ -22,7 +51,7 @@ export function buildSetupScript(platformRepoUrl: string, checkoutExisting = fal
     'git clone "$GIT_URL" /workspace/repo',
     `git clone --depth 1 ${platformRepoUrl} /workspace/platform 2>/dev/null || echo "WARN: platform repo clone failed, continuing without platform context"`,
     "cd /workspace/repo",
-    checkoutExisting ? 'git checkout "$GIT_BRANCH"' : 'git checkout -b "$GIT_BRANCH"',
+    checkoutCommand(checkout),
     'if [ -n "$DOPPLER_TOKEN" ]; then curl -sf --request GET "https://api.doppler.com/v3/configs/config/secrets/download?format=env" --header "Authorization: Bearer $DOPPLER_TOKEN" > .env.local && echo "Doppler: wrote .env.local ($(wc -l < .env.local) vars)" || echo "Doppler: API request failed"; fi',
   ].join(" && ");
 }
@@ -63,8 +92,8 @@ export interface WorkspaceOptions {
   gitUrl: string;
   branch: string;
   dopplerToken?: string;
-  /** Check out an existing remote branch instead of creating a new one */
-  checkoutExisting?: boolean;
+  /** How setup gets onto the branch (default `create`) — see `BranchCheckoutMode` */
+  checkout?: BranchCheckoutMode;
 }
 
 export interface TurnOptions {
@@ -82,8 +111,8 @@ export interface RunningContainer {
   id: string;
   name: string;
   previewSubdomain: string;
-  /** Setup checks out an existing remote branch instead of creating one */
-  checkoutExisting?: boolean;
+  /** How setup gets onto the branch (default `create`) — see `BranchCheckoutMode` */
+  checkout?: BranchCheckoutMode;
 }
 
 export async function createWorkspaceContainer(
@@ -155,7 +184,7 @@ export async function createWorkspaceContainer(
     id: container.id,
     name: containerName,
     previewSubdomain,
-    checkoutExisting: options.checkoutExisting,
+    checkout: options.checkout,
   };
 }
 
@@ -164,7 +193,7 @@ export async function execSetup(
 ): Promise<void> {
   const token = await getInstallationToken();
   const exec = await running.container.exec({
-    Cmd: ["bash", "-c", buildSetupScript(PLATFORM_REPO_URL, running.checkoutExisting ?? false)],
+    Cmd: ["bash", "-c", buildSetupScript(PLATFORM_REPO_URL, running.checkout ?? "create")],
     Env: [`GIT_AUTH_TOKEN=${token}`],
     AttachStdout: true,
     AttachStderr: true,

--- a/src/lib/github/__tests__/pull-requests.test.ts
+++ b/src/lib/github/__tests__/pull-requests.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createDraftPr, findOpenPrForHead } from "../pull-requests";
+
+// Mock the GitHub client so we can drive create/list behaviour per test.
+const { reposGet, pullsCreate, pullsList } = vi.hoisted(() => ({
+  reposGet: vi.fn(),
+  pullsCreate: vi.fn(),
+  pullsList: vi.fn(),
+}));
+
+vi.mock("@/lib/github/client", () => ({
+  isGitHubConfigured: () => true,
+  getOctokit: async () => ({
+    rest: {
+      repos: { get: reposGet },
+      pulls: { create: pullsCreate, list: pullsList },
+    },
+  }),
+}));
+
+beforeEach(() => {
+  reposGet.mockReset();
+  pullsCreate.mockReset();
+  pullsList.mockReset();
+  reposGet.mockResolvedValue({ data: { default_branch: "main" } });
+});
+
+const OPTS = {
+  owner: "lennons301",
+  repo: "interlude",
+  title: "Fix issue 8",
+  body: "Closes #8",
+  head: "agent/issue-8",
+};
+
+describe("createDraftPr", () => {
+  it("creates a fresh draft PR on the first push", async () => {
+    pullsCreate.mockResolvedValue({
+      data: { number: 17, html_url: "https://github.com/lennons301/interlude/pull/17" },
+    });
+
+    const pr = await createDraftPr(OPTS);
+
+    expect(pr).toEqual({
+      number: 17,
+      url: "https://github.com/lennons301/interlude/pull/17",
+    });
+    expect(pr?.adopted).toBeUndefined();
+    expect(pullsList).not.toHaveBeenCalled();
+  });
+
+  it("adopts the existing open PR when a retry's create is rejected (issue #72)", async () => {
+    // A retry that continued agent/issue-8 pushes to a head that already has an
+    // open PR; GitHub rejects the second create with 422.
+    pullsCreate.mockRejectedValue(
+      Object.assign(new Error("Validation Failed"), { status: 422 })
+    );
+    pullsList.mockResolvedValue({
+      data: [{ number: 17, html_url: "https://github.com/lennons301/interlude/pull/17" }],
+    });
+
+    const pr = await createDraftPr(OPTS);
+
+    expect(pr).toEqual({
+      number: 17,
+      url: "https://github.com/lennons301/interlude/pull/17",
+      adopted: true,
+    });
+    // Looked the branch up qualified by owner.
+    expect(pullsList).toHaveBeenCalledWith(
+      expect.objectContaining({ head: "lennons301:agent/issue-8", state: "open" })
+    );
+  });
+
+  it("returns null when create fails and no open PR exists for the head", async () => {
+    pullsCreate.mockRejectedValue(new Error("network blip"));
+    pullsList.mockResolvedValue({ data: [] });
+
+    expect(await createDraftPr(OPTS)).toBeNull();
+  });
+});
+
+describe("findOpenPrForHead", () => {
+  it("returns the single open PR for the head", async () => {
+    pullsList.mockResolvedValue({
+      data: [{ number: 17, html_url: "https://github.com/lennons301/interlude/pull/17" }],
+    });
+
+    expect(await findOpenPrForHead("lennons301", "interlude", "agent/issue-8")).toEqual({
+      number: 17,
+      url: "https://github.com/lennons301/interlude/pull/17",
+    });
+  });
+
+  it("returns null when the head has no open PR", async () => {
+    pullsList.mockResolvedValue({ data: [] });
+
+    expect(await findOpenPrForHead("lennons301", "interlude", "agent/issue-8")).toBeNull();
+  });
+});

--- a/src/lib/github/pull-requests.ts
+++ b/src/lib/github/pull-requests.ts
@@ -14,10 +14,50 @@ interface CreatePrOptions {
 interface PrResult {
   number: number;
   url: string;
+  /**
+   * True when an existing open PR for the head was adopted rather than a new
+   * one created — i.e. a retry continuing a previous attempt's branch (#72).
+   */
+  adopted?: boolean;
 }
 
 /**
- * Create a draft PR. Returns the PR number and URL.
+ * The open PR whose head is `head` (GitHub allows at most one), or null. Used
+ * to adopt a previous attempt's PR when a retry continues its branch (#72):
+ * the head filter must be qualified with the repo owner, and same-repo agent
+ * branches always share the repo owner.
+ */
+export async function findOpenPrForHead(
+  owner: string,
+  repo: string,
+  head: string
+): Promise<PrResult | null> {
+  if (!isGitHubConfigured()) return null;
+
+  try {
+    const octokit = await getOctokit();
+    const { data } = await octokit.rest.pulls.list({
+      owner,
+      repo,
+      head: `${owner}:${head}`,
+      state: "open",
+      per_page: 1,
+    });
+    const pr = data[0];
+    return pr ? { number: pr.number, url: pr.html_url } : null;
+  } catch (err) {
+    console.error(`[github] Failed to look up open PR for head "${head}":`, err);
+    return null;
+  }
+}
+
+/**
+ * Ensure a draft PR exists for the branch, returning its number and URL.
+ * Normally this creates one. On an autonomous retry that adopted a previous
+ * attempt's branch (#72), the head already has an open PR and GitHub rejects a
+ * second create with 422 — so fall back to adopting that PR rather than
+ * dropping the retry's work: the caller must re-link it to mark it ready and
+ * route it to review.
  */
 export async function createDraftPr(options: CreatePrOptions): Promise<PrResult | null> {
   if (!isGitHubConfigured()) return null;
@@ -46,6 +86,13 @@ export async function createDraftPr(options: CreatePrOptions): Promise<PrResult 
 
     return { number: pr.number, url: pr.html_url };
   } catch (err) {
+    const existing = await findOpenPrForHead(options.owner, options.repo, options.head);
+    if (existing) {
+      console.log(
+        `[github] Adopting existing open PR #${existing.number} for head "${options.head}" (#72)`
+      );
+      return { ...existing, adopted: true };
+    }
     console.error(`[github] Failed to create draft PR:`, err);
     return null;
   }

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -243,7 +243,9 @@ export function buildImplementPrompt(ticket: ImplementTicket): string {
       `is the BLOCKED marker described below.`,
     ``,
     `Operating rules:`,
-    `- You are on the branch agent/issue-${ticket.issueNumber}, already checked out.`,
+    `- You are on the branch agent/issue-${ticket.issueNumber}, already checked out. ` +
+      `If an earlier attempt already pushed commits to it, build on that work ` +
+      `rather than starting over.`,
     `- The ticket between the markers below is the complete specification. Do what ` +
       `it asks, all of it, and only it.`,
     `- Make small, atomic commits as you work. Run the repo's tests and lint before ` +

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -161,7 +161,11 @@ export async function startTask(taskId: string): Promise<void> {
       branch,
       dopplerToken:
         isReviewPass || isTriagePass ? undefined : (proj.dopplerToken ?? undefined),
-      checkoutExisting: isReviewPass || isRepairPass,
+      // Review/repair check out the PR branch (it must exist); an implement
+      // pass adopts agent/issue-<n> if a previous attempt already pushed it, so
+      // a retry continues that branch instead of racing a fresh one and being
+      // rejected non-fast-forward (issue #72); triage/interactive branch fresh.
+      checkout: isReviewPass || isRepairPass ? "existing" : isImplementPass ? "adopt" : "create",
     });
     activeTasks.set(taskId, { container: running, state: "setup", kind: task.kind });
 
@@ -1062,10 +1066,15 @@ async function runPostTurnCommitAndPush(taskId: string, running: RunningContaine
             pullRequestNumber: pr.number,
             pullRequestUrl: pr.url,
           });
-          if (task.githubIssue) {
+          // On a retry that adopted a previous attempt's PR (#72) the issue
+          // already carries its "opened" comment — don't post a duplicate;
+          // finishImplementPass will announce it "ready for review".
+          if (task.githubIssue && !pr.adopted) {
             await commentOnIssue(task.githubIssue, `Draft PR opened: #${pr.number}`);
           }
-          console.log(`[github] Draft PR #${pr.number} created for task ${taskId}`);
+          console.log(
+            `[github] Draft PR #${pr.number} ${pr.adopted ? "adopted" : "created"} for task ${taskId}`
+          );
         }
       }
     }


### PR DESCRIPTION
Closes #72

## Problem

On platform#8's first pilot runs, attempt 1 pushed `agent/issue-8` and opened PR #17 before dying at the turn limit. Attempts 2 and 3 each started a fresh container, created a new local `agent/issue-8` from the default branch, redid the work, and had their push **rejected non-fast-forward** — the remote branch from attempt 1 already existed and had diverged. Both retries were doomed before they started.

Root cause: container workspace setup always created the issue branch fresh from the default. The laptop runner never hits this because its persistent worktree naturally continues the same branch across attempts.

## Fix

**1. Adopt the branch (the ticket's core ask).** `buildSetupScript` gains a tri-state checkout mode:

- `create` — branch fresh off the default (triage/interactive, whose per-task branch never exists remotely). Unchanged behaviour.
- `existing` — check out a branch that must already exist (review/repair on the PR branch). Unchanged behaviour (was `checkoutExisting: true`).
- `adopt` — **new**, used by implement passes: check out `agent/issue-<n>` if a previous attempt already pushed it (continuing that branch, PR-preserving), else create it fresh. A full clone fetches the remote-tracking ref for every branch, so `git rev-parse --verify` gates and plain `git checkout` DWIMs a local tracking branch.

The implement prompt now tells the agent to build on any commits an earlier attempt left rather than restarting.

**2. Re-link the existing PR (necessary to actually preserve it).** Adopting the branch makes the retry's push *succeed*, but then `createDraftPr` hit GitHub's 422 "a pull request already exists for this head", swallowed it, and returned null — so the run stayed unlinked, never marked the PR ready, and never routed it to review. That's the same stuck end-state, reached via a successful push instead of a rejected one. `createDraftPr` now falls back to adopting the existing open PR for the head (`findOpenPrForHead`); the caller re-links it, `finishImplementPass` marks it ready and routes it to review, and the duplicate "Draft PR opened" issue comment is suppressed on adoption.

## Tests

- `buildSetupScript` renders the adopt sequence (rev-parse gate + both checkout forms); `create`/`existing` modes preserved.
- `createDraftPr` creates fresh normally, **adopts** the existing open PR when create is rejected, and returns null only when create fails *and* no open PR exists; `findOpenPrForHead` covered directly.
- Full suite: 382 passing. Lint clean on all changed files.

## Self-review (`/code-review` vs `origin/main`)

Ran the review skill; acted on its main finding (the orphaned-PR gap above — part 2 of this PR). Two findings I did **not** action, deliberately:

- *adopt keys on "branch exists" not "this run pushed it"*: a reopened+re-armed ticket whose old branch was never deleted could adopt a stale branch. This is exactly the semantics the ticket specifies ("check for an existing remote `agent/issue-<n>`; if present, check it out"). The estate deletes branches on merge and re-arming is a deliberate human action, so I followed the spec rather than adding run-ownership tracking of branches (a larger design change, out of scope).
- *no end-to-end turn-manager test*: the `isImplementPass → adopt` mapping is a one-line ternary and the repo doesn't mock the full `startTask` flow; I covered the two units that carry the logic (setup-script rendering and PR adoption) instead.

## Out of scope (sibling observations noted on the ticket)

The ticket flags two related-but-separate items from the same strikeout, left for their own tickets: the `MAX_TURNS` default (50) being too low for investigation-heavy tickets, and the exhaustion issue-comment not mentioning a live partial PR. Neither is part of the branch-collision fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)