### PR TITLE
Unparseable review verdict: one bounded format-retry before falling to human oversight

### DIFF
--- a/drizzle/0016_review_unparseable_count.sql
+++ b/drizzle/0016_review_unparseable_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `review_unparseable_count` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,588 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bcb2718c-7d82-449d-95c7-847f551cf116",
+  "prevId": "eac0a4fa-29bb-42c6-a09a-fa0b6ee6cb0b",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "review_unparseable_count": {
+          "name": "review_unparseable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "integration_count": {
+          "name": "integration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triage_result": {
+          "name": "triage_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786579200000,
       "tag": "0015_run_effort",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1786665600000,
+      "tag": "0016_review_unparseable_count",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -80,6 +80,13 @@ export const runs = sqliteTable("runs", {
     | { kind: "unparseable"; reason: string }
   >(),
   reviewCycleCount: int("review_cycle_count").notNull().default(0),
+  // Times a review pass produced an unparseable verdict this attempt (issue
+  // #89). A pure format slip — a substantively fine review whose final message
+  // just didn't lead with a VERDICT: line — buys one bounded re-queue with the
+  // parse failure fed back into the prompt, rather than costing a human
+  // intervention. Past MAX_UNPARSEABLE_REVIEW_RETRIES the verdict fails closed
+  // as before. Counted per attempt (never reset across review cycles).
+  reviewUnparseableCount: int("review_unparseable_count").notNull().default(0),
   // Repair passes run to resolve a CONFLICTING PR (issue #54). Counted per
   // conflict episode — reset to 0 once the PR is observed mergeable again, so
   // a fresh conflict earns fresh repairs; past MAX_INTEGRATION_ATTEMPTS a

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -163,7 +163,7 @@ function makeVerdict(overrides: Partial<PendingVerdict> = {}): PendingVerdict {
     result: { kind: "approve", body: "Verified against the ticket." },
     implementTaskId: "task-impl-1",
     reviewCycleCount: 0,
-    unparseableRetriesMade: 0,
+    reviewUnparseableCount: 0,
     ...overrides,
   };
 }
@@ -1355,7 +1355,7 @@ describe("decideNext — verdict-to-action mapping", () => {
         pendingVerdicts: [
           makeVerdict({
             result: { kind: "unparseable", reason: "no VERDICT line" },
-            unparseableRetriesMade: 0,
+            reviewUnparseableCount: 0,
           }),
         ],
       })
@@ -1381,7 +1381,7 @@ describe("decideNext — verdict-to-action mapping", () => {
         pendingVerdicts: [
           makeVerdict({
             result: { kind: "unparseable", reason: "still no VERDICT line" },
-            unparseableRetriesMade: 1,
+            reviewUnparseableCount: 1,
           }),
         ],
       })
@@ -1405,13 +1405,13 @@ describe("decideNext — verdict-to-action mapping", () => {
   it("never arms auto-merge from an unparseable verdict, whatever else is pending", () => {
     // The safety property: unparseable -> no armAutoMerge/postVerdict, whether
     // it retries (first) or fails closed (second).
-    for (const unparseableRetriesMade of [0, 1]) {
+    for (const reviewUnparseableCount of [0, 1]) {
       const actions = decideNext(
         makeSnapshot({
           pendingVerdicts: [
             makeVerdict({
               result: { kind: "unparseable", reason: "garbled output" },
-              unparseableRetriesMade,
+              reviewUnparseableCount,
             }),
           ],
           awaitingReview: [makeAwaitingReview({ runId: "run-2", prNumber: 44 })],
@@ -1431,7 +1431,7 @@ describe("decideNext — verdict-to-action mapping", () => {
         pendingVerdicts: [
           makeVerdict({
             result: { kind: "unparseable", reason: "no VERDICT line" },
-            unparseableRetriesMade: 1,
+            reviewUnparseableCount: 1,
           }),
         ],
         announcedVerdictErrors: ["run-1"],

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -59,6 +59,7 @@ function makeSnapshot(overrides: Partial<AutonomySnapshot> = {}): AutonomySnapsh
     maxAttempts: 3,
     maxInterruptions: 5,
     maxReviewCycles: 2,
+    maxUnparseableRetries: 1,
     maxIntegrationAttempts: 1,
     todayAutonomousSpendUsd: 0,
     dailyCapUsd: 500,
@@ -162,6 +163,7 @@ function makeVerdict(overrides: Partial<PendingVerdict> = {}): PendingVerdict {
     result: { kind: "approve", body: "Verified against the ticket." },
     implementTaskId: "task-impl-1",
     reviewCycleCount: 0,
+    unparseableRetriesMade: 0,
     ...overrides,
   };
 }
@@ -1195,6 +1197,25 @@ describe("decideNext — queueing the review pass", () => {
     expect(actions.filter((a) => a.type === "startReview")).toHaveLength(1);
     expect(claims(actions)).toEqual([]);
   });
+
+  it("reserves a claimable slot for a review it re-queues after an unparseable verdict", () => {
+    // The re-queued review will draw the one free slot, so a new claim must
+    // not double-book it — same reservation as a first review (issue #89).
+    const actions = decideNext(
+      makeSnapshot({
+        slots: { total: 2, occupied: 1, occupants: ["implement: acme/widgets#7"] },
+        pendingVerdicts: [
+          makeVerdict({
+            result: { kind: "unparseable", reason: "no VERDICT line" },
+          }),
+        ],
+        candidates: [makeCandidate({ issueRef: "acme/widgets#9", number: 9 })],
+      })
+    );
+
+    expect(actions.filter((a) => a.type === "retryReview")).toHaveLength(1);
+    expect(claims(actions)).toEqual([]);
+  });
 });
 
 describe("decideNext — verdict-to-action mapping", () => {
@@ -1325,13 +1346,42 @@ describe("decideNext — verdict-to-action mapping", () => {
     ]);
   });
 
-  it("maps an unparseable verdict to a notification and nothing else", () => {
+  it("re-queues the review once on a first unparseable verdict, feeding the parse failure back", () => {
+    // Issue #89: a pure format slip earns one bounded retry before anyone is
+    // paged. The parse failure rides along so the pass can restate in shape.
     const actions = decideNext(
       makeSnapshot({
         candidates: [],
         pendingVerdicts: [
           makeVerdict({
             result: { kind: "unparseable", reason: "no VERDICT line" },
+            unparseableRetriesMade: 0,
+          }),
+        ],
+      })
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "retryReview",
+        runId: "run-1",
+        issueRef: "acme/widgets#7",
+        prNumber: 41,
+        armed: true,
+        parseFailure: "no VERDICT line",
+      },
+    ]);
+  });
+
+  it("fails closed on a second unparseable verdict — notify, no further retry", () => {
+    // The one retry is spent, so the verdict now falls to human oversight.
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        pendingVerdicts: [
+          makeVerdict({
+            result: { kind: "unparseable", reason: "still no VERDICT line" },
+            unparseableRetriesMade: 1,
           }),
         ],
       })
@@ -1345,7 +1395,7 @@ describe("decideNext — verdict-to-action mapping", () => {
           runId: "run-1",
           issueRef: "acme/widgets#7",
           prNumber: 41,
-          reason: "no VERDICT line",
+          reason: "still no VERDICT line",
           armed: true,
         },
       },
@@ -1353,30 +1403,35 @@ describe("decideNext — verdict-to-action mapping", () => {
   });
 
   it("never arms auto-merge from an unparseable verdict, whatever else is pending", () => {
-    // The safety property named by the ticket: unparseable -> no armAutoMerge.
-    const actions = decideNext(
-      makeSnapshot({
-        pendingVerdicts: [
-          makeVerdict({
-            result: { kind: "unparseable", reason: "garbled output" },
-          }),
-        ],
-        awaitingReview: [makeAwaitingReview({ runId: "run-2", prNumber: 44 })],
-      })
-    );
+    // The safety property: unparseable -> no armAutoMerge/postVerdict, whether
+    // it retries (first) or fails closed (second).
+    for (const unparseableRetriesMade of [0, 1]) {
+      const actions = decideNext(
+        makeSnapshot({
+          pendingVerdicts: [
+            makeVerdict({
+              result: { kind: "unparseable", reason: "garbled output" },
+              unparseableRetriesMade,
+            }),
+          ],
+          awaitingReview: [makeAwaitingReview({ runId: "run-2", prNumber: 44 })],
+        })
+      );
 
-    expect(
-      actions.filter((a) => a.type === "armAutoMerge" || a.type === "postVerdict")
-    ).toEqual([]);
+      expect(
+        actions.filter((a) => a.type === "armAutoMerge" || a.type === "postVerdict")
+      ).toEqual([]);
+    }
   });
 
-  it("announces an unparseable verdict once, not once per sweep", () => {
+  it("announces an exhausted unparseable verdict once, not once per sweep", () => {
     const actions = decideNext(
       makeSnapshot({
         candidates: [],
         pendingVerdicts: [
           makeVerdict({
             result: { kind: "unparseable", reason: "no VERDICT line" },
+            unparseableRetriesMade: 1,
           }),
         ],
         announcedVerdictErrors: ["run-1"],
@@ -2038,6 +2093,7 @@ describe("arming boundary — interlude never applies ready-for-agent", () => {
     "armAutoMerge",
     "escalate",
     "startReview",
+    "retryReview",
     "postVerdict",
     "deliverFeedback",
     "finalizeRun",

--- a/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildImplementPrompt, resolveWorkflowSkill } from "../workflow";
+import {
+  buildImplementPrompt,
+  buildReviewPrompt,
+  resolveWorkflowSkill,
+} from "../workflow";
 
 const TICKET = {
   repo: "acme/widgets",
@@ -161,5 +165,43 @@ describe("buildImplementPrompt", () => {
         prompt.indexOf("--- PRIOR ATTEMPTS")
       );
     });
+  });
+});
+
+describe("buildReviewPrompt", () => {
+  const REVIEW = {
+    repo: "acme/widgets",
+    issueNumber: 7,
+    issueTitle: "Add the frobnicator",
+    issueBody: "Make the frobnicator frob.",
+    prNumber: 41,
+    armed: true,
+  };
+
+  it("carries no retry note on a first review", () => {
+    const prompt = buildReviewPrompt(REVIEW);
+    expect(prompt).not.toContain("this is a retry");
+    expect(prompt).not.toContain("NOTE —");
+  });
+
+  it("feeds the parse failure back on a re-queue (issue #89)", () => {
+    const prompt = buildReviewPrompt({
+      ...REVIEW,
+      parseFailure: "final message does not start with a VERDICT: line",
+    });
+    expect(prompt).toContain("this is a retry");
+    expect(prompt).toContain(
+      "final message does not start with a VERDICT: line"
+    );
+    expect(prompt).toContain("last retry");
+    // Still demands the same verdict shape the parser expects.
+    expect(prompt).toContain("VERDICT: approve");
+  });
+
+  it("places the retry note after the verdict-shape instructions", () => {
+    const prompt = buildReviewPrompt({ ...REVIEW, parseFailure: "no VERDICT line" });
+    expect(prompt.indexOf("blocks the merge and pages the owner")).toBeLessThan(
+      prompt.indexOf("this is a retry")
+    );
   });
 });

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -90,6 +90,16 @@ export const MAX_INTERRUPTIONS_PER_TICKET = 5;
  * request-changes fails the attempt instead of looping. */
 export const MAX_REVIEW_CYCLES_PER_ATTEMPT = 2;
 
+/** Re-queues a review pass earns after returning an unparseable verdict
+ * (issue #89). The common cause is a pure format slip — a substantively fine
+ * review whose final message just didn't lead with a `VERDICT:` line — which
+ * today fails closed terminally and costs a human intervention. One bounded
+ * retry, with the parse failure fed back into the prompt, removes it. A second
+ * unparseable verdict falls to the existing fail-closed path (nothing posted,
+ * human oversight). Counted per attempt on runs.review_unparseable_count, so a
+ * review that dies or slips its format once is retried, twice is a human's. */
+export const MAX_UNPARSEABLE_REVIEW_RETRIES = 1;
+
 /** Estate-wide daily autonomous spend cap in USD. Reaching it pauses pickup
  * until local midnight; interactive tasks (no run row) are exempt by
  * construction. */

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -115,6 +115,11 @@ export interface PendingVerdict {
   implementTaskId: string | null;
   /** Fix-up turns already bought by request-changes verdicts this attempt */
   reviewCycleCount: number;
+  /** Unparseable verdicts this attempt has already been re-queued for
+   * (runs.reviewUnparseableCount). Below `maxUnparseableRetries` an
+   * unparseable verdict buys one more review pass with the parse failure fed
+   * back; at or past it the verdict fails closed (issue #89). */
+  unparseableRetriesMade: number;
 }
 
 /** An implement turn that just finished, up for a park-or-proceed decision. */
@@ -210,6 +215,9 @@ export interface AutonomySnapshot {
   maxInterruptions: number;
   /** Implement↔review cycles allowed within one attempt */
   maxReviewCycles: number;
+  /** Unparseable review verdicts re-queued per attempt before one fails
+   * closed (issue #89) */
+  maxUnparseableRetries: number;
   /** Repair passes allowed per conflict episode before a still-CONFLICTING
    * parked PR escalates to a human */
   maxIntegrationAttempts: number;
@@ -333,6 +341,20 @@ export type Action =
       payload: { runId: string; issueRef: string; prNumber: number; reason: string };
     }
   | { type: "startReview"; runId: string; issueRef: string; prNumber: number; armed: boolean }
+  | {
+      // Re-queue a review pass whose prior verdict was unparseable (issue #89),
+      // feeding the parse failure back so it can restate the verdict in shape.
+      // The executor clears the stored result and counts the retry; a second
+      // unparseable verdict falls to the fail-closed `verdict-unparseable` path.
+      type: "retryReview";
+      runId: string;
+      issueRef: string;
+      prNumber: number;
+      armed: boolean;
+      /** Why the prior verdict could not be parsed — injected into the retry
+       * prompt verbatim (parser-generated, never container-controlled text) */
+      parseFailure: string;
+    }
   | {
       type: "postVerdict";
       runId: string;
@@ -459,6 +481,7 @@ export function passOutcomeSnapshot(now: Date, pass: PassOutcome): AutonomySnaps
     maxAttempts: 0,
     maxInterruptions: 0,
     maxReviewCycles: 0,
+    maxUnparseableRetries: 0,
     maxIntegrationAttempts: 0,
     todayAutonomousSpendUsd: 0,
     dailyCapUsd: 0,
@@ -677,13 +700,35 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
   // (review post and fix-up together) for a later sweep: posting the review
   // without delivering the feedback would strand the run mid-cycle.
   let slotsLeft = Math.max(0, snapshot.slots.total - snapshot.slots.occupied);
+  // A re-queued review reserves the slot it will draw exactly as a first
+  // review does, so it is counted with the fresh reviews below when new claims
+  // work out how many slots remain.
+  let reviewsQueuedThisSweep = 0;
   for (const pending of snapshot.pendingVerdicts) {
     if (blockedRunIds.has(pending.runId)) continue;
     const { result } = pending;
 
     if (result.kind === "unparseable") {
-      // The fail-closed case: no review is posted, nothing is armed, the
-      // owner is told (once). The executor disarms and adds human oversight.
+      // A pure format slip is the common cause — a substantively fine review
+      // whose final message just didn't lead with a VERDICT: line — so the
+      // pass earns one bounded re-queue with the parse failure fed back before
+      // anyone is paged (issue #89). Like a first review, this reserves intent,
+      // not a slot: the queue applies the capacity check when it starts.
+      if (pending.unparseableRetriesMade < snapshot.maxUnparseableRetries) {
+        reviewsQueuedThisSweep++;
+        actions.push({
+          type: "retryReview",
+          runId: pending.runId,
+          issueRef: pending.issueRef,
+          prNumber: pending.prNumber,
+          armed: pending.armed,
+          parseFailure: result.reason,
+        });
+        continue;
+      }
+      // Retries spent: the fail-closed case. No review is posted, nothing is
+      // armed, the owner is told (once). The executor disarms and adds human
+      // oversight, leaving the stored result in place as the record.
       if (!snapshot.announcedVerdictErrors.includes(pending.runId)) {
         actions.push({
           type: "notify",
@@ -767,7 +812,7 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
   // Review passes are queued before gate decisions and claims: they finish
   // work already in flight. The queue starts them under the ordinary
   // capacity check, so emitting one here only reserves intent, not a slot.
-  let reviewsQueuedThisSweep = 0;
+  // (reviewsQueuedThisSweep was seeded above by any unparseable re-queues.)
   for (const awaiting of snapshot.awaitingReview) {
     if (blockedRunIds.has(awaiting.runId)) continue;
     if (awaiting.hasReviewTask) continue;

--- a/src/lib/orchestrator/autonomy/decide.ts
+++ b/src/lib/orchestrator/autonomy/decide.ts
@@ -115,11 +115,12 @@ export interface PendingVerdict {
   implementTaskId: string | null;
   /** Fix-up turns already bought by request-changes verdicts this attempt */
   reviewCycleCount: number;
-  /** Unparseable verdicts this attempt has already been re-queued for
+  /** Unparseable verdicts this attempt has already produced
    * (runs.reviewUnparseableCount). Below `maxUnparseableRetries` an
    * unparseable verdict buys one more review pass with the parse failure fed
-   * back; at or past it the verdict fails closed (issue #89). */
-  unparseableRetriesMade: number;
+   * back; at or past it the verdict fails closed (issue #89). Named to mirror
+   * the sibling `reviewCycleCount`. */
+  reviewUnparseableCount: number;
 }
 
 /** An implement turn that just finished, up for a park-or-proceed decision. */
@@ -714,7 +715,7 @@ export function decideNext(snapshot: AutonomySnapshot): Action[] {
       // pass earns one bounded re-queue with the parse failure fed back before
       // anyone is paged (issue #89). Like a first review, this reserves intent,
       // not a slot: the queue applies the capacity check when it starts.
-      if (pending.unparseableRetriesMade < snapshot.maxUnparseableRetries) {
+      if (pending.reviewUnparseableCount < snapshot.maxUnparseableRetries) {
         reviewsQueuedThisSweep++;
         actions.push({
           type: "retryReview",

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -491,7 +491,7 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
         result: run.reviewResult,
         implementTaskId: liveImplementTaskId(run.id),
         reviewCycleCount: run.reviewCycleCount,
-        unparseableRetriesMade: run.reviewUnparseableCount,
+        reviewUnparseableCount: run.reviewUnparseableCount,
       });
       continue;
     }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -87,6 +87,7 @@ import {
   MAX_INTERRUPTIONS_PER_TICKET,
   MAX_REVIEW_CYCLES_PER_ATTEMPT,
   MAX_TRIAGE_PASSES_PER_ISSUE,
+  MAX_UNPARSEABLE_REVIEW_RETRIES,
 } from "./budgets";
 
 const SWEEP_INTERVAL_MS = 30_000;
@@ -345,6 +346,7 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     maxAttempts: MAX_ATTEMPTS,
     maxInterruptions: MAX_INTERRUPTIONS_PER_TICKET,
     maxReviewCycles: MAX_REVIEW_CYCLES_PER_ATTEMPT,
+    maxUnparseableRetries: MAX_UNPARSEABLE_REVIEW_RETRIES,
     maxIntegrationAttempts: MAX_INTEGRATION_ATTEMPTS,
     todayAutonomousSpendUsd: todayAutonomousSpendUsd(now),
     dailyCapUsd: DAILY_AUTONOMOUS_CAP_USD,
@@ -489,6 +491,7 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
         result: run.reviewResult,
         implementTaskId: liveImplementTaskId(run.id),
         reviewCycleCount: run.reviewCycleCount,
+        unparseableRetriesMade: run.reviewUnparseableCount,
       });
       continue;
     }
@@ -814,6 +817,9 @@ async function executeActions(actions: Action[]): Promise<void> {
       case "startReview":
         await executeStartReview(action);
         break;
+      case "retryReview":
+        await executeRetryReview(action);
+        break;
       case "postVerdict": {
         const posted = await executePostVerdict(action);
         if (!posted) failedVerdictPosts.add(action.runId);
@@ -1014,6 +1020,69 @@ async function executeStartReview(
   const run = db.select().from(runs).where(eq(runs.id, action.runId)).get();
   if (!run) return;
 
+  const taskId = await queueReviewTask(run, ref, action.prNumber, action.armed);
+  if (taskId) {
+    console.log(
+      `[autonomy] Queued review of ${action.issueRef} PR #${action.prNumber} -> task ${taskId}`
+    );
+  }
+}
+
+/**
+ * Re-queue a review pass after an unparseable verdict (issue #89): a bounded
+ * one-shot that feeds the parse failure back so the pass can restate its
+ * verdict in shape, rather than a pure format slip costing a human's time. The
+ * stored result and the retry count are only touched once the new task is in
+ * the queue — a GitHub read failure leaves the unparseable result in place so
+ * the next sweep retries the whole step without burning the retry.
+ */
+async function executeRetryReview(
+  action: Extract<Action, { type: "retryReview" }>
+): Promise<void> {
+  const ref = parseIssueRef(action.issueRef);
+  if (!ref) return;
+
+  const run = db.select().from(runs).where(eq(runs.id, action.runId)).get();
+  if (!run) return;
+
+  const taskId = await queueReviewTask(
+    run,
+    ref,
+    action.prNumber,
+    action.armed,
+    action.parseFailure
+  );
+  if (!taskId) return;
+
+  db.update(runs)
+    .set({
+      reviewResult: null,
+      reviewUnparseableCount: run.reviewUnparseableCount + 1,
+    })
+    .where(eq(runs.id, run.id))
+    .run();
+
+  console.log(
+    `[autonomy] Re-queued review of ${action.issueRef} PR #${action.prNumber} ` +
+      `after unparseable verdict -> task ${taskId}`
+  );
+}
+
+/**
+ * Queue one review-pass task for a run: read the live issue, build the prompt
+ * from the vendored reviewer definition (never from anything a container
+ * wrote), and insert the task. `parseFailure` is set only on a retry after an
+ * unparseable verdict (issue #89). Returns the new task ID, or null if the
+ * GitHub read or definition load failed — the caller leaves the run untouched
+ * so the next sweep retries.
+ */
+async function queueReviewTask(
+  run: typeof runs.$inferSelect,
+  ref: { owner: string; repo: string; number: number },
+  prNumber: number,
+  armed: boolean,
+  parseFailure?: string
+): Promise<string | null> {
   try {
     const octokit = await getOctokit();
     const { data: issue } = await octokit.rest.issues.get({
@@ -1034,8 +1103,9 @@ async function executeStartReview(
       issueNumber: ref.number,
       issueTitle: issue.title,
       issueBody: issue.body ?? "",
-      prNumber: action.prNumber,
-      armed: action.armed,
+      prNumber,
+      armed,
+      parseFailure,
     });
 
     const now = new Date();
@@ -1044,25 +1114,27 @@ async function executeStartReview(
       .values({
         id: taskId,
         projectId: run.projectId,
-        title: `Review PR #${action.prNumber}: ${issue.title}`,
+        title: `Review PR #${prNumber}: ${issue.title}`,
         description: prompt,
         status: "queued",
         kind: "review",
         runId: run.id,
-        githubIssue: action.issueRef,
+        githubIssue: `${ref.owner}/${ref.repo}#${ref.number}`,
         branch,
         createdAt: now,
         updatedAt: now,
       })
       .run();
 
-    console.log(
-      `[autonomy] Queued review of ${action.issueRef} PR #${action.prNumber} -> task ${taskId}`
-    );
+    return taskId;
   } catch (err) {
     // Missing reviewer definition or a GitHub read failure: the run stays
     // awaiting review and the next sweep retries.
-    console.error(`[autonomy] Failed to queue review for ${action.issueRef}:`, err);
+    console.error(
+      `[autonomy] Failed to queue review for ${ref.owner}/${ref.repo}#${ref.number}:`,
+      err
+    );
+    return null;
   }
 }
 

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -104,6 +104,10 @@ export interface ReviewTicket {
   prNumber: number;
   /** Auto-merge armed (an approval lands it) vs gated behind human-signoff */
   armed: boolean;
+  /** Set on a re-queue after the prior pass returned an unparseable verdict
+   * (issue #89): the parse failure, fed back so this pass restates its verdict
+   * in the required shape. Parser-generated text, never container-controlled. */
+  parseFailure?: string;
 }
 
 /**
@@ -124,6 +128,22 @@ export function buildReviewPrompt(ticket: ReviewTicket): string {
       `#${ticket.prNumber} on the default branch immediately.`
     : `Merge state: GATED — the PR carries \`human-signoff\` and auto-merge ` +
       `is off; your review informs the human who merges.`;
+
+  // On a re-queue after an unparseable verdict (issue #89), the prior pass's
+  // parse failure is fed back so this pass restates the verdict in shape. The
+  // reason is parser-generated, so it cannot smuggle instructions past the
+  // operating rules; it is guidance about format, not about the review.
+  const retryNote = ticket.parseFailure
+    ? [
+        ``,
+        `NOTE — this is a retry. A previous review pass reviewed this same PR ` +
+          `but its final message could not be parsed as a verdict ` +
+          `(${ticket.parseFailure}), so nothing was posted. Review the PR ` +
+          `again and this time make your final message begin with the ` +
+          `VERDICT: line in exactly the shape below. This is the last retry — ` +
+          `a second unparseable verdict falls to human oversight.`,
+      ]
+    : [];
 
   return [
     `You are an autonomous review pass for PR #${ticket.prNumber} of ` +
@@ -157,6 +177,7 @@ export function buildReviewPrompt(ticket: ReviewTicket): string {
       `non-empty body.`,
     ``,
     `A final message in any other shape blocks the merge and pages the owner.`,
+    ...retryNote,
   ].join("\n");
 }
 


### PR DESCRIPTION
Closes #89

## What & why

The first live occurrence (platform#16 / PR #20) was a review pass that wrote a substantively fine review whose final message just didn't lead with the required `VERDICT:` line. The orchestrator correctly failed closed — but *terminally*: no retry existed, so a pure format slip cost a human intervention.

This adds one bounded format-retry. On a `kind: unparseable` verdict the reducer now re-queues the review pass **once**, feeding the parse failure back into the prompt so it can restate the verdict in shape. A **second** unparseable verdict falls to the existing fail-closed path (nothing posted, disarmed, `human-signoff`, owner notified once) — unchanged.

## How

- **Schema:** `runs.reviewUnparseableCount` (int, default 0), migration `0016`. Counted per attempt, mirroring the sibling `reviewCycleCount`.
- **Bound:** `MAX_UNPARSEABLE_REVIEW_RETRIES = 1` in `budgets.ts`.
- **Reducer (`decideNext`, pure):** a new `retryReview` Action on the first unparseable verdict (below the bound); the fail-closed `notify` only fires once retries are spent. The re-queue reserves a slot exactly like a first review, so a new claim can't double-book it.
- **Prompt (`buildReviewPrompt`):** an optional `parseFailure` appends a retry note ("this is a retry … make your final message begin with the `VERDICT:` line … last retry").
- **Executor (`sweep.ts`):** `executeRetryReview` shares a new `queueReviewTask` helper with `executeStartReview` (removes a duplicated task-insert block). It clears the stored `reviewResult` and increments the counter **only after** the new task is queued, so a GitHub-read failure retries the whole step without burning the retry.

The fed-back parse-failure reason is parser-generated (`verdict.ts` / `pass-output.ts` — fixed strings plus the CLI's `result.subtype`), never the container's free-text message, so it opens no prompt-injection surface.

## Scope

Per the ticket, the "sibling fact" (unset `DISCORD_FLEET_CHANNEL_ID`) is operational, not code — deliberately untouched.

## Testing

- `pnpm test` — 451 passing (added: retry-then-notify in the reducer, the retry's slot reservation, the never-arm safety property across `reviewUnparseableCount ∈ {0,1}`, and the `parseFailure` feedback in `buildReviewPrompt`).
- `tsc --noEmit` — no new errors (one pre-existing error in `src/lib/docker/__tests__/container-manager.test.ts`, unrelated and on `main`).
- ESLint clean on all changed files (repo-wide lint has a known pre-existing baseline of unrelated errors on `main`).

## Self-review (rework-avoidance, not the gate)

Ran `/code-review` against `origin/main` with #89 as the spec. Spec axis: clean. Standards axis: two minor judgement calls — (1) a snapshot/DB naming asymmetry, **acted on** (renamed the snapshot field to `reviewUnparseableCount`); (2) `queueReviewTask`'s five positional params — **left as-is**: it matches the pre-existing positional style of `executeStartReview` and the extraction is a net DRY win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
