### PR TITLE
Rebuild agent image when Dockerfile.agent changes (#78)

### DIFF
--- a/src/lib/docker/__tests__/image-builder.test.ts
+++ b/src/lib/docker/__tests__/image-builder.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const HASH_LABEL = "co.interlude.agent-dockerfile-sha256";
+
+// The hash the real Dockerfile.agent on disk should produce — computed exactly
+// the way the module under test does, so the "fresh" cases carry a genuinely
+// matching label rather than a hard-coded string that could drift.
+const realHash = createHash("sha256")
+  .update(readFileSync(path.join(process.cwd(), "Dockerfile.agent")))
+  .digest("hex");
+
+// Mutable fake Docker, reconfigured per test via `state.inspect`.
+const { state, buildImageSpy } = vi.hoisted(() => ({
+  state: {
+    inspect: async (): Promise<unknown> => ({ Config: { Labels: {} } }),
+  },
+  buildImageSpy: vi.fn(async (): Promise<unknown> => "BUILD_STREAM"),
+}));
+
+vi.mock("@/lib/docker/client", () => ({
+  getDocker: () => ({
+    getImage: () => ({ inspect: () => state.inspect() }),
+    buildImage: buildImageSpy,
+    modem: {
+      followProgress: (_stream: unknown, onFinished: (err: unknown) => void) =>
+        onFinished(null),
+    },
+  }),
+}));
+
+// Keep the build hermetic: no real tar stream off the filesystem. The Dockerfile
+// is still read for real by node:fs/promises, which is what yields realHash.
+vi.mock("tar-fs", () => ({ pack: () => "TAR_STREAM" }));
+
+import { ensureImage, buildImage, imageExists } from "../image-builder";
+
+const missing = async (): Promise<never> => {
+  throw new Error("no such image: interlude-agent:latest");
+};
+
+beforeEach(() => {
+  buildImageSpy.mockClear();
+  state.inspect = async () => ({ Config: { Labels: {} } });
+});
+
+describe("ensureImage", () => {
+  it("builds when the image is missing", async () => {
+    state.inspect = missing;
+    await ensureImage();
+    expect(buildImageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds when the stamped Dockerfile hash no longer matches (issue #78)", async () => {
+    state.inspect = async () => ({ Config: { Labels: { [HASH_LABEL]: "stale" } } });
+    await ensureImage();
+    expect(buildImageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the build when the stamped hash matches the on-disk Dockerfile", async () => {
+    state.inspect = async () => ({ Config: { Labels: { [HASH_LABEL]: realHash } } });
+    await ensureImage();
+    expect(buildImageSpy).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds an existing but unstamped image (manual/old build)", async () => {
+    state.inspect = async () => ({ Config: { Labels: null } });
+    await ensureImage();
+    expect(buildImageSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildImage", () => {
+  it("stamps the current Dockerfile hash as a label on interlude-agent:latest", async () => {
+    await buildImage();
+    expect(buildImageSpy).toHaveBeenCalledTimes(1);
+    // `.mock.calls` carries no argument types for a no-arg fake, so reach the
+    // build options through `unknown`.
+    const [, opts] = buildImageSpy.mock.calls[0] as unknown as [
+      unknown,
+      { t: string; dockerfile: string; labels: Record<string, string> },
+    ];
+    expect(opts.t).toBe("interlude-agent:latest");
+    expect(opts.dockerfile).toBe("Dockerfile.agent");
+    expect(opts.labels[HASH_LABEL]).toBe(realHash);
+  });
+});
+
+describe("imageExists", () => {
+  it("is true when the image inspects and false when it does not", async () => {
+    state.inspect = async () => ({ Config: { Labels: {} } });
+    expect(await imageExists()).toBe(true);
+    state.inspect = missing;
+    expect(await imageExists()).toBe(false);
+  });
+});

--- a/src/lib/docker/image-builder.ts
+++ b/src/lib/docker/image-builder.ts
@@ -1,37 +1,69 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type Docker from "dockerode";
 import { pack } from "tar-fs";
 import { getDocker } from "./client";
 
 const IMAGE_NAME = "interlude-agent";
 const IMAGE_TAG = "latest";
+const DOCKERFILE = "Dockerfile.agent";
+
+// The image is stamped with the SHA-256 of the Dockerfile.agent it was built
+// from. ensureImage rebuilds when the on-disk Dockerfile no longer matches,
+// instead of trusting that `interlude-agent:latest` merely existing means it is
+// current — the existence-only check let merged Dockerfile changes (jq/yq in
+// #71) silently never reach running agents (issue #78).
+const DOCKERFILE_HASH_LABEL = "co.interlude.agent-dockerfile-sha256";
 
 export function getImageName(): string {
   return `${IMAGE_NAME}:${IMAGE_TAG}`;
 }
 
-export async function imageExists(): Promise<boolean> {
-  const docker = getDocker();
+/** SHA-256 of the Dockerfile.agent currently on disk (the build context). */
+async function dockerfileHash(): Promise<string> {
+  const contents = await readFile(path.join(process.cwd(), DOCKERFILE));
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+/** Inspect the agent image, or null if it does not exist. */
+async function inspectImage(): Promise<Docker.ImageInspectInfo | null> {
   try {
-    await docker.getImage(getImageName()).inspect();
-    return true;
+    return await getDocker().getImage(getImageName()).inspect();
   } catch {
-    return false;
+    return null;
   }
+}
+
+/**
+ * The Dockerfile hash `interlude-agent:latest` was built from, or null if the
+ * image is absent or unstamped (built before this label existed, or by a manual
+ * `docker build`). A null means "not known to be current" → rebuild.
+ */
+async function builtDockerfileHash(): Promise<string | null> {
+  const info = await inspectImage();
+  return info?.Config?.Labels?.[DOCKERFILE_HASH_LABEL] ?? null;
+}
+
+export async function imageExists(): Promise<boolean> {
+  return (await inspectImage()) !== null;
 }
 
 export async function buildImage(
   onProgress?: (message: string) => void
 ): Promise<void> {
   const docker = getDocker();
+  const hash = await dockerfileHash();
 
   const tarStream = pack(process.cwd(), {
-    entries: ["Dockerfile.agent"],
+    entries: [DOCKERFILE],
   });
 
   const stream = await docker.buildImage(tarStream, {
     t: getImageName(),
-    dockerfile: "Dockerfile.agent",
-    // Note: to pick up Dockerfile.agent changes, delete the image first:
-    // docker rmi interlude-agent:latest
+    dockerfile: DOCKERFILE,
+    // Stamp the source hash so ensureImage can detect a stale image later.
+    labels: { [DOCKERFILE_HASH_LABEL]: hash },
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -47,9 +79,19 @@ export async function buildImage(
   });
 }
 
+/**
+ * Build the agent image if it is missing or stale. Stale = the running
+ * `interlude-agent:latest` was built from a different Dockerfile.agent than the
+ * one on disk (issue #78). Docker's layer cache makes an unchanged rebuild
+ * cheap; a genuine Dockerfile change rebuilds so agents pick it up.
+ */
 export async function ensureImage(
   onProgress?: (message: string) => void
 ): Promise<void> {
-  if (await imageExists()) return;
+  const [current, built] = await Promise.all([
+    dockerfileHash(),
+    builtDockerfileHash(),
+  ]);
+  if (built === current) return;
   await buildImage(onProgress);
 }


### PR DESCRIPTION
Closes #78

## Problem

`ensureImage` (`src/lib/docker/image-builder.ts`) only checked whether `interlude-agent:latest` **existed**, returning early if it did. So a merged `Dockerfile.agent` change — e.g. the jq/yq addition in #71 — never reached running agents until someone rebuilt the image by hand on the VPS.

## Fix (Option 2 from the issue)

The issue offered two fixes and preferred **Option 2** — *"`ensureImage` tags the image with a content hash of `Dockerfile.agent` and rebuilds on mismatch (self-contained, no CI coupling)"* — as "more in keeping with the orchestrator owning its own runtime". This implements exactly that:

- `buildImage` stamps the image with a label (`co.interlude.agent-dockerfile-sha256`) carrying the SHA-256 of the `Dockerfile.agent` it was built from.
- `ensureImage` compares the on-disk Dockerfile hash against the stamped one and rebuilds unless they match — so it also rebuilds when the image is **missing** or **unstamped** (an old image, or the manual `docker build` hotfix). That one-time re-stamp is cheap thanks to Docker's layer cache.
- No deploy-workflow / CI changes — the orchestrator owns its runtime freshness.

Hashing only `Dockerfile.agent` is sufficient because the build context is that file alone (`entries: ["Dockerfile.agent"]`), so the hash captures the entire build input. (Inherent to Option 2: a `node:22-slim` upstream digest change under the same tag won't trigger a rebuild — out of scope for a content-hash-of-the-Dockerfile approach.)

## Tests

New `src/lib/docker/__tests__/image-builder.test.ts` exercises the missing / stale-label / matching / unstamped branches of `ensureImage`, and asserts `buildImage` stamps the current hash. Full suite green (413 tests); lint clean on changed files.

## Notes for the reviewer

- **Gated path.** This touches `src/lib/docker/**`, gated `agent-sandbox` in `docs/agents/review-gates.yaml`, so it must get `human-signoff` and must not be auto-merged.
- **Self-review (rework-avoidance, not the gate).** I ran `/code-review` against `origin/main`. Spec axis: faithful implementation of the preferred option, nothing missing. Standards axis raised two judgement calls: (1) duplicated inspect shape between `imageExists` and `builtDockerfileHash` — **acted on**, extracted a shared `inspectImage()` helper; (2) `Dockerfile.agent` is read/hashed twice on the build path (`ensureImage` then `buildImage`) — **left as-is** on purpose, so exported `buildImage` stays self-contained; the extra read is negligible.
- **Pre-existing, out of scope:** `ensureImage` runs per container-create, so concurrent callers on a stale hash could briefly overlap rebuilds against the same tag. This race predates the change and only appears in the short window after a Dockerfile change before the first rebuild re-stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)