### PR TITLE
Reasoning effort per pass kind — investigate the CLI mechanism and wire it like AGENT_MODEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,18 @@
 # AGENT_MODEL_REVIEW=claude-sonnet-5
 # AGENT_MODEL_TRIAGE=claude-haiku-4-5-20251001
 
+# Agent reasoning effort (issue #81) — the other half of the cost/quality dial
+# alongside the model. The headless CLI takes a `--effort` flag; valid levels
+# are low | medium | high | xhigh | max. AGENT_EFFORT is the base — implement,
+# repair and interactive passes use it. Review and triage are read-heavy and
+# cheaper-effort candidates: give them their own override, else they fall back
+# to AGENT_EFFORT. Leave all three unset to keep the CLI's own default (no
+# --effort). A ticket's `effort:` directive (Workflow section) may pin a work
+# pass to one of the levels above.
+# AGENT_EFFORT=high
+# AGENT_EFFORT_REVIEW=medium
+# AGENT_EFFORT_TRIAGE=low
+
 # Optional
 GIT_USER_NAME=Interlude Agent
 GIT_USER_EMAIL=agent@interlude.dev

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -210,6 +210,21 @@ pass normally but then forces `human-signoff` regardless of gate matches, carryi
 `<text>` as the note for what needs your decision. Use it for
 agent-doable-but-risky work you want to eyeball before merge.
 
+### Reasoning effort (`effort:`)
+
+`AGENT_EFFORT` pins the CLI's reasoning depth (the `--effort` flag) for the
+implement/repair/interactive passes, the other half of the cost/quality dial
+alongside `AGENT_MODEL`; `AGENT_EFFORT_REVIEW` / `AGENT_EFFORT_TRIAGE` give the
+read-heavy passes a lower level. Valid levels: `low`, `medium`, `high`, `xhigh`,
+`max`. Leave them unset and the CLI keeps its own default (no `--effort`).
+
+A ticket's `effort: <level>` directive in the Workflow section raises (or lowers)
+a single run's work-pass effort — a hard ticket can ask for `max`, a trivial one
+for `low`. It is clamped to the levels above (an unrecognised value is ignored
+and noted on the issue, never fatal) and changes only the depth the ticket's
+*work* runs at — the reviewer's effort is unaffected. The honoured level is
+recorded on the run row so spend reads against the depth it was earned at.
+
 ### Capacity / slots
 
 Slots derive at boot from the Docker daemon's CPU and memory

--- a/drizzle/0015_run_effort.sql
+++ b/drizzle/0015_run_effort.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `effort` text;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eac0a4fa-29bb-42c6-a09a-fa0b6ee6cb0b",
+  "prevId": "dc647566-b660-4991-8c45-b5253c441e1c",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "integration_count": {
+          "name": "integration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triage_result": {
+          "name": "triage_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1786492800000,
       "tag": "0014_run_model",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1786579200000,
+      "tag": "0015_run_effort",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -52,6 +52,12 @@ export const runs = sqliteTable("runs", {
   // interpretable against its tier. Set when the implement pass starts; null
   // means AGENT_MODEL was unset and the CLI resolved the account default.
   model: text("model"),
+  // Reasoning-effort level the implement pass ran at (issue #81) — the other
+  // half of the cost/quality dial alongside model. A ticket's `effort:`
+  // directive pins it from claim time; otherwise it is set when the implement
+  // pass starts. Null means AGENT_EFFORT was unset (no directive) and the CLI
+  // resolved its own default.
+  effort: text("effort"),
   totalCostUsd: real("total_cost_usd").notNull().default(0),
   pullRequestNumber: int("pull_request_number"),
   pullRequestUrl: text("pull_request_url"),

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  getConfig,
+  resetConfig,
   resolveAgentModel,
   resolveAgentEffort,
   type AppConfig,
@@ -139,5 +141,51 @@ describe("resolveAgentEffort (issue #81)", () => {
   it("falls back to the base when no ticket effort is given", () => {
     const c = effortCfg({ agentEffort: "high" });
     expect(resolveAgentEffort("implement", c, null)).toBe("high");
+  });
+});
+
+describe("getConfig effort env validation (issue #81)", () => {
+  const saved = {
+    AGENT_EFFORT: process.env.AGENT_EFFORT,
+    AGENT_EFFORT_REVIEW: process.env.AGENT_EFFORT_REVIEW,
+    AGENT_EFFORT_TRIAGE: process.env.AGENT_EFFORT_TRIAGE,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  };
+
+  beforeEach(() => {
+    // Suppress the unrelated "no Claude auth" warning so the assertions below
+    // observe only the effort-validation warning.
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    delete process.env.AGENT_EFFORT;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    resetConfig();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps a recognised env effort level", () => {
+    process.env.AGENT_EFFORT = "high";
+    resetConfig();
+    expect(getConfig().agentEffort).toBe("high");
+  });
+
+  it("drops an unrecognised env effort level to null and warns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.AGENT_EFFORT = "hihg"; // fleet-wide typo
+    resetConfig();
+    expect(getConfig().agentEffort).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("effort"));
+  });
+
+  it("treats an unset env effort as null without an effort warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetConfig();
+    expect(getConfig().agentEffort).toBeNull();
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("effort"));
   });
 });

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { resolveAgentModel, type AppConfig, type AgentPassKind } from "../config";
+import {
+  resolveAgentModel,
+  resolveAgentEffort,
+  type AppConfig,
+  type AgentPassKind,
+} from "../config";
 
 /** A config carrying only the fields resolveAgentModel reads. */
 function cfg(models: {
@@ -11,6 +16,19 @@ function cfg(models: {
     agentModel: models.agentModel,
     agentModelReview: models.agentModelReview ?? null,
     agentModelTriage: models.agentModelTriage ?? null,
+  } as AppConfig;
+}
+
+/** A config carrying only the fields resolveAgentEffort reads. */
+function effortCfg(efforts: {
+  agentEffort: string | null;
+  agentEffortReview?: string | null;
+  agentEffortTriage?: string | null;
+}): AppConfig {
+  return {
+    agentEffort: efforts.agentEffort,
+    agentEffortReview: efforts.agentEffortReview ?? null,
+    agentEffortTriage: efforts.agentEffortTriage ?? null,
   } as AppConfig;
 }
 
@@ -58,5 +76,68 @@ describe("resolveAgentModel (issue #74)", () => {
     expect(resolveAgentModel("review", c)).toBe("review-model");
     expect(resolveAgentModel("triage", c)).toBeNull();
     expect(resolveAgentModel("implement", c)).toBeNull();
+  });
+});
+
+describe("resolveAgentEffort (issue #81)", () => {
+  it("returns null for every kind when nothing is configured (CLI default)", () => {
+    const c = effortCfg({ agentEffort: null });
+    for (const kind of [
+      "interactive",
+      "implement",
+      "review",
+      "triage",
+      "repair",
+    ] as AgentPassKind[]) {
+      expect(resolveAgentEffort(kind, c)).toBeNull();
+    }
+  });
+
+  it("uses AGENT_EFFORT as the base for implement, repair and interactive", () => {
+    const c = effortCfg({ agentEffort: "high" });
+    expect(resolveAgentEffort("implement", c)).toBe("high");
+    expect(resolveAgentEffort("repair", c)).toBe("high");
+    expect(resolveAgentEffort("interactive", c)).toBe("high");
+  });
+
+  it("falls back review and triage to the base when they have no override", () => {
+    const c = effortCfg({ agentEffort: "high" });
+    expect(resolveAgentEffort("review", c)).toBe("high");
+    expect(resolveAgentEffort("triage", c)).toBe("high");
+  });
+
+  it("prefers the lower-level overrides for review and triage", () => {
+    const c = effortCfg({
+      agentEffort: "high",
+      agentEffortReview: "medium",
+      agentEffortTriage: "low",
+    });
+    expect(resolveAgentEffort("review", c)).toBe("medium");
+    expect(resolveAgentEffort("triage", c)).toBe("low");
+    // Overrides never leak onto the base kinds.
+    expect(resolveAgentEffort("implement", c)).toBe("high");
+  });
+
+  it("lets an override apply even when the base is unset", () => {
+    const c = effortCfg({ agentEffort: null, agentEffortReview: "medium" });
+    expect(resolveAgentEffort("review", c)).toBe("medium");
+    expect(resolveAgentEffort("triage", c)).toBeNull();
+    expect(resolveAgentEffort("implement", c)).toBeNull();
+  });
+
+  it("lets a ticket effort override the base for work kinds only", () => {
+    const c = effortCfg({ agentEffort: "medium", agentEffortReview: "low" });
+    // The ticket chooses the effort its *work* runs at...
+    expect(resolveAgentEffort("implement", c, "max")).toBe("max");
+    expect(resolveAgentEffort("repair", c, "max")).toBe("max");
+    expect(resolveAgentEffort("interactive", c, "max")).toBe("max");
+    // ...not the reviewer's or triage's, which keep their own resolution.
+    expect(resolveAgentEffort("review", c, "max")).toBe("low");
+    expect(resolveAgentEffort("triage", c, "max")).toBe("medium");
+  });
+
+  it("falls back to the base when no ticket effort is given", () => {
+    const c = effortCfg({ agentEffort: "high" });
+    expect(resolveAgentEffort("implement", c, null)).toBe("high");
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,26 @@
-import { DEFAULT_ATTEMPT_BUDGET_USD } from "./orchestrator/autonomy/budgets";
+import {
+  ALLOWED_TICKET_EFFORTS,
+  DEFAULT_ATTEMPT_BUDGET_USD,
+} from "./orchestrator/autonomy/budgets";
+
+/**
+ * Validate an `AGENT_EFFORT*` env value against the CLI's level set. Effort,
+ * unlike the model (an open-ended id/alias space), is a closed enum, so a bad
+ * value is both catastrophic — it reaches `--effort` on *every* turn fleet-wide
+ * — and cheap to catch. An unset var stays null (CLI default); a set-but-bad
+ * one warns and falls back to null rather than shipping a typo like
+ * `AGENT_EFFORT=hihg` to the CLI. The ticket-directive path clamps to the same
+ * set for the same reason.
+ */
+function normalizeEffort(raw: string | undefined): string | null {
+  if (raw == null || raw === "") return null;
+  if ((ALLOWED_TICKET_EFFORTS as readonly string[]).includes(raw)) return raw;
+  console.warn(
+    `Warning: ignoring unrecognised effort "${raw}" — expected one of ` +
+      `${ALLOWED_TICKET_EFFORTS.join(", ")}. Falling back to the CLI default.`
+  );
+  return null;
+}
 
 export interface AppConfig {
   /** Anthropic API key (optional if using CLAUDE_CODE_OAUTH_TOKEN) */
@@ -105,9 +127,9 @@ export function getConfig(): AppConfig {
     agentModel: process.env.AGENT_MODEL ?? null,
     agentModelReview: process.env.AGENT_MODEL_REVIEW ?? null,
     agentModelTriage: process.env.AGENT_MODEL_TRIAGE ?? null,
-    agentEffort: process.env.AGENT_EFFORT ?? null,
-    agentEffortReview: process.env.AGENT_EFFORT_REVIEW ?? null,
-    agentEffortTriage: process.env.AGENT_EFFORT_TRIAGE ?? null,
+    agentEffort: normalizeEffort(process.env.AGENT_EFFORT),
+    agentEffortReview: normalizeEffort(process.env.AGENT_EFFORT_REVIEW),
+    agentEffortTriage: normalizeEffort(process.env.AGENT_EFFORT_TRIAGE),
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",
     gitUserEmail: process.env.GIT_USER_EMAIL ?? "agent@interlude.dev",
     keepContainers: process.env.KEEP_CONTAINERS === "true",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,19 @@ export interface AppConfig {
   agentModelReview: string | null;
   /** Optional cheaper-tier override for triage passes; falls back to `agentModel` */
   agentModelTriage: string | null;
+  /**
+   * Reasoning-effort level the CLI runs an implement pass at — and the base
+   * every other pass falls back to (issue #81). The headless CLI exposes this
+   * as a first-class `--effort` flag (levels low | medium | high | xhigh |
+   * max), orthogonal to `--model`. Null = pass no `--effort`, letting the CLI
+   * resolve its own default (the pre-#81 behaviour), so leaving it unset
+   * changes nothing. Set it to pin the depth and record it on the run row.
+   */
+  agentEffort: string | null;
+  /** Optional lower-effort override for review passes; falls back to `agentEffort` */
+  agentEffortReview: string | null;
+  /** Optional lower-effort override for triage passes; falls back to `agentEffort` */
+  agentEffortTriage: string | null;
   gitUserName: string;
   gitUserEmail: string;
   keepContainers: boolean;
@@ -92,6 +105,9 @@ export function getConfig(): AppConfig {
     agentModel: process.env.AGENT_MODEL ?? null,
     agentModelReview: process.env.AGENT_MODEL_REVIEW ?? null,
     agentModelTriage: process.env.AGENT_MODEL_TRIAGE ?? null,
+    agentEffort: process.env.AGENT_EFFORT ?? null,
+    agentEffortReview: process.env.AGENT_EFFORT_REVIEW ?? null,
+    agentEffortTriage: process.env.AGENT_EFFORT_TRIAGE ?? null,
     gitUserName: process.env.GIT_USER_NAME ?? "Interlude Agent",
     gitUserEmail: process.env.GIT_USER_EMAIL ?? "agent@interlude.dev",
     keepContainers: process.env.KEEP_CONTAINERS === "true",
@@ -156,6 +172,37 @@ export function resolveAgentModel(
       return config.agentModelTriage ?? config.agentModel;
     default:
       return config.agentModel;
+  }
+}
+
+/**
+ * Which reasoning-effort level a turn of the given kind runs at (issue #81),
+ * the other half of the cost/quality dial alongside the model. `AGENT_EFFORT`
+ * is the base — implement, repair and interactive passes all use it; the
+ * read-heavy review and triage passes may name a lower level via
+ * `AGENT_EFFORT_REVIEW` / `AGENT_EFFORT_TRIAGE` and otherwise fall back to it.
+ * Null means "pass no `--effort`": the CLI resolves its own default, exactly
+ * as before this was configurable — issue #81 deliberately ships no default
+ * other than the CLI's own.
+ *
+ * `ticketEffort` is a per-ticket `effort:` directive, already clamped to the
+ * allowlist by the directive parser. When present it overrides the base for
+ * the pass kinds that carry a run's tier — implement, repair and interactive.
+ * Review and triage keep their own (lower) level regardless: the ticket
+ * chooses the effort its *work* runs at, not the reviewer's.
+ */
+export function resolveAgentEffort(
+  kind: AgentPassKind,
+  config: AppConfig = getConfig(),
+  ticketEffort: string | null = null
+): string | null {
+  switch (kind) {
+    case "review":
+      return config.agentEffortReview ?? config.agentEffort;
+    case "triage":
+      return config.agentEffortTriage ?? config.agentEffort;
+    default:
+      return ticketEffort ?? config.agentEffort;
   }
 }
 

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -172,6 +172,22 @@ describe("buildClaudeTurnCommand", () => {
     expect(cmd).not.toContain("--model claude-opus-4-8[1m]");
   });
 
+  it("omits --effort entirely when no level is pinned (issue #81)", () => {
+    expect(buildClaudeTurnCommand({ effort: null })).not.toContain("--effort");
+    expect(buildClaudeTurnCommand({})).not.toContain("--effort");
+  });
+
+  it("pins the reasoning effort with --effort when one is resolved (issue #81)", () => {
+    const cmd = buildClaudeTurnCommand({ effort: "high" });
+    expect(cmd).toContain("--effort 'high'");
+  });
+
+  it("carries both --model and --effort together, independently (issue #81)", () => {
+    const cmd = buildClaudeTurnCommand({ model: "claude-opus-4-8", effort: "max" });
+    expect(cmd).toContain("--model 'claude-opus-4-8'");
+    expect(cmd).toContain("--effort 'max'");
+  });
+
   it("appends --resume for a follow-up turn", () => {
     const cmd = buildClaudeTurnCommand({ sessionId: "sess-123" });
     expect(cmd).toContain("--resume sess-123");

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -294,9 +294,11 @@ export function buildClaudeTurnCommand(
   }
 
   if (options.effort) {
-    // Single-quote defensively for the same reason as the model above: the
-    // value is a bounded level in practice (allowlist-clamped from a ticket,
-    // or operator-set env), but this runs under `bash -c`.
+    // The value is always one of the CLI's bounded levels — both entry points
+    // validate against the same allowlist (the ticket directive clamps, the
+    // env is checked in config.ts), so no metacharacter can reach here. Still
+    // single-quoted for the same defence-in-depth reason as the model above,
+    // since this runs under `bash -c`.
     cmdParts.push("--effort", `'${options.effort}'`);
   }
 

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -109,6 +109,12 @@ export interface TurnOptions {
    * Null/undefined passes no `--model` — the CLI resolves the account default.
    */
   model?: string | null;
+  /**
+   * Reasoning-effort level for this turn, resolved from the task's kind
+   * (issue #81). Null/undefined passes no `--effort` — the CLI resolves its
+   * own default.
+   */
+  effort?: string | null;
 }
 
 export interface RunningContainer {
@@ -252,12 +258,16 @@ export async function execSetup(
 /**
  * Build the bash command a Claude turn runs inside the container. Pure and
  * exported so the flag wiring — notably the per-kind `--model` pin (issue #74)
- * — is unit-testable without a live Docker exec. `maxTurns`/`maxBudgetUsd`
- * fall back to the configured defaults; `model`, when set, pins the tier and
- * is otherwise omitted so the CLI resolves the account default as before.
+ * and `--effort` level (issue #81) — is unit-testable without a live Docker
+ * exec. `maxTurns`/`maxBudgetUsd` fall back to the configured defaults;
+ * `model` and `effort`, when set, pin the tier and reasoning depth and are
+ * otherwise omitted so the CLI resolves its own defaults as before.
  */
 export function buildClaudeTurnCommand(
-  options: Pick<TurnOptions, "sessionId" | "maxBudgetUsd" | "maxTurns" | "model">
+  options: Pick<
+    TurnOptions,
+    "sessionId" | "maxBudgetUsd" | "maxTurns" | "model" | "effort"
+  >
 ): string {
   const config = getConfig();
 
@@ -281,6 +291,13 @@ export function buildClaudeTurnCommand(
     // Single-quote the model id: real ids can carry shell glob metacharacters
     // (e.g. "claude-opus-4-8[1m]"), and this runs under `bash -c`.
     cmdParts.push("--model", `'${options.model}'`);
+  }
+
+  if (options.effort) {
+    // Single-quote defensively for the same reason as the model above: the
+    // value is a bounded level in practice (allowlist-clamped from a ticket,
+    // or operator-set env), but this runs under `bash -c`.
+    cmdParts.push("--effort", `'${options.effort}'`);
   }
 
   if (options.sessionId) {

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -205,6 +205,7 @@ describe("decideNext — claiming", () => {
         budgetUsd: 20,
         checkpoint: null,
         maxTurns: null,
+        effort: null,
         workflow: { source: "default" },
       },
     ]);
@@ -240,6 +241,24 @@ describe("decideNext — claiming", () => {
     );
 
     expect(claims(actions)[0]).toMatchObject({ budgetUsd: 40, maxTurns: 80 });
+  });
+
+  it("carries a clamped effort directive in the claim (issue #81)", () => {
+    const body = "Spec.\n\n## Workflow\n\neffort: max\n";
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ body })] })
+    );
+
+    expect(claims(actions)[0]).toMatchObject({ effort: "max" });
+  });
+
+  it("leaves effort null when the directive names an unknown level (issue #81)", () => {
+    const body = "Spec.\n\n## Workflow\n\neffort: turbo\n";
+    const actions = decideNext(
+      makeSnapshot({ candidates: [makeCandidate({ body })] })
+    );
+
+    expect(claims(actions)[0]).toMatchObject({ effort: null });
   });
 
   it("clamps an over-ceiling budget directive at claim time", () => {

--- a/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/ticket.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseBlockedByRefs,
   parseTicketDirectives,
+  rawEffortDirective,
   selectWorkflow,
   shouldCreateInteractiveTask,
 } from "../ticket";
@@ -13,6 +14,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      effort: null,
     });
   });
 
@@ -54,7 +56,7 @@ describe("parseTicketDirectives", () => {
     expect(parseTicketDirectives("## Workflow\nworkflow: tdd").workflow).toBe("tdd");
   });
 
-  it("parses all four directives together, bulleted and case-insensitive", () => {
+  it("parses all directives together, bulleted and case-insensitive", () => {
     const body = [
       "## Workflow",
       "",
@@ -62,12 +64,14 @@ describe("parseTicketDirectives", () => {
       "- MAX-TURNS: 60",
       "- checkpoint: pause before deploy",
       "- workflow: tdd",
+      "- Effort: HIGH",
     ].join("\n");
     expect(parseTicketDirectives(body)).toEqual({
       budget: 30,
       maxTurns: 60,
       checkpoint: "pause before deploy",
       workflow: "tdd",
+      effort: "high",
     });
   });
 
@@ -93,6 +97,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      effort: null,
     });
   });
 
@@ -119,6 +124,7 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      effort: null,
     });
   });
 
@@ -151,7 +157,31 @@ describe("parseTicketDirectives", () => {
       maxTurns: null,
       checkpoint: null,
       workflow: null,
+      effort: null,
     });
+  });
+
+  it("parses an effort directive, clamped to the allowlist (issue #81)", () => {
+    expect(parseTicketDirectives("## Workflow\neffort: max").effort).toBe("max");
+    expect(parseTicketDirectives("## Workflow\nEffort: LOW").effort).toBe("low");
+  });
+
+  it("ignores an unrecognised effort level — a bad value never binds", () => {
+    expect(parseTicketDirectives("## Workflow\neffort: turbo").effort).toBeNull();
+    expect(parseTicketDirectives("## Workflow\neffort: 11").effort).toBeNull();
+    expect(parseTicketDirectives("## Workflow\neffort:").effort).toBeNull();
+  });
+});
+
+describe("rawEffortDirective (issue #81)", () => {
+  it("reports the raw requested level, even one that would be ignored", () => {
+    expect(rawEffortDirective("## Workflow\neffort: turbo")).toBe("turbo");
+    expect(rawEffortDirective("## Workflow\nEffort: HIGH")).toBe("HIGH");
+  });
+
+  it("is null when no effort directive is present or the section is missing", () => {
+    expect(rawEffortDirective("## Workflow\nbudget: $30")).toBeNull();
+    expect(rawEffortDirective("Just prose.\n\neffort: max")).toBeNull();
   });
 });
 

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -16,6 +16,21 @@ export const MAX_ATTEMPT_BUDGET_USD = 75;
  * per-exec turn limit to (the default is the orchestrator's MAX_TURNS). */
 export const MAX_TURNS_CEILING = 100;
 
+/** Reasoning-effort levels a ticket's `effort:` directive may select (issue
+ * #81), the exact set the headless CLI's `--effort` flag accepts. A ticket
+ * body is semi-trusted input, so it may only choose from this fixed set —
+ * never name an arbitrary value — mirroring the reasoning behind the budget
+ * clamp. The level reaches the CLI as `--effort`; an unrecognised value is
+ * ignored (the run keeps its default effort), never fatal. Clamped in the
+ * directive parser, resolved through `resolveAgentEffort`. */
+export const ALLOWED_TICKET_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
 /** Budget for one review pass — its own allowance, separate from the
  * implement attempt's, so reviewing never eats into a fix-up's headroom. */
 export const DEFAULT_REVIEW_BUDGET_USD = 5;

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -296,6 +296,10 @@ export type Action =
       checkpoint: string | null;
       /** Per-exec turn limit from a max-turns directive; null = the default */
       maxTurns: number | null;
+      /** Reasoning-effort level from an `effort:` directive (issue #81),
+       * clamped to the allowlist; null = the configured default. Recorded on
+       * runs.effort. */
+      effort: string | null;
       workflow: WorkflowSelection;
     }
   | { type: "pausePickup"; reason: PauseReason; detail?: string }
@@ -991,6 +995,7 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       budgetUsd: directives.budget ?? snapshot.attemptBudgetUsd,
       checkpoint: directives.checkpoint,
       maxTurns: directives.maxTurns,
+      effort: directives.effort,
       workflow: selectWorkflow(candidate.body, candidate.labels),
     });
   }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -70,6 +70,7 @@ import {
   READY_FOR_HUMAN_LABEL,
   labelNames,
   parseBlockedByRefs,
+  rawEffortDirective,
 } from "./ticket";
 import {
   buildImplementPrompt,
@@ -1861,6 +1862,10 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
         budgetUsd: action.budgetUsd,
         checkpoint: action.checkpoint,
         maxTurns: action.maxTurns,
+        // An `effort:` directive (already allowlist-clamped) pins the level
+        // from claim time (issue #81); the implement pass resolves through the
+        // same value and records it here. Null keeps the configured default.
+        effort: action.effort,
         claimedAt: now,
         finishedAt: failure ? now : null,
         failureReason: failure ? `failed before start: ${failure}` : null,
@@ -1895,10 +1900,28 @@ async function executeClaim(action: Extract<Action, { type: "claimIssue" }>): Pr
     console.log(
       `[autonomy] Claimed ${action.issueRef} (attempt ${action.attempt}) -> task ${taskId}`
     );
+
+    // Note the effort directive on the run's issue thread (issue #81): the
+    // honoured level when one was picked, or an unrecognised request that was
+    // ignored — never silently swallowed, never fatal.
+    let effortNote = "";
+    if (action.effort) {
+      effortNote = `\n\nEffort: \`${action.effort}\` (ticket directive).`;
+    } else {
+      const rawEffort = rawEffortDirective(action.issueBody);
+      if (rawEffort) {
+        console.warn(
+          `[autonomy] Ignoring unrecognised effort directive "${rawEffort}" on ` +
+            `${action.issueRef} — using the default effort`
+        );
+        effortNote = `\n\nEffort directive \`${rawEffort}\` not recognised — running at the default effort.`;
+      }
+    }
+
     const domain = process.env.DOMAIN ?? "interludes.co.uk";
     await commentOnIssue(
       action.issueRef,
-      `Claimed by Interlude — attempt ${action.attempt}/${MAX_ATTEMPTS}.\n\n` +
+      `Claimed by Interlude — attempt ${action.attempt}/${MAX_ATTEMPTS}.${effortNote}\n\n` +
         `[View task](https://${domain}/tasks/${taskId})`
     );
   } finally {

--- a/src/lib/orchestrator/autonomy/ticket.ts
+++ b/src/lib/orchestrator/autonomy/ticket.ts
@@ -3,7 +3,11 @@
  * Nothing here performs I/O; the sweep gathers, these functions interpret.
  */
 
-import { MAX_ATTEMPT_BUDGET_USD, MAX_TURNS_CEILING } from "./budgets";
+import {
+  ALLOWED_TICKET_EFFORTS,
+  MAX_ATTEMPT_BUDGET_USD,
+  MAX_TURNS_CEILING,
+} from "./budgets";
 
 export const ARMING_LABEL = "ready-for-agent";
 export const READY_FOR_HUMAN_LABEL = "ready-for-human";
@@ -35,6 +39,9 @@ const WORKFLOW_LABEL_PREFIX = "workflow:";
 /** A `## Workflow` (or `### Workflow`) section heading in a ticket body. */
 const WORKFLOW_SECTION = /^#{2,3}\s+Workflow\s*$/im;
 
+/** A whole-line `key: value` directive (optionally bulleted, case-insensitive). */
+const DIRECTIVE_LINE = /^\s*(?:[-*]\s+)?([a-z-]+)\s*:\s*(.*)$/i;
+
 /**
  * The bounded directive set a ticket may carry in its Workflow section.
  * Null means "not specified — use the default". Directives can only move
@@ -51,6 +58,10 @@ export interface TicketDirectives {
   checkpoint: string | null;
   /** Named workflow — informational in v1 (selectWorkflow drives the pass) */
   workflow: string | null;
+  /** Reasoning-effort level to run the pass at (issue #81), clamped to
+   * ALLOWED_TICKET_EFFORTS. Null means unspecified or unrecognised — the run
+   * keeps its default effort; a bad value never fails the run. */
+  effort: string | null;
 }
 
 /**
@@ -65,10 +76,11 @@ export function parseTicketDirectives(body: string): TicketDirectives {
     maxTurns: null,
     checkpoint: null,
     workflow: null,
+    effort: null,
   };
 
   for (const line of workflowSectionLines(body)) {
-    const match = line.match(/^\s*(?:[-*]\s+)?([a-z-]+)\s*:\s*(.*)$/i);
+    const match = line.match(DIRECTIVE_LINE);
     if (!match) continue;
     const key = match[1].toLowerCase();
     const value = match[2].trim();
@@ -84,10 +96,31 @@ export function parseTicketDirectives(body: string): TicketDirectives {
       directives.checkpoint = value;
     } else if (key === "workflow" && directives.workflow === null) {
       directives.workflow = value;
+    } else if (key === "effort" && directives.effort === null) {
+      // Clamp to the allowlist: a semi-trusted body may pick a level, never
+      // name an arbitrary value. An unrecognised value stays null (ignored).
+      const level = value.toLowerCase();
+      if ((ALLOWED_TICKET_EFFORTS as readonly string[]).includes(level)) {
+        directives.effort = level;
+      }
     }
   }
 
   return directives;
+}
+
+/**
+ * The raw (un-clamped) value of an `effort:` directive in the Workflow
+ * section, if present — for surfacing an *ignored* request an operator
+ * otherwise couldn't see. Parsing for use goes through parseTicketDirectives,
+ * which clamps to the allowlist; this only reports what was asked for.
+ */
+export function rawEffortDirective(body: string): string | null {
+  for (const line of workflowSectionLines(body)) {
+    const match = line.match(DIRECTIVE_LINE);
+    if (match && match[1].toLowerCase() === "effort") return match[2].trim() || null;
+  }
+  return null;
 }
 
 /**

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -22,7 +22,12 @@ import {
   TRIAGE_MAX_TURNS,
 } from "./autonomy/budgets";
 import { scanPorts } from "./port-scanner";
-import { getConfig, resolveAgentModel, type AgentPassKind } from "../config";
+import {
+  getConfig,
+  resolveAgentModel,
+  resolveAgentEffort,
+  type AgentPassKind,
+} from "../config";
 import { getDocker } from "../docker/client";
 import { commentOnIssue, parseIssueRef } from "../github/issues";
 import { parseRepoFromGitUrl } from "../github/repo";
@@ -122,6 +127,12 @@ export async function startTask(taskId: string): Promise<void> {
   // interpretable against the tier it was earned on.
   const passModel = resolveAgentModel(task.kind);
 
+  // The reasoning-effort level this pass runs at (issue #81), the other half
+  // of the cost/quality dial. Pinned by kind and, for an implement-shaped or
+  // interactive pass, overridable by the run's `effort:` directive. Passed to
+  // every turn as `--effort` and recorded on the run row below.
+  const passEffort = resolveAgentEffort(task.kind, getConfig(), run?.effort ?? null);
+
   // Update task status
   updateTask(taskId, { status: "running", branch, containerStatus: "setup" });
   insertSystemMessage(taskId, `Provisioning agent container...${proj.dopplerToken ? " (Doppler configured)" : ""}`);
@@ -131,15 +142,17 @@ export async function startTask(taskId: string): Promise<void> {
   // pass keeps the run's original startedAt so the dashboard's elapsed time
   // does not jump when a conflict is repaired mid-life.
   if (run && isImplementShaped) {
-    // Record the implement-pass model on the run — it drives the bulk of a
-    // run's spend, so it is the tier the run's cost should be read against. A
-    // review pass writes its own (cheaper) model nowhere on the run, leaving
-    // this value stable. Repair keeps the original implement model (same tier).
+    // Record the implement-pass model and effort on the run — they drive the
+    // bulk of a run's spend, so they are the tier and depth the run's cost
+    // should be read against. A review pass writes its own (cheaper/lower)
+    // model and effort nowhere on the run, leaving these stable. Repair keeps
+    // the original implement values (same tier and depth).
     db.update(runs)
       .set({
         status: "implementing",
         startedAt: run.startedAt ?? new Date(),
         model: passModel,
+        effort: passEffort,
       })
       .where(eq(runs.id, run.id))
       .run();
@@ -227,6 +240,7 @@ export async function startTask(taskId: string): Promise<void> {
           : (run?.maxTurns ?? undefined),
       captureRaw: isReviewPass || isTriagePass,
       model: passModel,
+      effort: passEffort,
     });
 
     // Store session ID and cost
@@ -372,6 +386,7 @@ async function runTurn(
     maxTurns?: number;
     captureRaw?: boolean;
     model?: string | null;
+    effort?: string | null;
   }
 ): Promise<TurnResult & { raw?: string }> {
   const handler = createOutputHandler(taskId);
@@ -384,6 +399,7 @@ async function runTurn(
     maxBudgetUsd: opts?.maxBudgetUsd,
     maxTurns: opts?.maxTurns,
     model: opts?.model,
+    effort: opts?.effort,
   });
 
   // Race: wait for the exec stream to close OR the "result" event from Claude.
@@ -508,6 +524,7 @@ export async function processQueuedMessages(
         maxBudgetUsd: run ? run.budgetUsd - (task.totalCostUsd ?? 0) : undefined,
         maxTurns: run?.maxTurns ?? undefined,
         model: resolveAgentModel(task.kind),
+        effort: resolveAgentEffort(task.kind, getConfig(), run?.effort ?? null),
       }
     );
 


### PR DESCRIPTION
Closes #81

## Investigation (the first step the ticket asked for)

The ticket flagged the mechanism as uncertain (effort flag vs `MAX_THINKING_TOKENS`-style env vs settings.json). I checked the installed headless CLI (`@anthropic-ai/claude-code`) directly with `claude --help`:

- **The CLI exposes a first-class `--effort <level>` session flag**, levels **`low | medium | high | xhigh | max`**. Verbatim help text: *"Effort level for the current session (low, medium, high, xhigh, max)"*.
- **It is orthogonal to `--model`.** Both are independent session flags — `--effort` sets reasoning depth, `--model` sets the tier — and can be combined; the help documents no coupling. Unlike `--max-budget-usd`, `--effort` carries no `--print`-only restriction, so it applies to our headless (`-p`) runs.
- **No `MAX_THINKING_TOKENS` env and no settings.json field are needed** — the flag is the clean, model-parallel mechanism.

So the winner is the `--effort` flag, wired exactly like `--model` (#74). Per the ticket's "out of scope until measured", an unset `AGENT_EFFORT` passes **no** `--effort`, leaving the CLI's own default untouched — this ships no default other than the CLI's own.

## What this wires (mirrors #74)

- **`AGENT_EFFORT` + per-kind overrides** (`AGENT_EFFORT_REVIEW`, `AGENT_EFFORT_TRIAGE`) from Doppler/env, resolved by `resolveAgentEffort(kind, config, ticketEffort)` — implement/repair/interactive use the base; the read-heavy review/triage passes may name a lower level and otherwise fall back.
- **Per-exec**: `buildClaudeTurnCommand` emits `--effort '<level>'` for the initial and follow-up turns.
- **Recorded on the run row**: new additive `runs.effort` column (migration `0015_run_effort`), set when the implement-shaped pass starts, so spend reads against the depth it was earned at.
- **Clamped `effort:` ticket directive** (the optional half, pairing with the `model:` directive being built in #80): a Workflow-section `effort: <level>`, clamped to `ALLOWED_TICKET_EFFORTS`; an unrecognised value is ignored and surfaced on the claim comment, never fatal. It pins the run from claim time and overrides work-pass effort only — the reviewer's effort is unaffected.

Docs: `.env.example` and `docs/runbook.md`. Tests: `resolveAgentEffort`, the `--effort` flag, env validation, the `effort:` directive parse/clamp, `rawEffortDirective`, and the claim carrying it — full suite 435 passing.

## Self-review (`/code-review` vs `origin/main`)

- **Env values were forwarded to `--effort` unvalidated** — fixed. Effort is a *closed* 5-value enum (unlike the open-ended model space), so a typo in `AGENT_EFFORT` would hit every turn fleet-wide. `getConfig` now validates env values against the same allowlist the directive uses (warn + fall back to the CLI default). This also makes the value reaching `--effort` provably one of the bounded levels on both entry paths, closing a shell-quoting concern at the flag site.
- **Disagreed:** the reviewer suggested threading the raw (un-clamped) effort request through the `claimIssue` action instead of `rawEffortDirective` re-scanning the body in the sweep. I kept the re-scan: it's one cheap Workflow-section walk at claim time, it mirrors #80's `rawModelDirective` pattern (this directive is meant to pair with `model:`), and it keeps a presentation-only value out of the pure `decideNext` reducer.

## Note on #80

`effort:` deliberately mirrors #80's in-flight `model:` directive (allowlist in `budgets.ts`, `raw*Directive` helper, claim-time record + operator note, `resolve*(kind, config, ticket*)` third param). Built standalone on `main` since #80 isn't merged; the two are symmetric adjacent additions and should merge cleanly.
