### PR TITLE
Preflight: App-inaccessible repo reports as 'no branch protection' instead of naming the real problem

### DIFF
--- a/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
@@ -4,13 +4,16 @@ import { HUMAN_SIGNOFF_LABEL } from "../gates";
 
 // The check-to-status/reason mapping is the whole safety property here: a repo
 // is only "passing" when every requirement holds, and a failure must name what
-// is missing. computePreflight's GitHub I/O is a thin shell over this; the pure
-// function is what gets exhaustive coverage.
+// is missing — and, per issue #70, name the *right* missing thing: an
+// unreachable repo, a forbidden endpoint, and an unprotected branch are three
+// different owner actions. computePreflight's GitHub I/O is a thin shell over
+// this; the pure function is what gets exhaustive coverage.
 
 const ALL_PASS: PreflightChecks = {
   repoConfigured: true,
-  appInstalled: true,
-  branchProtected: true,
+  repo: "owner/repo",
+  repoAccessible: true,
+  branchProtection: "protected",
   reviewerIsCollaborator: true,
   signoffLabelExists: true,
 };
@@ -25,8 +28,9 @@ describe("evaluatePreflight", () => {
     // is the prerequisite that actually blocks the owner.
     const result = evaluatePreflight({
       repoConfigured: false,
-      appInstalled: false,
-      branchProtected: false,
+      repo: "",
+      repoAccessible: false,
+      branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
     });
@@ -34,21 +38,35 @@ describe("evaluatePreflight", () => {
     expect(result.reason).toBe("no GitHub repo configured (needs gitUrl and githubRepo)");
   });
 
-  it("short-circuits to the App reason when the App is missing", () => {
-    // Prerequisite failure hides the checks that couldn't be gathered anyway.
+  it("short-circuits to the access reason, naming the repo, when unreachable", () => {
+    // Prerequisite failure hides the checks that couldn't be gathered anyway,
+    // and names the repo so the owner knows which installation to fix.
     const result = evaluatePreflight({
       ...ALL_PASS,
-      appInstalled: false,
-      branchProtected: false,
+      repoAccessible: false,
+      branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
     });
     expect(result.status).toBe("failing");
-    expect(result.reason).toBe("the GitHub App is not installed on the repository");
+    expect(result.reason).toBe(
+      "the GitHub App cannot access owner/repo — add it to the App installation"
+    );
   });
 
-  it("names a missing branch protection", () => {
-    const result = evaluatePreflight({ ...ALL_PASS, branchProtected: false });
+  it("names the missing App permission when branch protection is forbidden", () => {
+    // A 403 on getBranchProtection is a permission gap, not a missing
+    // protection — the owner grants "Administration: read", they don't add a
+    // protection rule (issue #70).
+    const result = evaluatePreflight({ ...ALL_PASS, branchProtection: "forbidden" });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe(
+      'the GitHub App lacks the "Administration: read" permission needed to read branch protection on owner/repo'
+    );
+  });
+
+  it("names a genuinely unprotected default branch", () => {
+    const result = evaluatePreflight({ ...ALL_PASS, branchProtection: "unprotected" });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe("no branch protection on the default branch");
   });
@@ -68,14 +86,29 @@ describe("evaluatePreflight", () => {
   it("accumulates every independent failure into one reason", () => {
     const result = evaluatePreflight({
       repoConfigured: true,
-      appInstalled: true,
-      branchProtected: false,
+      repo: "owner/repo",
+      repoAccessible: true,
+      branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
     });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe(
       `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing`
+    );
+  });
+
+  it("accumulates a forbidden protection probe alongside other failures", () => {
+    // The forbidden reason participates in accumulation just like the others,
+    // so a repo with several gaps still lists them all in one pass.
+    const result = evaluatePreflight({
+      ...ALL_PASS,
+      branchProtection: "forbidden",
+      signoffLabelExists: false,
+    });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe(
+      `the GitHub App lacks the "Administration: read" permission needed to read branch protection on owner/repo; the "${HUMAN_SIGNOFF_LABEL}" label is missing`
     );
   });
 });

--- a/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
@@ -12,7 +12,7 @@ import { HUMAN_SIGNOFF_LABEL } from "../gates";
 const ALL_PASS: PreflightChecks = {
   repoConfigured: true,
   repo: "owner/repo",
-  repoAccessible: true,
+  repoAccess: "accessible",
   branchProtection: "protected",
   reviewerIsCollaborator: true,
   signoffLabelExists: true,
@@ -29,7 +29,7 @@ describe("evaluatePreflight", () => {
     const result = evaluatePreflight({
       repoConfigured: false,
       repo: "",
-      repoAccessible: false,
+      repoAccess: "inaccessible",
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
@@ -38,12 +38,12 @@ describe("evaluatePreflight", () => {
     expect(result.reason).toBe("no GitHub repo configured (needs gitUrl and githubRepo)");
   });
 
-  it("short-circuits to the access reason, naming the repo, when unreachable", () => {
+  it("short-circuits to the access reason, naming the repo, when inaccessible", () => {
     // Prerequisite failure hides the checks that couldn't be gathered anyway,
     // and names the repo so the owner knows which installation to fix.
     const result = evaluatePreflight({
       ...ALL_PASS,
-      repoAccessible: false,
+      repoAccess: "inaccessible",
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
@@ -52,6 +52,20 @@ describe("evaluatePreflight", () => {
     expect(result.reason).toBe(
       "the GitHub App cannot access owner/repo — add it to the App installation"
     );
+  });
+
+  it("reports a transient reach failure as retryable, not as a config fix", () => {
+    // A network/500 blip must not tell the owner to touch an installation that
+    // isn't broken — it's a different reason from `inaccessible` (issue #70).
+    const result = evaluatePreflight({
+      ...ALL_PASS,
+      repoAccess: "unreachable",
+      branchProtection: "unprotected",
+      reviewerIsCollaborator: false,
+      signoffLabelExists: false,
+    });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe("could not reach GitHub to check owner/repo — will retry");
   });
 
   it("names the missing App permission when branch protection is forbidden", () => {
@@ -87,7 +101,7 @@ describe("evaluatePreflight", () => {
     const result = evaluatePreflight({
       repoConfigured: true,
       repo: "owner/repo",
-      repoAccessible: true,
+      repoAccess: "accessible",
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -7,9 +7,16 @@
  *
  * The mapping from check results to a stored status + human-readable reason is
  * a pure function (`evaluatePreflight`) so it is table-testable with no I/O;
- * `computePreflight` is the thin GitHub-API shell that gathers the booleans.
+ * `computePreflight` is the thin GitHub-API shell that gathers the results.
  * The reason names what is missing, which is what the dashboard's "needs you"
  * bucket and the pause log surface to the owner.
+ *
+ * The access-failure path is deliberately fine-grained (issue #70): a repo the
+ * App can't reach, an endpoint the App lacks permission for, and a genuinely
+ * unprotected branch are three different owner actions, so they get three
+ * distinct reasons rather than collapsing into a misleading "no branch
+ * protection". We also never guess the default branch — a wrong guess would
+ * 404 the protection probe and mis-report a configured repo as unprotected.
  */
 
 import { db } from "@/db";
@@ -20,14 +27,25 @@ import { getConfig } from "../../config";
 import { getOctokit, isGitHubConfigured } from "../../github/client";
 import { HUMAN_SIGNOFF_LABEL } from "./gates";
 
-/** Every requirement autonomy depends on, as plain booleans. */
+/**
+ * Outcome of probing branch protection on the default branch. Three states
+ * because each needs a different owner action: turn protection on
+ * (`unprotected`), grant the App the "Administration: read" permission the
+ * endpoint requires (`forbidden`, a 403 "Resource not accessible by
+ * integration"), or nothing (`protected`).
+ */
+export type BranchProtectionStatus = "protected" | "unprotected" | "forbidden";
+
+/** Every requirement autonomy depends on. */
 export interface PreflightChecks {
   /** Project has both a gitUrl and an owner/repo githubRepo */
   repoConfigured: boolean;
-  /** The GitHub App installation can see the repo (clone/push + API) */
-  appInstalled: boolean;
-  /** The default branch has branch protection */
-  branchProtected: boolean;
+  /** owner/repo, named in the reasons that must point the owner at a repo */
+  repo: string;
+  /** The App installation can reach the repo at all (repos.get succeeds) */
+  repoAccessible: boolean;
+  /** Branch-protection probe on the repo's real default branch */
+  branchProtection: BranchProtectionStatus;
   /** The reviewer machine account is a collaborator on the repo */
   reviewerIsCollaborator: boolean;
   /** The `human-signoff` label exists so gated PRs can be labelled */
@@ -45,21 +63,32 @@ const PREFLIGHT_REFRESH_INTERVAL_MS = 5 * 60_000;
 
 /**
  * Pure: map gathered checks to a stored status and a reason that names what is
- * missing. `repoConfigured` and `appInstalled` are prerequisites — without them
- * the remaining checks cannot even be gathered, so a failure there short-circuits
- * to a single clear reason rather than a misleading list. The other three are
- * independent and accumulate, so the owner fixes everything in one pass.
+ * missing. `repoConfigured` and `repoAccessible` are prerequisites — without
+ * them the remaining checks cannot even be gathered, so a failure there
+ * short-circuits to a single clear reason rather than a misleading list. The
+ * rest are independent and accumulate, so the owner fixes everything in one
+ * pass. A branch-protection `forbidden` names the missing App permission, not a
+ * missing protection, so the owner grants the right thing (issue #70).
  */
 export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
   if (!checks.repoConfigured) {
     return { status: "failing", reason: "no GitHub repo configured (needs gitUrl and githubRepo)" };
   }
-  if (!checks.appInstalled) {
-    return { status: "failing", reason: "the GitHub App is not installed on the repository" };
+  if (!checks.repoAccessible) {
+    return {
+      status: "failing",
+      reason: `the GitHub App cannot access ${checks.repo} — add it to the App installation`,
+    };
   }
 
   const missing: string[] = [];
-  if (!checks.branchProtected) missing.push("no branch protection on the default branch");
+  if (checks.branchProtection === "forbidden") {
+    missing.push(
+      `the GitHub App lacks the "Administration: read" permission needed to read branch protection on ${checks.repo}`
+    );
+  } else if (checks.branchProtection === "unprotected") {
+    missing.push("no branch protection on the default branch");
+  }
   if (!checks.reviewerIsCollaborator) missing.push("the reviewer account is not a collaborator");
   if (!checks.signoffLabelExists) missing.push(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
 
@@ -70,9 +99,19 @@ export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
 
 type ProjectRow = typeof projects.$inferSelect;
 
+/** The HTTP status of an Octokit error, if it carries one. */
+function httpStatus(err: unknown): number | undefined {
+  return typeof err === "object" && err !== null ? (err as { status?: number }).status : undefined;
+}
+
 /** Did an Octokit call fail with an HTTP 404 (as opposed to a real error)? */
 function isNotFound(err: unknown): boolean {
-  return typeof err === "object" && err !== null && (err as { status?: number }).status === 404;
+  return httpStatus(err) === 404;
+}
+
+/** A 403 — the App is authenticated but lacks the permission for this endpoint. */
+function isForbidden(err: unknown): boolean {
+  return httpStatus(err) === 403;
 }
 
 /**
@@ -90,6 +129,31 @@ async function apiCheck(label: string, fn: () => Promise<unknown>): Promise<bool
       console.error(`[preflight] ${label} failed:`, err);
     }
     return false;
+  }
+}
+
+/**
+ * Probe branch protection on the default branch, keeping the three outcomes
+ * distinct (issue #70): a 403 "Resource not accessible by integration" means
+ * the App is missing the "Administration: read" permission the endpoint needs,
+ * a 404 means the branch is genuinely unprotected, and success means protected.
+ * Any other (transient) error fails closed as `unprotected` but is logged, so
+ * the "no branch protection" reason it produces can be traced to its real cause.
+ */
+async function probeBranchProtection(
+  octokit: Awaited<ReturnType<typeof getOctokit>>,
+  owner: string,
+  repo: string,
+  branch: string
+): Promise<BranchProtectionStatus> {
+  try {
+    await octokit.rest.repos.getBranchProtection({ owner, repo, branch });
+    return "protected";
+  } catch (err) {
+    if (isForbidden(err)) return "forbidden";
+    if (isNotFound(err)) return "unprotected";
+    console.error(`[preflight] getBranchProtection ${owner}/${repo} failed:`, err);
+    return "unprotected";
   }
 }
 
@@ -121,11 +185,11 @@ async function isReviewerCollaborator(
 }
 
 /**
- * Gather the four autonomy checks for a project via the GitHub API. Every
- * network failure resolves a check to `false` (fail closed) so an unreachable
- * or under-permissioned repo never reads as ready. Downstream checks are only
- * attempted once the App is confirmed installed, since they all need the
- * installation token.
+ * Gather the autonomy checks for a project via the GitHub API. Every network
+ * failure resolves to the fail-closed value so an unreachable or
+ * under-permissioned repo never reads as ready. Downstream checks are only
+ * attempted once the App is confirmed to reach the repo, since they all need
+ * the installation token — and only against the repo's real default branch.
  */
 export async function computePreflight(project: ProjectRow): Promise<PreflightResult> {
   const repoConfigured = !!project.gitUrl && !!project.githubRepo;
@@ -133,53 +197,59 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
   if (!repoConfigured || !owner || !repo) {
     return evaluatePreflight({
       repoConfigured: false,
-      appInstalled: false,
-      branchProtected: false,
+      repo: project.githubRepo ?? "",
+      repoAccessible: false,
+      branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
     });
   }
 
+  const repoLabel = `${owner}/${repo}`;
   const octokit = await getOctokit();
 
-  // App installed — a repos.get through the installation token both proves the
-  // App can see the repo and yields the default branch for the next check.
-  let appInstalled = false;
-  let defaultBranch = "main";
+  // A repos.get through the installation token both proves the App can reach the
+  // repo and yields the *real* default branch. We never fall back to a guessed
+  // "main": a wrong guess would 404 the protection probe on a non-default branch
+  // and mis-report a configured repo as unprotected (issue #70).
+  let repoAccessible = false;
+  let defaultBranch: string | null = null;
   try {
     const { data } = await octokit.rest.repos.get({ owner, repo });
-    appInstalled = true;
+    repoAccessible = true;
     defaultBranch = data.default_branch;
   } catch (err) {
-    if (!isNotFound(err)) {
-      console.error(`[preflight] repos.get failed for ${owner}/${repo}:`, err);
+    // A 404/403 both mean the installation can't see this repo — a first-class,
+    // short-circuiting failure. Anything else is a real fault worth logging.
+    if (!isNotFound(err) && !isForbidden(err)) {
+      console.error(`[preflight] repos.get failed for ${repoLabel}:`, err);
     }
   }
 
-  if (!appInstalled) {
+  if (!repoAccessible || !defaultBranch) {
     return evaluatePreflight({
       repoConfigured: true,
-      appInstalled: false,
-      branchProtected: false,
+      repo: repoLabel,
+      repoAccessible: false,
+      branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
     });
   }
 
-  const [branchProtected, reviewerIsCollaborator, signoffLabelExists] = await Promise.all([
-    apiCheck(`getBranchProtection ${owner}/${repo}`, () =>
-      octokit.rest.repos.getBranchProtection({ owner, repo, branch: defaultBranch })
-    ),
+  const [branchProtection, reviewerIsCollaborator, signoffLabelExists] = await Promise.all([
+    probeBranchProtection(octokit, owner, repo, defaultBranch),
     isReviewerCollaborator(octokit, owner, repo),
-    apiCheck(`getLabel ${owner}/${repo}`, () =>
+    apiCheck(`getLabel ${repoLabel}`, () =>
       octokit.rest.issues.getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
     ),
   ]);
 
   return evaluatePreflight({
     repoConfigured: true,
-    appInstalled: true,
-    branchProtected,
+    repo: repoLabel,
+    repoAccessible: true,
+    branchProtection,
     reviewerIsCollaborator,
     signoffLabelExists,
   });

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -36,14 +36,24 @@ import { HUMAN_SIGNOFF_LABEL } from "./gates";
  */
 export type BranchProtectionStatus = "protected" | "unprotected" | "forbidden";
 
+/**
+ * Outcome of the App-token repos.get. `inaccessible` (a 404/403) is the repo
+ * not being in the App installation — a specific owner fix — whereas
+ * `unreachable` is a transient/unknown GitHub error that no config change would
+ * fix. Keeping them distinct stops a network blip from telling the owner to
+ * "add the repo to the installation" when nothing is actually misconfigured
+ * (issue #70).
+ */
+export type RepoAccess = "accessible" | "inaccessible" | "unreachable";
+
 /** Every requirement autonomy depends on. */
 export interface PreflightChecks {
   /** Project has both a gitUrl and an owner/repo githubRepo */
   repoConfigured: boolean;
   /** owner/repo, named in the reasons that must point the owner at a repo */
   repo: string;
-  /** The App installation can reach the repo at all (repos.get succeeds) */
-  repoAccessible: boolean;
+  /** Whether the App installation can reach the repo at all (repos.get) */
+  repoAccess: RepoAccess;
   /** Branch-protection probe on the repo's real default branch */
   branchProtection: BranchProtectionStatus;
   /** The reviewer machine account is a collaborator on the repo */
@@ -63,8 +73,8 @@ const PREFLIGHT_REFRESH_INTERVAL_MS = 5 * 60_000;
 
 /**
  * Pure: map gathered checks to a stored status and a reason that names what is
- * missing. `repoConfigured` and `repoAccessible` are prerequisites — without
- * them the remaining checks cannot even be gathered, so a failure there
+ * missing. `repoConfigured` and `repoAccess` are prerequisites — without them
+ * the remaining checks cannot even be gathered, so a failure there
  * short-circuits to a single clear reason rather than a misleading list. The
  * rest are independent and accumulate, so the owner fixes everything in one
  * pass. A branch-protection `forbidden` names the missing App permission, not a
@@ -74,10 +84,16 @@ export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
   if (!checks.repoConfigured) {
     return { status: "failing", reason: "no GitHub repo configured (needs gitUrl and githubRepo)" };
   }
-  if (!checks.repoAccessible) {
+  if (checks.repoAccess === "inaccessible") {
     return {
       status: "failing",
       reason: `the GitHub App cannot access ${checks.repo} — add it to the App installation`,
+    };
+  }
+  if (checks.repoAccess === "unreachable") {
+    return {
+      status: "failing",
+      reason: `could not reach GitHub to check ${checks.repo} — will retry`,
     };
   }
 
@@ -198,7 +214,7 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
     return evaluatePreflight({
       repoConfigured: false,
       repo: project.githubRepo ?? "",
-      repoAccessible: false,
+      repoAccess: "inaccessible",
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
@@ -212,25 +228,31 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
   // repo and yields the *real* default branch. We never fall back to a guessed
   // "main": a wrong guess would 404 the protection probe on a non-default branch
   // and mis-report a configured repo as unprotected (issue #70).
-  let repoAccessible = false;
+  let repoAccess: RepoAccess = "unreachable";
   let defaultBranch: string | null = null;
   try {
     const { data } = await octokit.rest.repos.get({ owner, repo });
-    repoAccessible = true;
+    repoAccess = "accessible";
     defaultBranch = data.default_branch;
   } catch (err) {
-    // A 404/403 both mean the installation can't see this repo — a first-class,
-    // short-circuiting failure. Anything else is a real fault worth logging.
-    if (!isNotFound(err) && !isForbidden(err)) {
+    // A 404/403 both mean the installation can't see this repo — a specific,
+    // actionable owner fix. Anything else is a transient/unknown fault: fail
+    // closed as `unreachable` (not `inaccessible`) so we don't tell the owner to
+    // touch an installation that isn't broken, and log it (issue #70).
+    if (isNotFound(err) || isForbidden(err)) {
+      repoAccess = "inaccessible";
+    } else {
       console.error(`[preflight] repos.get failed for ${repoLabel}:`, err);
     }
   }
 
-  if (!repoAccessible || !defaultBranch) {
+  // A null default branch means repos.get did not succeed, so repoAccess already
+  // carries why (inaccessible or unreachable) and the dependent checks are skipped.
+  if (defaultBranch === null) {
     return evaluatePreflight({
       repoConfigured: true,
       repo: repoLabel,
-      repoAccessible: false,
+      repoAccess,
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
@@ -248,7 +270,7 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
   return evaluatePreflight({
     repoConfigured: true,
     repo: repoLabel,
-    repoAccessible: true,
+    repoAccess: "accessible",
     branchProtection,
     reviewerIsCollaborator,
     signoffLabelExists,


### PR DESCRIPTION
Closes #70

## What was wrong

`computePreflight` collapsed three distinct owner actions into one misleading `no branch protection on the default branch` reason:

1. It fell back to `defaultBranch = "main"` when `repos.get` failed, so a repo whose real default is `master` would 404 the protection probe and read as unprotected.
2. `getBranchProtection`'s **403** `Resource not accessible by integration` (the App missing the `Administration: read` permission — which interlude's App never needed before preflight existed) was flattened into the same `false` as a genuine **404** `Branch not protected`.

Both come together in the pilot symptom: the App *could* see `lennons301/platform` (collaborator/label reads passed), but the branch-protection probe 403'd on a missing permission, and the "main" guess would also have mis-probed had access been the issue.

## The fix (body + the owner's "Diagnosis correction" comment)

- **Never guess the default branch.** `defaultBranch` starts `null` and is only set from a successful `repos.get`; a null branch short-circuits to a named access reason instead of probing a guessed branch.
- **Three-state `BranchProtectionStatus`** (`protected` / `unprotected` / `forbidden`). `probeBranchProtection` maps `403 → forbidden` and `404 → unprotected`, and `evaluatePreflight` names the missing **App permission** distinctly from a missing **protection rule** — three different owner actions, per the correction's (a)/(b)/(c).
- **The access reason names `owner/repo`** so the owner knows which installation to fix.
- `evaluatePreflight` stays pure and table-tested; new cases cover the `forbidden` and access reasons.

## Beyond the ticket (from self-review, disclosed)

Self-review (`/code-review` vs `origin/main`) surfaced that the `repos.get` catch applied the "add it to the App installation" reason to **every** failure, including a transient 500/network blip — telling the owner to fix an installation that isn't broken. That is the same misattribution class the ticket targets, so I fixed it: repo access is a three-state `RepoAccess` (`accessible` / `inaccessible` / `unreachable`) — only a 404/403 is `inaccessible` (the actionable installation fix); anything else is `unreachable` with a retryable reason, mirroring how `probeBranchProtection` already separates its 403/404 from transient faults. Both still fail closed.

## Review findings I considered and did not act on

- **Duplicated fail-closed literals** across the short-circuit returns — pre-existing house style (the old `appInstalled: false` blocks had the same shape); each explicit literal is clearer at its call site than a positional helper. Left as-is.
- **`repo: string` living inside `PreflightChecks`** — it's context for the reason string rather than a check, but keeping it in the struct lets `evaluatePreflight` stay pure and table-testable with a single object. Defensible; left as-is.

## Validation

- `pnpm test` — 399 passed (21 files), including 11 `evaluatePreflight` cases.
- `npx tsc --noEmit` — clean.
- `pnpm lint` on the two changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
