### PR TITLE
Fleet dashboard: make review/triage passes legible; fix premature sign-off + surface unparseable-verdict runs (#90)

### DIFF
--- a/src/components/fleet/needs-you.tsx
+++ b/src/components/fleet/needs-you.tsx
@@ -5,6 +5,7 @@ import { Chip, Eyebrow } from "./fleet-bits";
 const CAUSE_LABEL: Record<NeedsYouItem["cause"], string> = {
   blocked: "blocked question",
   signoff: "sign-off",
+  unparseable: "verdict error",
   conflict: "merge conflict",
   exhausted: "exhausted",
   cap: "cap pause",
@@ -14,6 +15,7 @@ const CAUSE_LABEL: Record<NeedsYouItem["cause"], string> = {
 const CAUSE_TONE: Record<NeedsYouItem["cause"], "amber" | "red"> = {
   blocked: "amber",
   signoff: "amber",
+  unparseable: "red",
   conflict: "red",
   exhausted: "red",
   cap: "red",

--- a/src/components/fleet/running-list.tsx
+++ b/src/components/fleet/running-list.tsx
@@ -2,6 +2,16 @@ import Link from "next/link";
 import type { FleetView, RunningCard } from "@/lib/fleet/fleet-view";
 import { AttemptPips, Chip, Eyebrow, Gauge, Money, formatElapsed } from "./fleet-bits";
 
+// afk work is the green "the fleet is driving" state; supervised and
+// interactive are cool (a human is in the loop); a triage pass is the lightest
+// read-only work, so it stays quiet.
+const MODE_TONE: Record<RunningCard["mode"], "green" | "cool" | "quiet"> = {
+  afk: "green",
+  supervised: "cool",
+  interactive: "cool",
+  triage: "quiet",
+};
+
 export function RunningList({ view, now }: { view: FleetView; now: number }) {
   return (
     <section aria-label="Running" className="space-y-3">
@@ -29,7 +39,7 @@ function RunCard({ card, now }: { card: RunningCard; now: number }) {
           {card.projectName}
           {card.ticket && <span className="text-fl-ink"> {card.ticket}</span>}
         </span>
-        <Chip tone={card.mode === "afk" ? "green" : "cool"}>{card.mode}</Chip>
+        <Chip tone={MODE_TONE[card.mode]}>{card.mode}</Chip>
       </div>
 
       <p className="truncate text-sm text-fl-ink">{card.title}</p>

--- a/src/lib/fleet/__tests__/digest.test.ts
+++ b/src/lib/fleet/__tests__/digest.test.ts
@@ -64,6 +64,8 @@ function makeRun(overrides: Partial<FleetRunRow> = {}): FleetRunRow {
     pullRequestUrl: null,
     blockedQuestion: null,
     integrationCount: 0,
+    reviewVerdict: null,
+    reviewResult: null,
     claimedAt: aug(1, 9),
     startedAt: aug(1, 9),
     finishedAt: null,
@@ -271,6 +273,9 @@ describe("renderDailyDigest — blocked on you", () => {
           projectId: "p1",
           githubIssue: "lennons301/lemons#35",
           status: "gated",
+          // An approved-but-gated PR is a genuine sign-off wait (issue #90):
+          // one human merge away.
+          reviewVerdict: "approve",
           claimedAt: aug(1, 10),
           pullRequestNumber: 55,
           pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -51,6 +51,8 @@ function makeRun(overrides: Partial<FleetRunRow> = {}): FleetRunRow {
     pullRequestUrl: null,
     blockedQuestion: null,
     integrationCount: 0,
+    reviewVerdict: null,
+    reviewResult: null,
     claimedAt: TODAY_9AM,
     startedAt: TODAY_9AM,
     finishedAt: null,
@@ -395,7 +397,7 @@ describe("buildFleetView — needs you", () => {
     });
   });
 
-  it("raises a gated PR waiting for human sign-off", () => {
+  it("raises a gated PR waiting for human sign-off once its review approves", () => {
     const view = buildFleetView(
       baseRows({
         projects: [makeProject({ id: "p1", name: "lemons" })],
@@ -404,6 +406,8 @@ describe("buildFleetView — needs you", () => {
             id: "r1",
             projectId: "p1",
             status: "gated",
+            // The review has landed as approve — the PR is one human merge away.
+            reviewVerdict: "approve",
             pullRequestNumber: 55,
             pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
           }),
@@ -423,6 +427,114 @@ describe("buildFleetView — needs you", () => {
         },
       },
     ]);
+  });
+
+  it("does not raise a gated PR whose review is still in flight (issue #90)", () => {
+    // The premature-firing bug: a gated run with no verdict yet was flagged as
+    // a sign-off wait. Until the review lands it is fleet activity, not a
+    // needs-you item.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            reviewVerdict: null,
+            reviewResult: null,
+            pullRequestNumber: 55,
+            pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
+          }),
+        ],
+        tasks: [
+          makeTask({
+            id: "t-review",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Review PR #55: Add auth",
+            status: "running",
+            containerStatus: "running",
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou).toEqual([]);
+    // It reads as fleet activity instead, under Running.
+    expect(view.running.map((c) => c.runId)).toEqual(["r1"]);
+  });
+
+  it("raises a gated PR whose reviewer escalated for sign-off", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            reviewVerdict: "escalate",
+            pullRequestNumber: 55,
+            pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou).toEqual([
+      {
+        cause: "signoff",
+        severity: "amber",
+        context: "lemons #34 · attempt 1/3",
+        body: "PR #55 — the reviewer escalated for your sign-off",
+        action: {
+          label: "Review PR #55",
+          href: "https://github.com/lennons301/lemons/pull/55",
+        },
+      },
+    ]);
+  });
+
+  it("raises a run parked by an unparseable review verdict as its own cause (issue #90)", () => {
+    // Terminal by design: the review pass finished but its verdict could not
+    // be read, so the run is parked for a human. Distinct from a happy sign-off
+    // wait — it must not sit in `signoff` indistinguishable from one.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            reviewVerdict: null,
+            reviewResult: {
+              kind: "unparseable",
+              reason: "final message does not start with a VERDICT: line",
+            },
+            pullRequestNumber: 55,
+            pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou).toEqual([
+      {
+        cause: "unparseable",
+        severity: "red",
+        context: "lemons #34 · attempt 1/3",
+        body: "Review verdict couldn't be read on PR #55 — parked, nothing merges until you look",
+        action: {
+          label: "Open PR #55",
+          href: "https://github.com/lennons301/lemons/pull/55",
+        },
+      },
+    ]);
+    // A parked run is not running — its review is over, not in flight.
+    expect(view.running).toEqual([]);
   });
 
   it("raises a gated PR stalled on a merge conflict as a distinct red state (issue #54)", () => {
@@ -459,8 +571,8 @@ describe("buildFleetView — needs you", () => {
   });
 
   it("keeps a repaired-and-mergeable gated PR as an ordinary sign-off", () => {
-    // A successful repair resets integrationCount to 0, so the run reads as a
-    // clean sign-off wait, not a conflict.
+    // A successful repair resets integrationCount to 0, so an approved run
+    // reads as a clean sign-off wait, not a conflict.
     const view = buildFleetView(
       baseRows({
         projects: [makeProject({ id: "p1", name: "lemons" })],
@@ -470,6 +582,7 @@ describe("buildFleetView — needs you", () => {
             projectId: "p1",
             status: "gated",
             integrationCount: 0,
+            reviewVerdict: "approve",
             pullRequestNumber: 55,
             pullRequestUrl: "https://github.com/lennons301/lemons/pull/55",
           }),
@@ -630,6 +743,7 @@ describe("buildFleetView — needs you", () => {
             projectId: "p1",
             githubIssue: "o/r#2",
             status: "gated",
+            reviewVerdict: "approve",
             pullRequestNumber: 9,
             pullRequestUrl: "https://github.com/o/r/pull/9",
           }),
@@ -804,7 +918,113 @@ describe("buildFleetView — running", () => {
     expect(view.running[0].title).toBe("Live review pass");
   });
 
-  it("excludes finished runs and containerless interactive tasks from running", () => {
+  it("surfaces a gated run under review as fleet activity with the review pass's spend (issue #90)", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            status: "gated",
+            reviewVerdict: null,
+            reviewResult: null,
+            totalCostUsd: 9.5, // implement + review, rolled up on the run
+            budgetUsd: 20,
+          }),
+        ],
+        tasks: [
+          // The implement pass, parked idle awaiting a possible fix-up...
+          makeTask({
+            id: "t-impl",
+            projectId: "p1",
+            runId: "r1",
+            kind: "implement",
+            title: "Add auth",
+            status: "running",
+            containerStatus: "idle",
+            totalCostUsd: 7.4,
+            createdAt: new Date(2026, 7, 1, 9, 0, 0),
+          }),
+          // ...while the review pass actively runs.
+          makeTask({
+            id: "t-review",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Review PR #55: Add auth",
+            status: "running",
+            containerStatus: "running",
+            totalCostUsd: 2.1,
+            turns: 1,
+            createdAt: new Date(2026, 7, 1, 9, 30, 0),
+          }),
+        ],
+      })
+    );
+
+    expect(view.needsYou).toEqual([]);
+    expect(view.running).toHaveLength(1);
+    expect(view.running[0]).toMatchObject({
+      taskId: "t-review",
+      runId: "r1",
+      title: "Review PR #55: Add auth",
+      mode: "afk",
+      phases: [
+        { name: "implement", state: "done" },
+        { name: "review", state: "current" },
+        { name: "merge", state: "todo" },
+      ],
+      turns: 1,
+      // The review pass's own spend against the review budget — not the run's
+      // rolled-up spend against the $20 attempt budget.
+      spend: { usd: 2.1, budgetUsd: 5 },
+    });
+  });
+
+  it("surfaces a triage pass as its own kind of fleet activity (issue #90)", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        tasks: [
+          makeTask({
+            id: "t-triage",
+            projectId: "p1",
+            runId: null,
+            kind: "triage",
+            title: "Triage: Add auth",
+            status: "running",
+            containerStatus: "running",
+            totalCostUsd: 0.8,
+            turns: 1,
+            githubIssue: "lennons301/lemons#90",
+            createdAt: TODAY_9AM,
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toEqual([
+      {
+        taskId: "t-triage",
+        runId: null,
+        projectName: "lemons",
+        ticket: "#90",
+        title: "Triage: Add auth",
+        mode: "triage",
+        phases: null,
+        attempt: null,
+        turns: 1,
+        startedAt: TODAY_9AM.toISOString(),
+        spend: { usd: 0.8, budgetUsd: 2 },
+      },
+    ]);
+  });
+
+  it("excludes finished runs and gated runs with no live pass from running", () => {
+    // A merged run is done; a gated run with no live container is either
+    // between sweeps or already resolved (a landed verdict routes it to
+    // needs-you), so neither reads as fleet activity.
     const view = buildFleetView(
       baseRows({
         projects: [makeProject({ id: "p1" })],

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -225,6 +225,12 @@ const TERMINAL_TASK_STATUSES = new Set<FleetTaskRow["status"]>([
   "cancelled",
 ]);
 
+/** A live task still has a container and hasn't reached a terminal status — a
+ * stale container_status on a finished task (issue #46) is not "live". The one
+ * predicate behind slot occupancy and every run's card face. */
+const isLiveTask = (t: FleetTaskRow): boolean =>
+  t.containerStatus !== null && !TERMINAL_TASK_STATUSES.has(t.status);
+
 export function buildFleetView(rows: FleetRows): FleetView {
   const projectById = new Map(rows.projects.map((p) => [p.id, p]));
   const runById = new Map(rows.runs.map((r) => [r.id, r]));
@@ -243,9 +249,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
   // container_status='idle') must not resurrect it as a running session here.
   const occupants = rows.tasks.filter(
     (t) =>
-      !TERMINAL_TASK_STATUSES.has(t.status) &&
-      t.containerStatus !== null &&
-      !(t.kind !== "interactive" && t.containerStatus === "idle")
+      isLiveTask(t) && !(t.kind !== "interactive" && t.containerStatus === "idle")
   );
   const segments: SlotSegment[] = occupants.map((t) => {
     const run = t.runId ? runById.get(t.runId) : undefined;
@@ -282,10 +286,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
   const currentTaskOf = (runId: string) => {
     const owned = tasksOfRun(runId);
     return (
-      owned.find(
-        (t) =>
-          t.containerStatus !== null && !TERMINAL_TASK_STATUSES.has(t.status)
-      ) ??
+      owned.find(isLiveTask) ??
       owned.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
       null
     );
@@ -362,7 +363,9 @@ export function buildFleetView(rows: FleetRows): FleetView {
   // needs-you item — it appears under Running until a verdict lands, so the
   // sign-off bucket never fires prematurely on a still-reviewing PR.
   for (const run of rows.runs.filter((r) => r.status === "gated")) {
-    const pr = run.pullRequestNumber;
+    // "PR #55" when the number is known, a bare "PR" otherwise — the copy and
+    // the action label share it, so neither has to re-branch on the number.
+    const prTag = run.pullRequestNumber ? `PR #${run.pullRequestNumber}` : "PR";
     const link = (label: string): NeedsYouItem["action"] =>
       run.pullRequestUrl ? { label, href: run.pullRequestUrl } : null;
     const disposition = classifyGated(run);
@@ -372,20 +375,16 @@ export function buildFleetView(rows: FleetRows): FleetView {
         cause: "conflict",
         severity: "red",
         context: runContext(run),
-        body: pr
-          ? `PR #${pr} still conflicts with the default branch — resolve and merge`
-          : "PR still conflicts with the default branch — resolve and merge",
-        action: link(pr ? `Resolve PR #${pr}` : "Resolve PR"),
+        body: `${prTag} still conflicts with the default branch — resolve and merge`,
+        action: link(`Resolve ${prTag}`),
       });
     } else if (disposition.kind === "unparseable") {
       needsYou.push({
         cause: "unparseable",
         severity: "red",
         context: runContext(run),
-        body: pr
-          ? `Review verdict couldn't be read on PR #${pr} — parked, nothing merges until you look`
-          : "Review verdict couldn't be read — parked, nothing merges until you look",
-        action: link(pr ? `Open PR #${pr}` : "Open PR"),
+        body: `Review verdict couldn't be read on ${prTag} — parked, nothing merges until you look`,
+        action: link(`Open ${prTag}`),
       });
     } else if (disposition.kind === "signoff") {
       needsYou.push({
@@ -394,13 +393,9 @@ export function buildFleetView(rows: FleetRows): FleetView {
         context: runContext(run),
         body:
           disposition.verdict === "escalate"
-            ? pr
-              ? `PR #${pr} — the reviewer escalated for your sign-off`
-              : "PR — the reviewer escalated for your sign-off"
-            : pr
-              ? `PR #${pr} waits for your sign-off`
-              : "PR waits for your sign-off",
-        action: link(pr ? `Review PR #${pr}` : "Review PR"),
+            ? `${prTag} — the reviewer escalated for your sign-off`
+            : `${prTag} waits for your sign-off`,
+        action: link(`Review ${prTag}`),
       });
     }
     // disposition.kind === "in-flight": review still running — fleet activity,
@@ -451,9 +446,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
   // pass runs, so prefer the actively-running (non-idle) pass — otherwise the
   // card would read as the paused implement rather than the live review.
   const activePassOf = (runId: string): FleetTaskRow | null => {
-    const live = tasksOfRun(runId).filter(
-      (t) => t.containerStatus !== null && !TERMINAL_TASK_STATUSES.has(t.status)
-    );
+    const live = tasksOfRun(runId).filter(isLiveTask);
     const busy = live.filter((t) => t.containerStatus !== "idle");
     const pool = busy.length > 0 ? busy : live;
     return (

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+  DEFAULT_REVIEW_BUDGET_USD,
+  DEFAULT_TRIAGE_BUDGET_USD,
   MAX_ATTEMPTS,
   MAX_INTEGRATION_ATTEMPTS,
 } from "../orchestrator/autonomy/budgets";
@@ -62,6 +64,19 @@ export interface FleetRunRow {
    * at or past MAX_INTEGRATION_ATTEMPTS is a stalled merge conflict, not a
    * plain sign-off */
   integrationCount: number;
+  /** The last verdict the orchestrator POSTED to GitHub for this run. A gated
+   * run is a sign-off wait only once this is `approve` (the PR is one human
+   * merge away) or `escalate` (the reviewer handed it to a human); until then
+   * its review is still in flight (issue #90). */
+  reviewVerdict: "approve" | "request-changes" | "escalate" | null;
+  /** A finished review pass's parsed output, held until the orchestrator acts.
+   * A stored `unparseable` result is terminal by design: the review couldn't be
+   * read, the run is parked for a human, and it reads as its own needs-you
+   * cause rather than an ordinary sign-off (issue #90). */
+  reviewResult:
+    | { kind: "approve" | "request-changes" | "escalate"; body: string }
+    | { kind: "unparseable"; reason: string }
+    | null;
   claimedAt: Date;
   startedAt: Date | null;
   finishedAt: Date | null;
@@ -91,6 +106,8 @@ export { MAX_ATTEMPTS };
 export type NeedsYouCause =
   | "blocked"
   | "signoff"
+  /** A run whose review verdict couldn't be read — parked for a human (#90) */
+  | "unparseable"
   | "conflict"
   | "exhausted"
   | "cap"
@@ -117,9 +134,11 @@ export interface RunningCard {
   projectName: string;
   ticket: string | null;
   title: string;
-  /** Mode chip: afk = full autonomy, supervised = forced human-signoff */
-  mode: "afk" | "supervised" | "interactive";
-  /** implement ▸ review ▸ merge pipeline; null for interactive sessions */
+  /** Card kind: afk = full autonomy, supervised = forced human-signoff,
+   * interactive = a chat session, triage = a read-only triage pass (#90) */
+  mode: "afk" | "supervised" | "interactive" | "triage";
+  /** implement ▸ review ▸ merge pipeline; null for standalone interactive
+   * sessions and triage passes, which sit outside the ticket pipeline */
   phases: { name: "implement" | "review" | "merge"; state: PhaseState }[] | null;
   attempt: { current: number; max: number } | null;
   turns: number;
@@ -290,6 +309,27 @@ export function buildFleetView(rows: FleetRows): FleetView {
     return task ? { label: "Open task", href: `/tasks/${task.id}` } : null;
   };
 
+  // Where a gated run's review stands — the single source of truth for both
+  // its needs-you disposition and whether it still reads as fleet activity
+  // (issue #90), so the two can never disagree. A gated run is exactly one of
+  // these. Precedence: a spent-repairs conflict (issue #54) outranks a stored
+  // verdict, an unreadable verdict outranks a posted one, and only a posted
+  // approve/escalate is a sign-off wait; anything else means the review is
+  // still in flight.
+  type GatedDisposition =
+    | { kind: "conflict" }
+    | { kind: "unparseable" }
+    | { kind: "signoff"; verdict: "approve" | "escalate" }
+    | { kind: "in-flight" };
+  const classifyGated = (run: FleetRunRow): GatedDisposition => {
+    if (run.integrationCount >= MAX_INTEGRATION_ATTEMPTS) return { kind: "conflict" };
+    if (run.reviewResult?.kind === "unparseable") return { kind: "unparseable" };
+    if (run.reviewVerdict === "approve" || run.reviewVerdict === "escalate") {
+      return { kind: "signoff", verdict: run.reviewVerdict };
+    }
+    return { kind: "in-flight" };
+  };
+
   // Ordered by what to do next: the fleet-wide pause first, then a parked
   // agent waiting on an answer, then reviews, then post-mortems, then config.
   const needsYou: NeedsYouItem[] = [];
@@ -314,15 +354,20 @@ export function buildFleetView(rows: FleetRows): FleetView {
     });
   }
 
-  // A gated run is normally a clean sign-off wait, but one whose integration
-  // repairs are spent (issue #54) is stalled on a merge conflict — a distinct,
-  // red, "resolve it" state rather than silence or an ordinary sign-off.
+  // A gated run's needs-you disposition follows where its review stands
+  // (issue #90). Repairs spent → a red merge-conflict stall (issue #54); an
+  // unreadable verdict → a run parked for a human, its own distinct cause; a
+  // posted approve/escalate → a genuine sign-off wait, the PR one human step
+  // away. A gated run whose review is still in flight is fleet activity, not a
+  // needs-you item — it appears under Running until a verdict lands, so the
+  // sign-off bucket never fires prematurely on a still-reviewing PR.
   for (const run of rows.runs.filter((r) => r.status === "gated")) {
     const pr = run.pullRequestNumber;
     const link = (label: string): NeedsYouItem["action"] =>
       run.pullRequestUrl ? { label, href: run.pullRequestUrl } : null;
+    const disposition = classifyGated(run);
 
-    if (run.integrationCount >= MAX_INTEGRATION_ATTEMPTS) {
+    if (disposition.kind === "conflict") {
       needsYou.push({
         cause: "conflict",
         severity: "red",
@@ -332,17 +377,34 @@ export function buildFleetView(rows: FleetRows): FleetView {
           : "PR still conflicts with the default branch — resolve and merge",
         action: link(pr ? `Resolve PR #${pr}` : "Resolve PR"),
       });
-    } else {
+    } else if (disposition.kind === "unparseable") {
+      needsYou.push({
+        cause: "unparseable",
+        severity: "red",
+        context: runContext(run),
+        body: pr
+          ? `Review verdict couldn't be read on PR #${pr} — parked, nothing merges until you look`
+          : "Review verdict couldn't be read — parked, nothing merges until you look",
+        action: link(pr ? `Open PR #${pr}` : "Open PR"),
+      });
+    } else if (disposition.kind === "signoff") {
       needsYou.push({
         cause: "signoff",
         severity: "amber",
         context: runContext(run),
-        body: pr
-          ? `PR #${pr} waits for your sign-off`
-          : "PR waits for your sign-off",
+        body:
+          disposition.verdict === "escalate"
+            ? pr
+              ? `PR #${pr} — the reviewer escalated for your sign-off`
+              : "PR — the reviewer escalated for your sign-off"
+            : pr
+              ? `PR #${pr} waits for your sign-off`
+              : "PR waits for your sign-off",
         action: link(pr ? `Review PR #${pr}` : "Review PR"),
       });
     }
+    // disposition.kind === "in-flight": review still running — fleet activity,
+    // surfaced under Running, deliberately not a needs-you item.
   }
 
   // An exhausted ticket needs a human until either they re-arm it (a newer
@@ -372,59 +434,104 @@ export function buildFleetView(rows: FleetRows): FleetView {
     });
   }
 
-  // Running = every run holding (or waiting on) a slot, then interactive
-  // sessions as quiet, unbudgeted cards — they hold slots too (review
-  // decision 2), they just answer to no ledger.
-  const ACTIVE_RUN_STATUSES = new Set([
+  // Running = active fleet work. Every run mid-pipeline shows its
+  // implement ▸ review ▸ merge phases; a gated run whose review is still in
+  // flight (issue #90) is activity too, not a premature sign-off, so it appears
+  // here until a verdict lands and moves it to needs-you. Interactive sessions
+  // and triage passes are quiet standalone cards holding slots outside the
+  // ticket pipeline.
+  const ACTIVE_RUN_STATUSES = new Set<FleetRunRow["status"]>([
     "claimed",
     "implementing",
     "reviewing",
     "blocked",
   ]);
-  const phasePipeline = (
-    status: FleetRunRow["status"]
-  ): NonNullable<RunningCard["phases"]> => {
-    const reviewReached = status === "reviewing";
-    return [
-      { name: "implement", state: reviewReached ? "done" : "current" },
-      { name: "review", state: reviewReached ? "current" : "todo" },
-      { name: "merge", state: "todo" },
-    ];
+  // The pass a run is currently executing. A run under review keeps its
+  // implement container parked (idle) for a possible fix-up while the review
+  // pass runs, so prefer the actively-running (non-idle) pass — otherwise the
+  // card would read as the paused implement rather than the live review.
+  const activePassOf = (runId: string): FleetTaskRow | null => {
+    const live = tasksOfRun(runId).filter(
+      (t) => t.containerStatus !== null && !TERMINAL_TASK_STATUSES.has(t.status)
+    );
+    const busy = live.filter((t) => t.containerStatus !== "idle");
+    const pool = busy.length > 0 ? busy : live;
+    return (
+      pool.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
+      null
+    );
   };
+  // The review stage is live for both the armed path (status `reviewing`) and a
+  // gated run whose review is still in flight (the only gated runs that reach
+  // Running — a landed verdict routes them to needs-you instead).
+  const phasePipeline = (
+    reviewing: boolean
+  ): NonNullable<RunningCard["phases"]> => [
+    { name: "implement", state: reviewing ? "done" : "current" },
+    { name: "review", state: reviewing ? "current" : "todo" },
+    { name: "merge", state: "todo" },
+  ];
 
   const running: RunningCard[] = rows.runs
-    .filter((r) => ACTIVE_RUN_STATUSES.has(r.status))
+    .filter(
+      (r) =>
+        ACTIVE_RUN_STATUSES.has(r.status) ||
+        // A gated run reads as activity only while its review is genuinely in
+        // flight — a live pass on a slot. Without one it is either between
+        // sweeps or already resolved, not something to show as running.
+        (r.status === "gated" &&
+          classifyGated(r).kind === "in-flight" &&
+          activePassOf(r.id) !== null)
+    )
     .sort((a, b) => a.claimedAt.getTime() - b.claimedAt.getTime())
     .map((run) => {
-      const task = currentTaskOf(run.id);
+      const pass = activePassOf(run.id);
+      const reviewing = run.status === "reviewing" || run.status === "gated";
+      // An in-flight review pass reads with its own spend against the review
+      // budget (issue #90); the run's rolled-up spend against the attempt
+      // budget would read as the implement pass and hide the review's cost.
+      const spend =
+        pass?.kind === "review"
+          ? { usd: pass.totalCostUsd, budgetUsd: DEFAULT_REVIEW_BUDGET_USD }
+          : { usd: run.totalCostUsd, budgetUsd: run.budgetUsd };
       return {
-        taskId: task?.id ?? null,
+        taskId: pass?.id ?? null,
         runId: run.id,
         projectName: projectName(run.projectId),
         ticket: ticketLabel(run.githubIssue),
-        title: task?.title ?? run.githubIssue,
+        title: pass?.title ?? run.githubIssue,
         mode: run.mode === "autonomous" ? ("afk" as const) : ("supervised" as const),
-        phases: phasePipeline(run.status),
+        phases: phasePipeline(reviewing),
         attempt: { current: run.attempt, max: MAX_ATTEMPTS },
-        turns: task?.turns ?? 0,
+        turns: pass?.turns ?? 0,
         startedAt: (run.startedAt ?? run.claimedAt).toISOString(),
-        spend: { usd: run.totalCostUsd, budgetUsd: run.budgetUsd },
+        spend,
       };
     });
 
-  for (const task of occupants.filter((t) => t.kind === "interactive")) {
+  // Standalone passes with no ticket pipeline: interactive chat sessions and
+  // read-only triage passes (issue #90). Triage reads as its own kind of work
+  // with the triage pass's spend against the triage budget; both take their
+  // face straight from the occupying task.
+  for (const task of occupants.filter(
+    (t) => t.kind === "interactive" || t.kind === "triage"
+  )) {
+    const triage = task.kind === "triage";
     running.push({
       taskId: task.id,
       runId: null,
       projectName: projectName(task.projectId),
       ticket: ticketLabel(task.githubIssue),
       title: task.title,
-      mode: "interactive",
+      mode: triage ? "triage" : "interactive",
       phases: null,
       attempt: null,
       turns: task.turns,
       startedAt: task.createdAt.toISOString(),
-      spend: { usd: task.totalCostUsd, budgetUsd: null },
+      spend: {
+        usd: task.totalCostUsd,
+        budgetUsd: triage ? DEFAULT_TRIAGE_BUDGET_USD : null,
+      },
     });
   }
 


### PR DESCRIPTION
Closes #90

## What & why

During the pilot re-test, review passes ran for PRs #17/#20 but "it looked like the PRs had no review." Three interrelated `buildFleetView` gaps, all fixed at the established read-model seam with table-driven tests:

### 1. Review (and triage) passes are now legible as fleet activity
- A **gated run whose review is still in flight** now appears under **Running** (previously invisible — `gated` was not an active status, so a gated review showed nowhere).
- The run's card face prefers the **actively-running pass** over its parked (idle) implement container, so a review reads as the review — new `activePassOf`.
- A review card shows the **review pass's own spend against the review budget** ($5), not the run's rolled-up spend against the $20 attempt budget, so what the review is costing is visible.
- **Triage passes** — which own no run — now surface as their own standalone `mode: "triage"` cards with the triage pass's spend.

### 2. Unparseable-verdict runs get their own needs-you cause
A run parked by `reviewResult.kind === "unparseable"` (terminal by design) was sitting in `gated` indistinguishable from a happy sign-off wait. It's now a distinct red **`unparseable`** needs-you cause: "Review verdict couldn't be read … parked, nothing merges until you look."

### 3. The sign-off bucket no longer fires prematurely
Per the scope addition: a gated run is a sign-off item **only once its review verdict has landed**. Before that the review is in flight → it reads as activity, not a needs-you item. This fixes PR #17 (CHANGES_REQUESTED mid-cycle) and PR #20 (no posted review) being flagged as "waits for your sign-off" while their reviews were still running.

## Design notes / one interpretation call for the reviewer

A single **`classifyGated`** helper is the sole source of truth for both a gated run's needs-you disposition and whether it still reads as fleet activity, so the two views can never disagree. Precedence: spent-repairs conflict → unreadable verdict → posted approve/escalate → in-flight.

**`escalate` is treated as a sign-off item, alongside `approve`.** The scope-addition's literal wording says the bucket fires "only once its review verdict is **approve** (the PR is one human merge away)." I read that as the owner reasoning about the concrete premature-fire bug (in-flight reviews with no landed verdict), not as a decision to drop `escalate`. `docs/runbook.md` (lines 166–170) is explicit that a PR gets `human-signoff` and appears as a needs-you sign-off item **both** when it touches a gated path (approved) **and** when the reviewer escalated — so an escalated PR is a genuine "waits for you" state. Excluding it would make escalated PRs invisible on the dashboard (not needs-you, not running, not recent), which contradicts the ticket's whole goal. Escalate therefore stays in `signoff` with a distinct body ("the reviewer escalated for your sign-off"). Flagging it here for the fresh-eyes reviewer; happy to split it into its own cause if the owner wants the literal reading.

## Changes
- `FleetRunRow` gains `reviewVerdict` / `reviewResult` (already on the DB row — no query change in `rows.ts`); `NeedsYouCause` gains `unparseable`; `RunningCard.mode` gains `triage`.
- Render sites updated: `needs-you.tsx` (`unparseable` label + red tone), `running-list.tsx` (typed `MODE_TONE`, triage chip).
- A `/code-review` self-review pass (Standards + Spec) ran against `origin/main`; its two actionable Standards findings are applied in the second commit (extracted `isLiveTask`; flattened the needs-you PR copy).

## Validation
- `pnpm test` — 451 passing (55 in `src/lib/fleet`, including new cases for in-flight/approve/escalate/unparseable sign-off, gated-review activity with review spend, and triage cards).
- `eslint` clean on all changed files; `tsc --noEmit` clean for the changed files (the two pre-existing `container-manager.test.ts` errors are untouched and predate this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)