### PR TITLE
Triage pass: suggest ticket directives (model/budget/max-turns) in its assessment

### DIFF
--- a/docs/agents/triage-pass.md
+++ b/docs/agents/triage-pass.md
@@ -25,8 +25,9 @@ here.
 - **recommend** — the issue is well specified: it names what to build, where
   it lives, and how to tell it is done. Your body is the assessment the owner
   reads before arming: what the issue asks, why it is ready, anything the
-  implementer should watch. The owner arms it — or doesn't; you only ever
-  recommend.
+  implementer should watch, and — where one clearly fits — a suggested
+  Workflow-section directive or two (see *Suggested directives* below). The
+  owner arms it — or doesn't; you only ever recommend.
 - **needs-info** — the issue cannot be implemented from its text, but the
   gaps are questions with answers. Your body is the specific questions, as a
   list the reporter can answer one by one. Ask about the issue's gaps, not
@@ -39,6 +40,39 @@ here.
 When exits compete, prefer the one that moves the issue least: missing facts
 are `needs-info` even when a design question lurks behind them, and only a
 genuinely decision-shaped issue is `ready-for-human`.
+
+## Suggested directives (recommend only)
+
+Only when you **recommend** an issue may you also suggest directives for its
+Workflow section — the settings the owner would copy into the ticket when they
+arm it. Suggesting is not applying: exactly the arming boundary, you write the
+suggestions as text in your assessment body, edit nothing and label nothing,
+and the human decides whether to copy them in. The other two exits carry no
+directive suggestions.
+
+Suggest a directive only when one clearly fits — silence is the default, and a
+well-scoped ordinary ticket needs none. Each suggestion is one directive line
+plus a one-line reason, gathered in your body under a short heading like
+`Suggested directives (copy into a Workflow section when arming):`. The
+directives you may suggest, and when:
+
+- **`model: haiku | sonnet | opus`** — match the tier to the work. A mechanical
+  fix (a rename, a docs edit, a one-line guard) warrants `model: haiku`; a
+  gnarly refactor or a subtle change warrants `model: opus`. Say nothing to
+  leave the default tier.
+- **`budget: $<n>`** — raise the $20 per-attempt default (the owner can go to at
+  most $75) when the work is genuinely large: many files, a migration, broad
+  test churn.
+- **`max-turns: <n>`** — raise the per-exec turn cap when the work is many small
+  steps rather than a few large ones.
+- **`checkpoint: <text>`** — force a human sign-off before merge for
+  agent-doable-but-risky work (a schema change, a security-adjacent edit, a
+  destructive migration); `<text>` names what to eyeball.
+
+Never present a directive as already set. It is advice the owner takes or
+ignores; the effect of an unfit or mistyped one is nil (an unknown or
+out-of-range directive is ignored at pickup), so err toward suggesting only
+what you are sure of.
 
 ## Rules
 

--- a/docs/agents/triage-pass.md
+++ b/docs/agents/triage-pass.md
@@ -70,9 +70,10 @@ directives you may suggest, and when:
   destructive migration); `<text>` names what to eyeball.
 
 Never present a directive as already set. It is advice the owner takes or
-ignores; the effect of an unfit or mistyped one is nil (an unknown or
-out-of-range directive is ignored at pickup), so err toward suggesting only
-what you are sure of.
+ignores, and pickup is defensive about it: an unknown key or an unrecognised
+`model:` alias is dropped, and an over-range `budget:` or `max-turns:` is
+clamped to its ceiling — a mistyped suggestion never fails a run. Still, err
+toward suggesting only what you are sure of.
 
 ## Rules
 


### PR DESCRIPTION
Closes #86

Follow-on to #80. The triage pass recommends arming issues but its vendored definition (`docs/agents/triage-pass.md`) didn't know the Workflow-section directive vocabulary, so it could never suggest `model: haiku` for a mechanical fix or `budget:` + `checkpoint:` for a heavy one.

## What changed

One new section in `docs/agents/triage-pass.md` — **Suggested directives (recommend only)** — plus a one-clause pointer from the `recommend` bullet into it. The section:

- Scopes suggestions to the **recommend** exit only (the other two exits carry none).
- Documents the four suggestable directives with one-line reasoning and *when* to reach for each: `model:` (haiku/sonnet/opus tiers), `budget:` (raise the $20 default toward the $75 ceiling for large work), `max-turns:`, and `checkpoint:` (force human sign-off for agent-doable-but-risky work).
- Reinforces the arming boundary: suggestions are **text in the assessment body only** — the pass applies no labels and edits no issues; a suggestion the human copies in is a human decision. "Never present a directive as already set."

Docs-only change: no code, no label behaviour, no second section. The estate-sibling platform-side `/to-tickets` work is out of scope (filed on the platform repo, per the issue).

## Validation

- Full test suite green (427 passing), including the triage/workflow suites that build the pass prompt by reading this doc at runtime.
- No lint impact — the change is markdown, which ESLint doesn't cover here.

## Self-review (`/code-review` vs `origin/main`, spec = #86)

Both axes came back clean on spec fidelity and scope. The one substantive finding — my draft claimed out-of-range directives are "ignored at pickup", when `budget:`/`max-turns:` are actually **clamped** to their ceilings and only unknown keys / unrecognised model aliases are dropped — is fixed in the second commit. The "restates the boundary a few times" note I left as-is on purpose: in an injected prompt, reinforcing "applies nothing" is a feature, and it's the pass's most safety-critical property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)