### PR TITLE
Ticket directive: per-ticket model override, clamped to an allowlist

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -210,6 +210,17 @@ pass normally but then forces `human-signoff` regardless of gate matches, carryi
 `<text>` as the note for what needs your decision. Use it for
 agent-doable-but-risky work you want to eyeball before merge.
 
+### Model tier (`model:`)
+
+A `model: <alias>` directive in a ticket's Workflow section picks the tier the
+implement (and repair) pass runs on — `opus`, `sonnet` or `haiku`. Use it to
+match spend to the work: a mechanical rename doesn't need Opus; a gnarly
+refactor can ask for it explicitly. The set is a fixed allowlist (issue text is
+semi-trusted, so it may only select a tier, never name an arbitrary model); an
+unrecognised value is ignored — the run keeps its default model and the claim
+comment notes that it was dropped. Review and triage passes keep their own
+(cheaper) tier regardless. The chosen tier is recorded on the run.
+
 ### Capacity / slots
 
 Slots derive at boot from the Docker daemon's CPU and memory

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,8 +49,10 @@ export const runs = sqliteTable("runs", {
   // Per-exec turn limit from a ticket's max-turns directive; null = default
   maxTurns: int("max_turns"),
   // Model the implement pass ran on (issue #74), so this run's spend is
-  // interpretable against its tier. Set when the implement pass starts; null
-  // means AGENT_MODEL was unset and the CLI resolved the account default.
+  // interpretable against its tier. A ticket's `model:` directive (issue #80)
+  // pins it from claim time; otherwise it is set when the implement pass
+  // starts. Null means AGENT_MODEL was unset (no directive) and the CLI
+  // resolved the account default.
   model: text("model"),
   totalCostUsd: real("total_cost_usd").notNull().default(0),
   pullRequestNumber: int("pull_request_number"),

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -60,3 +60,33 @@ describe("resolveAgentModel (issue #74)", () => {
     expect(resolveAgentModel("implement", c)).toBeNull();
   });
 });
+
+describe("resolveAgentModel ticket model override (issue #80)", () => {
+  it("lets a ticket model override the base for the work-carrying kinds", () => {
+    const c = cfg({ agentModel: "base-model" });
+    expect(resolveAgentModel("implement", c, "opus")).toBe("opus");
+    expect(resolveAgentModel("repair", c, "opus")).toBe("opus");
+    expect(resolveAgentModel("interactive", c, "opus")).toBe("opus");
+  });
+
+  it("overrides even when no base model is configured", () => {
+    const c = cfg({ agentModel: null });
+    expect(resolveAgentModel("implement", c, "sonnet")).toBe("sonnet");
+  });
+
+  it("never lets a ticket model touch the reviewer's or triage's tier", () => {
+    const c = cfg({
+      agentModel: "base-model",
+      agentModelReview: "review-model",
+      agentModelTriage: "triage-model",
+    });
+    expect(resolveAgentModel("review", c, "opus")).toBe("review-model");
+    expect(resolveAgentModel("triage", c, "opus")).toBe("triage-model");
+  });
+
+  it("falls back to the base when the override is null", () => {
+    const c = cfg({ agentModel: "base-model" });
+    expect(resolveAgentModel("implement", c, null)).toBe("base-model");
+    expect(resolveAgentModel("implement", c)).toBe("base-model");
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -144,10 +144,17 @@ export type AgentPassKind =
  * triage may name a cheaper tier via `AGENT_MODEL_REVIEW` / `AGENT_MODEL_TRIAGE`
  * and otherwise fall back to it. Null means "pass no `--model`": the CLI
  * resolves the account default, exactly as before this was configurable.
+ *
+ * `ticketModel` is a per-ticket `model:` directive (issue #80), already
+ * clamped to the allowlist by the directive parser. When present it overrides
+ * the base for the pass kinds that carry a run's tier — implement, repair and
+ * interactive. Review and triage keep their own (cheaper) tier regardless: the
+ * ticket chooses the model its *work* runs on, not the reviewer's.
  */
 export function resolveAgentModel(
   kind: AgentPassKind,
-  config: AppConfig = getConfig()
+  config: AppConfig = getConfig(),
+  ticketModel: string | null = null
 ): string | null {
   switch (kind) {
     case "review":
@@ -155,7 +162,7 @@ export function resolveAgentModel(
     case "triage":
       return config.agentModelTriage ?? config.agentModel;
     default:
-      return config.agentModel;
+      return ticketModel ?? config.agentModel;
   }
 }
 

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -205,6 +205,7 @@ describe("decideNext — claiming", () => {
         budgetUsd: 20,
         checkpoint: null,
         maxTurns: null,
+        model: null,
         workflow: { source: "default" },
       },
     ]);
@@ -255,6 +256,18 @@ describe("decideNext — claiming", () => {
     const actions = decideNext(makeSnapshot());
 
     expect(claims(actions)[0]).toMatchObject({ budgetUsd: 20, maxTurns: null });
+  });
+
+  it("carries an allowlisted model directive, and ignores an unknown one", () => {
+    const honoured = "Spec.\n\n## Workflow\n\nmodel: haiku\n";
+    expect(
+      claims(decideNext(makeSnapshot({ candidates: [makeCandidate({ body: honoured })] })))[0]
+    ).toMatchObject({ model: "haiku" });
+
+    const ignored = "Spec.\n\n## Workflow\n\nmodel: gpt-4\n";
+    expect(
+      claims(decideNext(makeSnapshot({ candidates: [makeCandidate({ body: ignored })] })))[0]
+    ).toMatchObject({ model: null });
   });
 
   it("claims a checkpoint ticket as a supervised run, carrying the checkpoint text", () => {

--- a/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseBlockedByRefs,
   parseTicketDirectives,
+  rawModelDirective,
   selectWorkflow,
   shouldCreateInteractiveTask,
 } from "../ticket";
@@ -13,6 +14,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      model: null,
     });
   });
 
@@ -54,7 +56,7 @@ describe("parseTicketDirectives", () => {
     expect(parseTicketDirectives("## Workflow\nworkflow: tdd").workflow).toBe("tdd");
   });
 
-  it("parses all four directives together, bulleted and case-insensitive", () => {
+  it("parses all directives together, bulleted and case-insensitive", () => {
     const body = [
       "## Workflow",
       "",
@@ -62,12 +64,14 @@ describe("parseTicketDirectives", () => {
       "- MAX-TURNS: 60",
       "- checkpoint: pause before deploy",
       "- workflow: tdd",
+      "- Model: Opus",
     ].join("\n");
     expect(parseTicketDirectives(body)).toEqual({
       budget: 30,
       maxTurns: 60,
       checkpoint: "pause before deploy",
       workflow: "tdd",
+      model: "opus",
     });
   });
 
@@ -93,6 +97,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      model: null,
     });
   });
 
@@ -119,6 +124,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      model: null,
     });
   });
 
@@ -151,7 +157,46 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      model: null,
     });
+  });
+
+  it("parses a model directive and lowercases the alias", () => {
+    expect(parseTicketDirectives("## Workflow\nmodel: sonnet").model).toBe("sonnet");
+    expect(parseTicketDirectives("## Workflow\nmodel: HAIKU").model).toBe("haiku");
+  });
+
+  it("ignores a model value that is not on the allowlist", () => {
+    // A semi-trusted body may pick a tier, never name an arbitrary model.
+    expect(parseTicketDirectives("## Workflow\nmodel: gpt-4").model).toBeNull();
+    expect(
+      parseTicketDirectives("## Workflow\nmodel: claude-opus-4-8[1m]").model
+    ).toBeNull();
+    expect(parseTicketDirectives("## Workflow\nmodel:").model).toBeNull();
+  });
+
+  it("takes the first model when the directive repeats", () => {
+    expect(parseTicketDirectives("## Workflow\nmodel: opus\nmodel: haiku").model).toBe(
+      "opus"
+    );
+  });
+});
+
+describe("rawModelDirective", () => {
+  it("returns the raw requested value, un-clamped", () => {
+    expect(rawModelDirective("## Workflow\nmodel: gpt-4")).toBe("gpt-4");
+    expect(rawModelDirective("## Workflow\nModel: Opus")).toBe("Opus");
+  });
+
+  it("returns null when there is no model directive or it is bare", () => {
+    expect(rawModelDirective("## Workflow\nbudget: $30")).toBeNull();
+    expect(rawModelDirective("## Workflow\nmodel:")).toBeNull();
+    expect(rawModelDirective("Just prose.\nmodel: opus")).toBeNull();
+  });
+
+  it("ignores a model directive inside a code fence", () => {
+    const body = ["## Workflow", "```", "model: opus", "```"].join("\n");
+    expect(rawModelDirective(body)).toBeNull();
   });
 });
 

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -16,6 +16,14 @@ export const MAX_ATTEMPT_BUDGET_USD = 75;
  * per-exec turn limit to (the default is the orchestrator's MAX_TURNS). */
 export const MAX_TURNS_CEILING = 100;
 
+/** Model tiers a ticket's `model:` directive may select (issue #80). A ticket
+ * body is semi-trusted input, so it may only choose from this fixed set of
+ * aliases — never name an arbitrary model string — mirroring the reasoning
+ * behind the $75 budget clamp. The alias reaches the CLI as `--model`; an
+ * unrecognised value is ignored (the run keeps its default model), never
+ * fatal. Clamped in the directive parser, resolved through `resolveAgentModel`. */
+export const ALLOWED_TICKET_MODELS = ["opus", "sonnet", "haiku"] as const;
+
 /** Budget for one review pass — its own allowance, separate from the
  * implement attempt's, so reviewing never eats into a fix-up's headroom. */
 export const DEFAULT_REVIEW_BUDGET_USD = 5;

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -296,6 +296,9 @@ export type Action =
       checkpoint: string | null;
       /** Per-exec turn limit from a max-turns directive; null = the default */
       maxTurns: number | null;
+      /** Model alias from a `model:` directive (issue #80), clamped to the
+       * allowlist; null = the configured default. Recorded on runs.model. */
+      model: string | null;
       workflow: WorkflowSelection;
     }
   | { type: "pausePickup"; reason: PauseReason; detail?: string }
@@ -991,6 +994,7 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       budgetUsd: directives.budget ?? snapshot.attemptBudgetUsd,
       checkpoint: directives.checkpoint,
       maxTurns: directives.maxTurns,
+      model: directives.model,
       workflow: selectWorkflow(candidate.body, candidate.labels),
     });
   }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -70,6 +70,7 @@ import {
   READY_FOR_HUMAN_LABEL,
   labelNames,
   parseBlockedByRefs,
+  rawModelDirective,
 } from "./ticket";
 import {
   buildImplementPrompt,
@@ -1861,6 +1862,10 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
         budgetUsd: action.budgetUsd,
         checkpoint: action.checkpoint,
         maxTurns: action.maxTurns,
+        // A `model:` directive (already allowlist-clamped) pins the tier from
+        // claim time (issue #80); the implement pass resolves through the same
+        // value and records it here. Null keeps the configured default.
+        model: action.model,
         claimedAt: now,
         finishedAt: failure ? now : null,
         failureReason: failure ? `failed before start: ${failure}` : null,
@@ -1895,10 +1900,28 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
     console.log(
       `[autonomy] Claimed ${action.issueRef} (attempt ${action.attempt}) -> task ${taskId}`
     );
+
+    // Note the model directive on the run's issue thread (issue #80): the
+    // honoured tier when one was picked, or an unrecognised request that was
+    // ignored — never silently swallowed, never fatal.
+    let modelNote = "";
+    if (action.model) {
+      modelNote = `\n\nModel: \`${action.model}\` (ticket directive).`;
+    } else {
+      const rawModel = rawModelDirective(action.issueBody);
+      if (rawModel) {
+        console.warn(
+          `[autonomy] Ignoring unrecognised model directive "${rawModel}" on ` +
+            `${action.issueRef} — using the default model`
+        );
+        modelNote = `\n\nModel directive \`${rawModel}\` not recognised — running on the default model.`;
+      }
+    }
+
     const domain = process.env.DOMAIN ?? "interludes.co.uk";
     await commentOnIssue(
       action.issueRef,
-      `Claimed by Interlude — attempt ${action.attempt}/${MAX_ATTEMPTS}.\n\n` +
+      `Claimed by Interlude — attempt ${action.attempt}/${MAX_ATTEMPTS}.${modelNote}\n\n` +
         `[View task](https://${domain}/tasks/${taskId})`
     );
   } finally {

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -3,7 +3,11 @@
  * Nothing here performs I/O; the sweep gathers, these functions interpret.
  */
 
-import { MAX_ATTEMPT_BUDGET_USD, MAX_TURNS_CEILING } from "./budgets";
+import {
+  ALLOWED_TICKET_MODELS,
+  MAX_ATTEMPT_BUDGET_USD,
+  MAX_TURNS_CEILING,
+} from "./budgets";
 
 export const ARMING_LABEL = "ready-for-agent";
 export const READY_FOR_HUMAN_LABEL = "ready-for-human";
@@ -35,6 +39,9 @@ const WORKFLOW_LABEL_PREFIX = "workflow:";
 /** A `## Workflow` (or `### Workflow`) section heading in a ticket body. */
 const WORKFLOW_SECTION = /^#{2,3}\s+Workflow\s*$/im;
 
+/** A whole-line `key: value` directive (optionally bulleted, case-insensitive). */
+const DIRECTIVE_LINE = /^\s*(?:[-*]\s+)?([a-z-]+)\s*:\s*(.*)$/i;
+
 /**
  * The bounded directive set a ticket may carry in its Workflow section.
  * Null means "not specified — use the default". Directives can only move
@@ -51,6 +58,10 @@ export interface TicketDirectives {
   checkpoint: string | null;
   /** Named workflow — informational in v1 (selectWorkflow drives the pass) */
   workflow: string | null;
+  /** Model alias to run the pass on (issue #80), clamped to
+   * ALLOWED_TICKET_MODELS. Null means unspecified or unrecognised — the run
+   * keeps its default model; a bad value never fails the run. */
+  model: string | null;
 }
 
 /**
@@ -65,10 +76,11 @@ export function parseTicketDirectives(body: string): TicketDirectives {
     maxTurns: null,
     checkpoint: null,
     workflow: null,
+    model: null,
   };
 
   for (const line of workflowSectionLines(body)) {
-    const match = line.match(/^\s*(?:[-*]\s+)?([a-z-]+)\s*:\s*(.*)$/i);
+    const match = line.match(DIRECTIVE_LINE);
     if (!match) continue;
     const key = match[1].toLowerCase();
     const value = match[2].trim();
@@ -84,10 +96,31 @@ export function parseTicketDirectives(body: string): TicketDirectives {
       directives.checkpoint = value;
     } else if (key === "workflow" && directives.workflow === null) {
       directives.workflow = value;
+    } else if (key === "model" && directives.model === null) {
+      // Clamp to the allowlist: a semi-trusted body may pick a tier, never
+      // name an arbitrary model. An unrecognised value stays null (ignored).
+      const alias = value.toLowerCase();
+      if ((ALLOWED_TICKET_MODELS as readonly string[]).includes(alias)) {
+        directives.model = alias;
+      }
     }
   }
 
   return directives;
+}
+
+/**
+ * The raw (un-clamped) value of a `model:` directive in the Workflow section,
+ * if present — for surfacing an *ignored* request an operator otherwise
+ * couldn't see. Parsing for use goes through parseTicketDirectives, which
+ * clamps to the allowlist; this only reports what was asked for.
+ */
+export function rawModelDirective(body: string): string | null {
+  for (const line of workflowSectionLines(body)) {
+    const match = line.match(DIRECTIVE_LINE);
+    if (match && match[1].toLowerCase() === "model") return match[2].trim() || null;
+  }
+  return null;
 }
 
 /**

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -117,10 +117,12 @@ export async function startTask(taskId: string): Promise<void> {
     ? db.select().from(runs).where(eq(runs.id, task.runId)).get()
     : undefined;
 
-  // The model this pass runs on, pinned by kind (issue #74). Passed to every
-  // turn as `--model` and recorded on the run row below so spend is
-  // interpretable against the tier it was earned on.
-  const passModel = resolveAgentModel(task.kind);
+  // The model this pass runs on, pinned by kind (issue #74) and, for an
+  // implement-shaped or interactive pass, overridable by the run's `model:`
+  // directive (issue #80). Passed to every turn as `--model` and recorded on
+  // the run row below so spend is interpretable against the tier it was
+  // earned on.
+  const passModel = resolveAgentModel(task.kind, getConfig(), run?.model ?? null);
 
   // Update task status
   updateTask(taskId, { status: "running", branch, containerStatus: "setup" });
@@ -507,7 +509,7 @@ export async function processQueuedMessages(
       {
         maxBudgetUsd: run ? run.budgetUsd - (task.totalCostUsd ?? 0) : undefined,
         maxTurns: run?.maxTurns ?? undefined,
-        model: resolveAgentModel(task.kind),
+        model: resolveAgentModel(task.kind, config, run?.model ?? null),
       }
     );
 


### PR DESCRIPTION
Closes #80

## What

Adds a per-ticket `model:` directive so scoping can choose the tier a ticket's work runs on — a mechanical rename needn't burn Opus; a gnarly refactor can ask for it explicitly.

- **Parse + clamp (trusted code).** `model:` joins `TicketDirectives`, parsed from the Workflow section exactly like `budget:`/`max-turns:` and clamped to `ALLOWED_TICKET_MODELS` (`opus`/`sonnet`/`haiku`) in `budgets.ts`. A semi-trusted body may only *select a tier*, never name an arbitrary model — mirroring the $75 budget clamp. Only the clamped value ever reaches `--model`.
- **Resolved through the `resolveAgentModel` seam.** It gains an already-clamped `ticketModel` override that wins for the run-carrying kinds (implement, repair, interactive). **Review and triage keep their own cheaper tier regardless** — the ticket chooses the model its *work* runs on, not the reviewer's.
- **Recorded on `runs.model`** (as with #74): pinned at claim time from the directive, then resolved consistently when the implement pass starts.
- **Never fails on a bad directive.** An unrecognised value is ignored (the run keeps its default) and *noted*, not swallowed — a `console.warn` plus a line on the claim comment. The honoured tier is likewise noted on the claim comment.

## Tests

- `ticket.test.ts` — parses/lowercases an allowlisted alias, ignores non-allowlisted/arbitrary model ids and a bare `model:`, first-wins on repeat, code-fence exclusion; plus `rawModelDirective`.
- `config.test.ts` — override applies to implement/repair/interactive, never to review/triage, falls back to base when null.
- `decide.test.ts` — the claim action carries an allowlisted model and drops an unknown one.

Full suite green (421 passed); lint clean on changed files. (The two pre-existing `tsc` errors in `container-manager.test.ts` are on `main`, untouched here.)

## Notes for the reviewer

- **"note it in the run" — interpretation.** There's no free-text notes column on `runs`, and adding one for this edge case felt like more than the ticket asked. I read "the run" as its lifecycle record: an ignored directive is surfaced on the run's issue thread (the claim comment) and in the orchestrator log, while `runs.model` truthfully records the model actually used (the default). Happy to persist it on a column instead if you'd prefer.
- **Minor scope beyond the strict ask** (both benign): the *honoured* case also gets a claim-comment note (operator visibility), and `interactive` shares the override branch — harmless, since interactive tasks have no run, and it preserves #74's kind grouping.
- Self-reviewed via `/code-review` against `origin/main`; the documentation-drift finding is addressed (runbook now documents the directive). The `rawModelDirective`/parser duplication is a deliberate, documented raw-vs-clamped split kept small by sharing the `DIRECTIVE_LINE` regex and `workflowSectionLines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
