### PR TITLE
fix(docker): ship triage-pass.md in the app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ node_modules
 docs
 !docs/agents/workflows
 !docs/agents/review-pass.md
+!docs/agents/triage-pass.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=build /app/custom-server.js ./custom-server.js
 COPY --from=build /app/docs/agents/workflows ./docs/agents/workflows
 # Vendored reviewer definition, injected into review pass prompts (issue #17)
 COPY --from=build /app/docs/agents/review-pass.md ./docs/agents/review-pass.md
+COPY --from=build /app/docs/agents/triage-pass.md ./docs/agents/triage-pass.md
 
 # Install the Doppler CLI so the app boots via `doppler run`, pulling orchestrator
 # secrets from the Doppler `interlude/prd` config at runtime. DOPPLER_TOKEN (a prd


### PR DESCRIPTION
First live triage attempt (platform#18 opened → Platform project enabled → triage queued) failed loudly: `triage pass definition not found — expected /app/docs/agents/triage-pass.md`.

#23 added the prompt-injected triage definition but never packaged it into the image; #17 did both steps for `review-pass.md`, which is why review passes are unaffected. Two lines: `.dockerignore` re-include + Dockerfile COPY, exactly mirroring review-pass.md's.

Third packaging/gating miss for a prompt-injected doc (#45's gate line, #55's gate line, now this) — the retro convention of one wholesale-gated, wholesale-copied directory for injected content is overdue; this PR stays minimal.

Fail-loud worked: no spend, clear reason, caught at queue time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)