### PR TITLE
Pin and configure the agent model per pass kind (implement / review / triage)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@
 # Option 2: ANTHROPIC_API_KEY=sk-ant-...
 # (The legacy mounted ~/.claude credentials file was removed in issue #28.)
 
+# Agent model (issue #74). Pin the model the CLI runs so it is explicit and
+# recorded on the run row, instead of silently following the account default.
+# AGENT_MODEL is the base — implement, repair and interactive passes use it.
+# Review and triage are read-heavy and cheaper-tier candidates: give them their
+# own override, else they fall back to AGENT_MODEL. Leave all three unset to
+# keep the pre-#74 behaviour (no --model; the CLI resolves the account default).
+# AGENT_MODEL=claude-opus-4-8
+# AGENT_MODEL_REVIEW=claude-sonnet-5
+# AGENT_MODEL_TRIAGE=claude-haiku-4-5-20251001
+
 # Optional
 GIT_USER_NAME=Interlude Agent
 GIT_USER_EMAIL=agent@interlude.dev

--- a/drizzle/0014_run_model.sql
+++ b/drizzle/0014_run_model.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `model` text;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,573 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dc647566-b660-4991-8c45-b5253c441e1c",
+  "prevId": "f7ab1732-f364-45e0-8eb7-2093fd129af9",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "integration_count": {
+          "name": "integration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triage_result": {
+          "name": "triage_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786406400000,
       "tag": "0013_integration_count",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1786492800000,
+      "tag": "0014_run_model",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/__tests__/runs-ledger.test.ts
+++ b/src/db/__tests__/runs-ledger.test.ts
@@ -40,6 +40,7 @@ describe("runs ledger schema (fresh from-migrations DB)", () => {
     expect(run.blockedQuestion).toBeNull();
     expect(run.pullRequestNumber).toBeNull();
     expect(run.pullRequestUrl).toBeNull();
+    expect(run.model).toBeNull();
     expect(run.startedAt).toBeNull();
     expect(run.finishedAt).toBeNull();
   });
@@ -65,6 +66,7 @@ describe("runs ledger schema (fresh from-migrations DB)", () => {
         reviewCycleCount: 2,
         interruptionCount: 1,
         blockedQuestion: "Which auth provider should this target?",
+        model: "claude-opus-4-8",
         claimedAt,
         startedAt,
         finishedAt,
@@ -78,6 +80,7 @@ describe("runs ledger schema (fresh from-migrations DB)", () => {
     expect(run.totalCostUsd).toBe(13.37);
     expect(run.gateCategories).toEqual(["migrations", "auth"]);
     expect(run.reviewVerdict).toBe("request-changes");
+    expect(run.model).toBe("claude-opus-4-8");
     expect(run.claimedAt).toEqual(claimedAt);
     expect(run.startedAt).toEqual(startedAt);
     expect(run.finishedAt).toEqual(finishedAt);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -48,6 +48,10 @@ export const runs = sqliteTable("runs", {
   budgetUsd: real("budget_usd").notNull(),
   // Per-exec turn limit from a ticket's max-turns directive; null = default
   maxTurns: int("max_turns"),
+  // Model the implement pass ran on (issue #74), so this run's spend is
+  // interpretable against its tier. Set when the implement pass starts; null
+  // means AGENT_MODEL was unset and the CLI resolved the account default.
+  model: text("model"),
   totalCostUsd: real("total_cost_usd").notNull().default(0),
   pullRequestNumber: int("pull_request_number"),
   pullRequestUrl: text("pull_request_url"),

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { resolveAgentModel, type AppConfig, type AgentPassKind } from "../config";
+
+/** A config carrying only the fields resolveAgentModel reads. */
+function cfg(models: {
+  agentModel: string | null;
+  agentModelReview?: string | null;
+  agentModelTriage?: string | null;
+}): AppConfig {
+  return {
+    agentModel: models.agentModel,
+    agentModelReview: models.agentModelReview ?? null,
+    agentModelTriage: models.agentModelTriage ?? null,
+  } as AppConfig;
+}
+
+describe("resolveAgentModel (issue #74)", () => {
+  it("returns null for every kind when nothing is configured (CLI default)", () => {
+    const c = cfg({ agentModel: null });
+    for (const kind of [
+      "interactive",
+      "implement",
+      "review",
+      "triage",
+      "repair",
+    ] as AgentPassKind[]) {
+      expect(resolveAgentModel(kind, c)).toBeNull();
+    }
+  });
+
+  it("uses AGENT_MODEL as the base for implement, repair and interactive", () => {
+    const c = cfg({ agentModel: "base-model" });
+    expect(resolveAgentModel("implement", c)).toBe("base-model");
+    expect(resolveAgentModel("repair", c)).toBe("base-model");
+    expect(resolveAgentModel("interactive", c)).toBe("base-model");
+  });
+
+  it("falls back review and triage to the base when they have no override", () => {
+    const c = cfg({ agentModel: "base-model" });
+    expect(resolveAgentModel("review", c)).toBe("base-model");
+    expect(resolveAgentModel("triage", c)).toBe("base-model");
+  });
+
+  it("prefers the cheaper-tier overrides for review and triage", () => {
+    const c = cfg({
+      agentModel: "base-model",
+      agentModelReview: "review-model",
+      agentModelTriage: "triage-model",
+    });
+    expect(resolveAgentModel("review", c)).toBe("review-model");
+    expect(resolveAgentModel("triage", c)).toBe("triage-model");
+    // Overrides never leak onto the base kinds.
+    expect(resolveAgentModel("implement", c)).toBe("base-model");
+  });
+
+  it("lets an override apply even when the base is unset", () => {
+    const c = cfg({ agentModel: null, agentModelReview: "review-model" });
+    expect(resolveAgentModel("review", c)).toBe("review-model");
+    expect(resolveAgentModel("triage", c)).toBeNull();
+    expect(resolveAgentModel("implement", c)).toBeNull();
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,17 @@ export interface AppConfig {
   anthropicApiKey: string | null;
   /** Long-lived OAuth token from `claude setup-token`, injected into agent containers at exec — the sole subscription-auth path (#28) */
   claudeCodeOauthToken: string | null;
+  /**
+   * Model the CLI runs for an implement pass — and the base every other pass
+   * falls back to (issue #74). Null = pass no `--model`, letting the CLI
+   * resolve the account default (the pre-#74 behaviour), so leaving it unset
+   * changes nothing. Set it to pin the tier and record it on the run row.
+   */
+  agentModel: string | null;
+  /** Optional cheaper-tier override for review passes; falls back to `agentModel` */
+  agentModelReview: string | null;
+  /** Optional cheaper-tier override for triage passes; falls back to `agentModel` */
+  agentModelTriage: string | null;
   gitUserName: string;
   gitUserEmail: string;
   keepContainers: boolean;
@@ -78,6 +89,9 @@ export function getConfig(): AppConfig {
   _config = {
     anthropicApiKey,
     claudeCodeOauthToken,
+    agentModel: process.env.AGENT_MODEL ?? null,
+    agentModelReview: process.env.AGENT_MODEL_REVIEW ?? null,
+    agentModelTriage: process.env.AGENT_MODEL_TRIAGE ?? null,
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",
     gitUserEmail: process.env.GIT_USER_EMAIL ?? "agent@interlude.dev",
     keepContainers: process.env.KEEP_CONTAINERS === "true",
@@ -114,6 +128,35 @@ export function getConfig(): AppConfig {
 /** Clear cached config so next getConfig() re-reads from env/filesystem */
 export function resetConfig(): void {
   _config = null;
+}
+
+/** The pass kinds a Claude turn can run as (mirrors `tasks.kind`). */
+export type AgentPassKind =
+  | "interactive"
+  | "implement"
+  | "review"
+  | "triage"
+  | "repair";
+
+/**
+ * Which model a turn of the given kind runs on (issue #74). `AGENT_MODEL` is
+ * the base — implement, repair and interactive passes all use it; review and
+ * triage may name a cheaper tier via `AGENT_MODEL_REVIEW` / `AGENT_MODEL_TRIAGE`
+ * and otherwise fall back to it. Null means "pass no `--model`": the CLI
+ * resolves the account default, exactly as before this was configurable.
+ */
+export function resolveAgentModel(
+  kind: AgentPassKind,
+  config: AppConfig = getConfig()
+): string | null {
+  switch (kind) {
+    case "review":
+      return config.agentModelReview ?? config.agentModel;
+    case "triage":
+      return config.agentModelTriage ?? config.agentModel;
+    default:
+      return config.agentModel;
+  }
 }
 
 // Platform repo URL — cloned into agent containers for estate-wide context

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -3,6 +3,7 @@ import {
   buildSetupScript,
   buildPushScript,
   buildTurnEnv,
+  buildClaudeTurnCommand,
   createWorkspaceContainer,
 } from "../container-manager";
 
@@ -36,6 +37,8 @@ vi.mock("@/lib/config", () => ({
     claudeCodeOauthToken: "sk-ant-oat01-test",
     gitUserName: "Interlude Agent",
     gitUserEmail: "agent@interlude.dev",
+    maxTurns: 50,
+    maxBudgetUsd: 20,
   }),
 }));
 
@@ -133,6 +136,45 @@ describe("buildPushScript", () => {
   it("does not embed any token", () => {
     expect(script).not.toContain("GIT_TOKEN");
     expect(script).not.toContain("GIT_AUTH_TOKEN");
+  });
+});
+
+describe("buildClaudeTurnCommand", () => {
+  it("runs Claude with stream-json and the configured limits", () => {
+    const cmd = buildClaudeTurnCommand({});
+    expect(cmd).toContain("cd /workspace/repo");
+    expect(cmd).toContain("claude -p");
+    expect(cmd).toContain("--output-format stream-json");
+    expect(cmd).toContain("--max-turns 50");
+    expect(cmd).toContain("--max-budget-usd 20");
+  });
+
+  it("prefers per-exec budget and turn overrides over the config defaults", () => {
+    const cmd = buildClaudeTurnCommand({ maxTurns: 100, maxBudgetUsd: 75 });
+    expect(cmd).toContain("--max-turns 100");
+    expect(cmd).toContain("--max-budget-usd 75");
+  });
+
+  it("omits --model entirely when no model is pinned (issue #74)", () => {
+    expect(buildClaudeTurnCommand({ model: null })).not.toContain("--model");
+    expect(buildClaudeTurnCommand({})).not.toContain("--model");
+  });
+
+  it("pins the model with --model when one is resolved (issue #74)", () => {
+    const cmd = buildClaudeTurnCommand({ model: "claude-sonnet-5" });
+    expect(cmd).toContain("--model 'claude-sonnet-5'");
+  });
+
+  it("single-quotes the model so glob metacharacters stay literal (issue #74)", () => {
+    const cmd = buildClaudeTurnCommand({ model: "claude-opus-4-8[1m]" });
+    // The bracketed id must not be exposed to bash pathname expansion.
+    expect(cmd).toContain("--model 'claude-opus-4-8[1m]'");
+    expect(cmd).not.toContain("--model claude-opus-4-8[1m]");
+  });
+
+  it("appends --resume for a follow-up turn", () => {
+    const cmd = buildClaudeTurnCommand({ sessionId: "sess-123" });
+    expect(cmd).toContain("--resume sess-123");
   });
 });
 

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -104,6 +104,11 @@ export interface TurnOptions {
   maxBudgetUsd?: number;
   /** Per-exec turn-limit override (a ticket's max-turns directive) */
   maxTurns?: number;
+  /**
+   * Model to pin for this turn, resolved from the task's kind (issue #74).
+   * Null/undefined passes no `--model` — the CLI resolves the account default.
+   */
+  model?: string | null;
 }
 
 export interface RunningContainer {
@@ -244,11 +249,17 @@ export async function execSetup(
   }
 }
 
-export async function execClaudeTurn(
-  options: TurnOptions
-): Promise<{ stream: NodeJS.ReadableStream; exec: Docker.Exec }> {
+/**
+ * Build the bash command a Claude turn runs inside the container. Pure and
+ * exported so the flag wiring — notably the per-kind `--model` pin (issue #74)
+ * — is unit-testable without a live Docker exec. `maxTurns`/`maxBudgetUsd`
+ * fall back to the configured defaults; `model`, when set, pins the tier and
+ * is otherwise omitted so the CLI resolves the account default as before.
+ */
+export function buildClaudeTurnCommand(
+  options: Pick<TurnOptions, "sessionId" | "maxBudgetUsd" | "maxTurns" | "model">
+): string {
   const config = getConfig();
-  const docker = getDocker();
 
   const cmdParts = [
     "cd /workspace/repo",
@@ -266,13 +277,28 @@ export async function execClaudeTurn(
     String(options.maxBudgetUsd ?? config.maxBudgetUsd),
   ];
 
+  if (options.model) {
+    // Single-quote the model id: real ids can carry shell glob metacharacters
+    // (e.g. "claude-opus-4-8[1m]"), and this runs under `bash -c`.
+    cmdParts.push("--model", `'${options.model}'`);
+  }
+
   if (options.sessionId) {
     cmdParts.push("--resume", options.sessionId);
   }
 
+  return cmdParts.join(" ");
+}
+
+export async function execClaudeTurn(
+  options: TurnOptions
+): Promise<{ stream: NodeJS.ReadableStream; exec: Docker.Exec }> {
+  const docker = getDocker();
+  const config = getConfig();
+
   const token = await getInstallationToken();
   const exec = await options.container.exec({
-    Cmd: ["bash", "-c", cmdParts.join(" ")],
+    Cmd: ["bash", "-c", buildClaudeTurnCommand(options)],
     Env: buildTurnEnv({
       prompt: options.prompt,
       gitAuthToken: token,

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -22,7 +22,7 @@ import {
   TRIAGE_MAX_TURNS,
 } from "./autonomy/budgets";
 import { scanPorts } from "./port-scanner";
-import { getConfig } from "../config";
+import { getConfig, resolveAgentModel, type AgentPassKind } from "../config";
 import { getDocker } from "../docker/client";
 import { commentOnIssue, parseIssueRef } from "../github/issues";
 import { parseRepoFromGitUrl } from "../github/repo";
@@ -36,7 +36,7 @@ const activeTasks = new Map<
   {
     container: RunningContainer;
     state: "setup" | "running" | "idle" | "completing";
-    kind: "interactive" | "implement" | "review" | "triage" | "repair";
+    kind: AgentPassKind;
   }
 >();
 
@@ -117,6 +117,11 @@ export async function startTask(taskId: string): Promise<void> {
     ? db.select().from(runs).where(eq(runs.id, task.runId)).get()
     : undefined;
 
+  // The model this pass runs on, pinned by kind (issue #74). Passed to every
+  // turn as `--model` and recorded on the run row below so spend is
+  // interpretable against the tier it was earned on.
+  const passModel = resolveAgentModel(task.kind);
+
   // Update task status
   updateTask(taskId, { status: "running", branch, containerStatus: "setup" });
   insertSystemMessage(taskId, `Provisioning agent container...${proj.dopplerToken ? " (Doppler configured)" : ""}`);
@@ -126,8 +131,16 @@ export async function startTask(taskId: string): Promise<void> {
   // pass keeps the run's original startedAt so the dashboard's elapsed time
   // does not jump when a conflict is repaired mid-life.
   if (run && isImplementShaped) {
+    // Record the implement-pass model on the run — it drives the bulk of a
+    // run's spend, so it is the tier the run's cost should be read against. A
+    // review pass writes its own (cheaper) model nowhere on the run, leaving
+    // this value stable. Repair keeps the original implement model (same tier).
     db.update(runs)
-      .set({ status: "implementing", startedAt: run.startedAt ?? new Date() })
+      .set({
+        status: "implementing",
+        startedAt: run.startedAt ?? new Date(),
+        model: passModel,
+      })
       .where(eq(runs.id, run.id))
       .run();
   }
@@ -213,6 +226,7 @@ export async function startTask(taskId: string): Promise<void> {
           ? undefined
           : (run?.maxTurns ?? undefined),
       captureRaw: isReviewPass || isTriagePass,
+      model: passModel,
     });
 
     // Store session ID and cost
@@ -353,7 +367,12 @@ async function runTurn(
   running: RunningContainer,
   prompt: string,
   sessionId?: string,
-  opts?: { maxBudgetUsd?: number; maxTurns?: number; captureRaw?: boolean }
+  opts?: {
+    maxBudgetUsd?: number;
+    maxTurns?: number;
+    captureRaw?: boolean;
+    model?: string | null;
+  }
 ): Promise<TurnResult & { raw?: string }> {
   const handler = createOutputHandler(taskId);
   const rawChunks: Buffer[] = [];
@@ -364,6 +383,7 @@ async function runTurn(
     sessionId,
     maxBudgetUsd: opts?.maxBudgetUsd,
     maxTurns: opts?.maxTurns,
+    model: opts?.model,
   });
 
   // Race: wait for the exec stream to close OR the "result" event from Claude.
@@ -487,6 +507,7 @@ export async function processQueuedMessages(
       {
         maxBudgetUsd: run ? run.budgetUsd - (task.totalCostUsd ?? 0) : undefined,
         maxTurns: run?.maxTurns ?? undefined,
+        model: resolveAgentModel(task.kind),
       }
     );
 


### PR DESCRIPTION
Closes #74

## What & why

`execClaudeTurn` passed no `--model`, so agent containers ran whatever the CLI resolved as the account default — an implicit dependency that could change under us, unrecorded in the run ledger. This pins the model per pass kind and records it so spend is interpretable.

## Changes

- **Config** (`src/lib/config.ts`): `AGENT_MODEL` is the base tier (implement, repair, interactive); optional `AGENT_MODEL_REVIEW` / `AGENT_MODEL_TRIAGE` name cheaper tiers for those read-heavy passes and fall back to the base. `resolveAgentModel(kind)` centralises the mapping. **Leaving all three unset passes no `--model` and preserves the pre-#74 CLI-default behaviour**, so this is a safe no-op until an operator opts in.
- **`--model` wiring** (`src/lib/docker/container-manager.ts`, `src/lib/orchestrator/turn-manager.ts`): the model is resolved from `task.kind` and threaded through every turn — the initial pass and follow-up turns. The command construction is extracted into a pure, exported `buildClaudeTurnCommand` so the flag wiring is unit-testable without a live Docker exec. The model id is single-quoted (real ids can carry glob metacharacters, e.g. `claude-opus-4-8[1m]`, and this runs under `bash -c`).
- **Recording** (`src/db/schema.ts` + migration `drizzle/0014_run_model.sql`): new nullable `runs.model` column, written when an implement-shaped pass starts.
- **Docs**: `.env.example` documents the three new vars.
- **Tests**: resolver matrix (`src/lib/__tests__/config.test.ts`), command-builder `--model` on/off + quoting (`container-manager.test.ts`), and `runs.model` round-trip in the ledger test.

## Self-review (ran `/code-review` vs `origin/main`, #74 as spec)

Both axes came back clean of hard violations. Two notes I want to be explicit about rather than silently ignore:

- **Recorded model vs blended run spend (Spec axis).** `runs.model` records the *implement* tier, but `runs.totalCostUsd` also folds in review-pass spend, which may run on a cheaper `AGENT_MODEL_REVIEW` tier. I kept recording on the run row exactly as the ticket scoped it ("record the model used on the run row"): the implement pass dominates a run's spend, review carries its own separate ~$5 budget, and the review tier is a known global config value — so the run stays interpretable without a second per-task column (which would be out of scope). A code comment at the write site documents this.
- **`kind` union duplication (Standards axis).** I introduced `AgentPassKind` as the canonical pass-kind type and pointed `turn-manager`'s active-task map at it. The same inline union still exists in `src/lib/fleet/fleet-view.ts`; I left that untouched to keep this PR scoped to the model change — consolidating it there is a worthwhile standalone follow-up.

## Validation

- `pnpm test` — 407 passing (includes the new migration applied from scratch and on a populated previous-head DB)
- `pnpm build` — compiles/typechecks clean
- `pnpm lint` — no new findings; the 16 pre-existing baseline errors (in `preview-pane.tsx` / `output-parser.test.ts`) are untouched
