### PR TITLE
Agent image lacks jq (and likely yq) — platform repo checks fail in-container

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -5,7 +5,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     iproute2 \
+    jq \
     && rm -rf /var/lib/apt/lists/*
+
+# yq (mikefarah) — a standalone YAML processor, not packaged for Debian.
+# Paired with jq (above) so in-container repo checks and review-gates tooling
+# that parse JSON/YAML can validate their own work; the platform repo's
+# checks/tests/*.sh need both (issue #71). Pinned by version and verified by
+# SHA-256 because it's a raw binary download.
+ARG YQ_VERSION=v4.53.3
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+         amd64) yq_sha256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4" ;; \
+         arm64) yq_sha256="578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea" ;; \
+         *) echo "unsupported arch for yq: $arch" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${arch}" -o /usr/local/bin/yq \
+    && echo "${yq_sha256}  /usr/local/bin/yq" | sha256sum -c - \
+    && chmod 0755 /usr/local/bin/yq \
+    && yq --version
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
Closes #71

## What

Add `jq` and `yq` to `Dockerfile.agent` so repos whose in-container checks parse JSON/YAML can validate their own work. Observed on the first autonomous runs (platform#8/#16, 2026-08-04): `checks/tests/*.sh` failed with a missing `jq` binary in the agent sandbox — correctly identified as pre-existing on the base image.

- **jq** — added to the existing apt install list (Debian package, single layer, no extra `apt-get update`).
- **yq** — installed as a pinned, checksum-verified standalone binary (`ARG YQ_VERSION=v4.53.3`), arch-aware (`amd64`/`arm64` via `dpkg --print-architecture`), with a `yq --version` build-time smoke test that fails the build on a bad download.

## Decisions worth a reviewer's eye

- **Which `yq`.** I installed **mikefarah's `yq`** (the Go, YAML-native binary — the de-facto "yq"), not the Debian/apt `yq` package (kislyuk's Python jq-wrapper, a different tool with jq-style syntax). The ticket says *"yq, same family, used by review-gates tooling"*; "same family" is slightly ambiguous, and the review-gates tooling that would confirm the expected variant lives in the platform repo, which is outside this session's allowed directories, so I could not verify it directly. mikefarah is the overwhelmingly dominant "yq" and the natural choice for reading YAML config like `review-gates.yaml`. If the platform's `checks/tests/*.sh` actually invoke yq with jq-style filters (the kislyuk variant), swap the install for `apt-get install -y yq` — flagging so the human gate can confirm against the real platform scripts.
- **Pinning + checksum.** Not literally requested, but `yq` isn't in apt, so a raw binary download needs an integrity story; `sha256sum -c -` fails closed. This is deliberately stricter than the surrounding image (`pnpm@latest`, unversioned `claude-code`) — I left those alone as out of scope.

## Validation

- `pnpm test` → 396 passed (change touches no TS; confirms no regression).
- `pnpm lint` → 16 pre-existing errors only (known baseline on `main`); this change adds none (Dockerfiles aren't linted).
- Verified the pinned `yq` download: `v4.53.3` `yq_linux_amd64` returns HTTP 200 and its SHA-256 matches the hardcoded amd64 value exactly (`fa52a4e7…eded4`). arm64 hash taken from the same official `checksums` file.
- Docker build could not be run here (permission-gated in this non-interactive session), so the full image build is unverified end-to-end; the download + checksum + arch logic was validated on the host and the Dockerfile's own `yq --version` step is the build-time guard.

## Self-review

Ran `/code-review` against `origin/main` with issue #71 as the spec (two parallel axes). Standards: clean. Spec: literal request fully met; the only substantive finding is the yq-variant risk documented above.

Gated path (`Dockerfile.agent` → `agent-sandbox`), so this will get `human-signoff` and won't auto-merge — appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
