### PR TITLE
Review sessions in the UI: link the run card to its review task, not the finished implement pass

### DIFF
--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -881,7 +881,7 @@ describe("buildFleetView — running", () => {
   });
 
   it("picks a run's live pass as its face, ignoring a finished pass with a stale container_status", () => {
-    // Issue #46, sibling path: currentTaskOf must not surface a terminal task
+    // Issue #46, sibling path: currentPassOf must not surface a terminal task
     // as a run's current face just because it still carries container_status.
     const view = buildFleetView(
       baseRows({
@@ -916,6 +916,143 @@ describe("buildFleetView — running", () => {
     expect(view.running).toHaveLength(1);
     expect(view.running[0].taskId).toBe("t-live");
     expect(view.running[0].title).toBe("Live review pass");
+  });
+
+  it("keeps a reviewing run's card on its review pass after the review container is gone (issue #96)", () => {
+    // Symptom 1: the review pass has completed (terminal task.status, container
+    // torn down) but the run is still `reviewing` until the next sweep posts the
+    // verdict, and the implement pass sits parked running/idle beside it. The
+    // card must point at the review task, not the finished implement pass.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [makeRun({ id: "r1", projectId: "p1", status: "reviewing" })],
+        tasks: [
+          makeTask({
+            id: "t-impl",
+            projectId: "p1",
+            runId: "r1",
+            kind: "implement",
+            title: "Add auth",
+            status: "running",
+            containerStatus: "idle",
+            createdAt: new Date(2026, 7, 1, 9, 0, 0),
+          }),
+          makeTask({
+            id: "t-review",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Review PR #55: Add auth",
+            status: "completed",
+            containerStatus: null,
+            createdAt: new Date(2026, 7, 1, 9, 30, 0),
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toHaveLength(1);
+    expect(view.running[0].taskId).toBe("t-review");
+    expect(view.running[0].title).toBe("Review PR #55: Add auth");
+  });
+
+  it("resolves a reviewing run's face by phase, not by a stale busy implement (issue #96)", () => {
+    // An ungraceful death can leave the implement pass at running/running
+    // instead of parked idle. Selecting purely by container-busyness would pick
+    // that stale implement; selecting within the run's phase (review) picks the
+    // review pass even while its own container is momentarily idle between turns.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [makeRun({ id: "r1", projectId: "p1", status: "reviewing" })],
+        tasks: [
+          makeTask({
+            id: "t-impl",
+            projectId: "p1",
+            runId: "r1",
+            kind: "implement",
+            status: "running",
+            containerStatus: "running", // stale — never parked to idle
+            createdAt: new Date(2026, 7, 1, 9, 0, 0),
+          }),
+          makeTask({
+            id: "t-review",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Review PR #55",
+            status: "running",
+            containerStatus: "idle", // between review turns
+            createdAt: new Date(2026, 7, 1, 9, 30, 0),
+          }),
+        ],
+      })
+    );
+
+    expect(view.running[0].taskId).toBe("t-review");
+  });
+
+  it("resolves duplicate review passes to the one actually running (issue #95)", () => {
+    // Two review passes on one run (issue #95): the card links to the container
+    // that is really executing, not the dead earlier attempt.
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [makeRun({ id: "r1", projectId: "p1", status: "reviewing" })],
+        tasks: [
+          makeTask({
+            id: "t-review-old",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            status: "failed",
+            containerStatus: null,
+            createdAt: new Date(2026, 7, 1, 9, 0, 0),
+          }),
+          makeTask({
+            id: "t-review-live",
+            projectId: "p1",
+            runId: "r1",
+            kind: "review",
+            title: "Review PR #55 (retry)",
+            status: "running",
+            containerStatus: "running",
+            createdAt: new Date(2026, 7, 1, 9, 30, 0),
+          }),
+        ],
+      })
+    );
+
+    expect(view.running[0].taskId).toBe("t-review-live");
+  });
+
+  it("does not link a reviewing run to the parked implement before its review pass exists (issue #96)", () => {
+    // The status flips to `reviewing` a sweep before the review pass is queued.
+    // In that window the card must not fall back to the parked implement — it
+    // shows as a non-clickable review card until the review task appears, rather
+    // than deep-linking to the finished implement task (the exact symptom 1).
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "lemons" })],
+        runs: [makeRun({ id: "r1", projectId: "p1", status: "reviewing" })],
+        tasks: [
+          makeTask({
+            id: "t-impl",
+            projectId: "p1",
+            runId: "r1",
+            kind: "implement",
+            title: "Add auth",
+            status: "running",
+            containerStatus: "idle",
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toHaveLength(1);
+    expect(view.running[0].runId).toBe("r1");
+    expect(view.running[0].taskId).toBeNull();
   });
 
   it("surfaces a gated run under review as fleet activity with the review pass's spend (issue #90)", () => {

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -277,20 +277,58 @@ export function buildFleetView(rows: FleetRows): FleetView {
     .reduce((sum, r) => sum + r.totalCostUsd, 0);
   const capPaused = todayUsd >= rows.dailyCapUsd;
 
-  // A run's face in the UI is its latest task — the live container if one
-  // exists, otherwise the most recently created pass. A finished pass with a
-  // stale container_status is not "live" (issue #46), so the same terminal
-  // guard applies here as in the occupants filter.
   const tasksOfRun = (runId: string) =>
     rows.tasks.filter((t) => t.runId === runId);
-  const currentTaskOf = (runId: string) => {
-    const owned = tasksOfRun(runId);
-    return (
-      owned.find(isLiveTask) ??
-      owned.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
-      null
-    );
+
+  // Newest pass first, with a stable id tiebreak so a createdAt collision
+  // between two passes can't resolve arbitrarily (ULIDs sort by creation time).
+  const byNewest = (a: FleetTaskRow, b: FleetTaskRow) =>
+    b.createdAt.getTime() - a.createdAt.getTime() || b.id.localeCompare(a.id);
+
+  // A pass whose container is actually executing: live (issue #46's terminal
+  // guard) and not parked idle. The one predicate behind both pickPass's busy
+  // preference and the gated-run activity gate (hasBusyPass).
+  const isBusyPass = (t: FleetTaskRow): boolean =>
+    isLiveTask(t) && t.containerStatus !== "idle";
+
+  // The pass kinds that make up a run's current phase: a reviewing or gated run
+  // is on its review pass; every other status is on its implement/repair pass.
+  // This mirrors the orchestrator's own workingTaskOf, which selects the working
+  // pass by kind — the view must resolve a run's face by phase, not by inferring
+  // it from container_status races (issue #96).
+  const phaseKinds = (status: FleetRunRow["status"]): FleetTaskRow["kind"][] =>
+    status === "reviewing" || status === "gated"
+      ? ["review"]
+      : ["implement", "repair"];
+
+  // Pick a run's face from the passes of its current phase: prefer the container
+  // actually executing, else the newest. When the review pass has finished but
+  // the run is still reviewing (its container gone, or idle between turns), no
+  // pass is busy, so the newest — deliberately including that finished review
+  // pass — is returned. That is the point: the card stays on the review pass
+  // rather than the parked implement beside it (issue #96, symptom 1).
+  const pickPass = (pool: FleetTaskRow[]): FleetTaskRow | null => {
+    const busy = pool.filter(isBusyPass);
+    return (busy.length > 0 ? busy : pool).sort(byNewest)[0] ?? null;
   };
+
+  // A run's live face — the task its card shows and links to — resolved within
+  // the run's current phase only. If that phase owns no pass yet (a brief window
+  // after the status flips to reviewing, before the review pass is queued), the
+  // card links nowhere rather than falling back to the wrong-phase implement
+  // pass: a non-clickable review card, not a link to the finished implement task
+  // (issue #96). It also resolves duplicate review passes (issue #95) to the one
+  // really running.
+  const currentPassOf = (run: FleetRunRow): FleetTaskRow | null =>
+    pickPass(
+      tasksOfRun(run.id).filter((t) => phaseKinds(run.status).includes(t.kind))
+    );
+
+  // Whether a run has a container actually executing right now — a live,
+  // non-idle pass on a slot. A gated run reads as fleet activity only while this
+  // holds; without it the run is between sweeps or already resolved (issue #90).
+  const hasBusyPass = (runId: string): boolean =>
+    tasksOfRun(runId).some(isBusyPass);
 
   const runContext = (run: FleetRunRow) =>
     `${projectName(run.projectId)} ${ticketLabel(run.githubIssue) ?? run.githubIssue} · attempt ${run.attempt}/${MAX_ATTEMPTS}`;
@@ -306,7 +344,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
         href: `https://discord.com/channels/${rows.discordGuildId}/${channelId}`,
       };
     }
-    const task = currentTaskOf(run.id);
+    const task = currentPassOf(run);
     return task ? { label: "Open task", href: `/tasks/${task.id}` } : null;
   };
 
@@ -441,19 +479,6 @@ export function buildFleetView(rows: FleetRows): FleetView {
     "reviewing",
     "blocked",
   ]);
-  // The pass a run is currently executing. A run under review keeps its
-  // implement container parked (idle) for a possible fix-up while the review
-  // pass runs, so prefer the actively-running (non-idle) pass — otherwise the
-  // card would read as the paused implement rather than the live review.
-  const activePassOf = (runId: string): FleetTaskRow | null => {
-    const live = tasksOfRun(runId).filter(isLiveTask);
-    const busy = live.filter((t) => t.containerStatus !== "idle");
-    const pool = busy.length > 0 ? busy : live;
-    return (
-      pool.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
-      null
-    );
-  };
   // The review stage is live for both the armed path (status `reviewing`) and a
   // gated run whose review is still in flight (the only gated runs that reach
   // Running — a landed verdict routes them to needs-you instead).
@@ -474,11 +499,11 @@ export function buildFleetView(rows: FleetRows): FleetView {
         // sweeps or already resolved, not something to show as running.
         (r.status === "gated" &&
           classifyGated(r).kind === "in-flight" &&
-          activePassOf(r.id) !== null)
+          hasBusyPass(r.id))
     )
     .sort((a, b) => a.claimedAt.getTime() - b.claimedAt.getTime())
     .map((run) => {
-      const pass = activePassOf(run.id);
+      const pass = currentPassOf(run);
       const reviewing = run.status === "reviewing" || run.status === "gated";
       // An in-flight review pass reads with its own spend against the review
       // budget (issue #90); the run's rolled-up spend against the attempt
@@ -555,7 +580,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
     const outcome = RUN_OUTCOMES[run.status];
     const finishedAt = run.finishedAt;
     if (!outcome || !finishedAt || finishedAt.getTime() < windowStart) continue;
-    const task = currentTaskOf(run.id);
+    const task = currentPassOf(run);
     recentItems.push({
       title: task?.title ?? run.githubIssue,
       projectName: projectName(run.projectId),


### PR DESCRIPTION
Closes #96

## The bug

Watching the fleet dashboard during the LPS batch, a running **review** session's card sometimes navigated to the run's **finished implement task** instead of the review task (symptom 1), and sometimes the review task didn't visibly appear at all despite a review container running (symptom 2).

Root cause: the Running card linked to `activePassOf(run.id)?.id`, and **neither** `activePassOf` nor `currentTaskOf` selected by `tasks.kind` — even though the orchestrator's own `workingTaskOf` does. During review the implement pass is parked `status:"running"`/`containerStatus:"idle"` **by design** (issue #17) while the review pass runs. Once the review pass reaches a terminal `task.status` (its container torn down) but the run is still `reviewing`/`gated` until the next sweep posts the verdict, `activePassOf` finds no busy pass and falls back to the only live task — the parked implement. So the review card links to the finished implement pass, and the review session has no visible face of its own. Under the slow sweeps of the memory-pressure incident, that window was wide open.

## The fix

Resolve a run's dashboard face **by phase**:

- `phaseKinds(run.status)` names the pass kind for the phase — `review` for `reviewing`/`gated`, `implement`/`repair` otherwise — mirroring the orchestrator's `workingTaskOf`.
- `currentPassOf` picks **within that phase only**: prefer the container actually executing, else the newest (deliberately including a *finished* review pass, so a reviewing card stays on its review pass even after the container is gone). It does **not** fall back across phases — before the review pass is queued the card links nowhere (a non-clickable review card) rather than deep-linking to the parked implement, which would be the exact symptom again.
- Duplicate review passes (#95) resolve to the one really running.

It also unifies the two previously-divergent selectors (`activePassOf`, `currentTaskOf`) into one `currentPassOf`, used by the running card, the blocked deep-link, and the recent ledger. A shared `isBusyPass` predicate is extracted; a boolean `hasBusyPass` gates the gated-in-flight "is this fleet activity" check so #90's between-sweeps semantics are preserved.

## Deliberate scope / consequences (called out in self-review)

- **Recent-ledger title change** (side effect of unifying selectors): a terminal run is now titled by its **implement** pass (the actual work, e.g. "Add auth") rather than whatever pass was newest (often "Review PR #55: …"). This is an improvement and is what the ledger should show; flagging it since it wasn't strictly requested.
- **Invariant is bounded to *executing* containers.** A parked-idle implement is a live container that holds no slot (#17) and intentionally has no separate session card; duplicate review containers (#95, a separate cause listed in the issue) still collapse to one card. Fully honouring "every live container → exactly one card" for those would need the one-card-per-run model to change — out of scope here.

## Tests

Added four regression cases to `fleet-view.test.ts`: a reviewing run links to its review pass after the review container is gone; phase (not stale busy implement) decides the face; duplicate review passes resolve to the running one; and a reviewing run with no review pass yet renders a non-clickable card instead of linking to the parked implement. Full suite: 460 passing; lint and typecheck clean on the changed files (two pre-existing, unrelated `container-manager.test.ts` type errors remain on `main`).

## Self-review

Ran `/code-review` (Standards + Spec) against `origin/main` with #96 as the spec. Acted on all findings I agreed with: extracted the duplicated busy predicate, made `hasBusyPass` a boolean, sharpened the misleading `pickPass` comment, and — the substantive one — removed the cross-phase fallback that reintroduced symptom 1 in the pre-review-pass window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)