### PR TITLE
Stop parked autonomous containers to free memory (host OOM fix) (#93)

### DIFF
--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -413,6 +413,25 @@ export async function stopContainer(
   }
 }
 
+/**
+ * Start (or resume) a container's Docker process. Idempotent: the daemon
+ * answers an already-running container with a 304, which is not an error we
+ * care about — a genuine start failure (bad image, missing container) still
+ * propagates so the caller's turn fails loudly rather than execing into a dead
+ * container. Used to resume a container `stopContainer` parked to free memory
+ * (issue #93).
+ */
+export async function startContainer(
+  running: RunningContainer
+): Promise<void> {
+  try {
+    await running.container.start();
+  } catch (err) {
+    if ((err as { statusCode?: number })?.statusCode === 304) return; // Already running
+    throw err;
+  }
+}
+
 export async function removeContainer(
   running: RunningContainer
 ): Promise<void> {

--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { createLocalCapacityProvider, deriveCapacity } from "../capacity";
+import {
+  createLocalCapacityProvider,
+  deriveCapacity,
+  wouldOvercommitMemory,
+} from "../capacity";
 
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
@@ -87,6 +91,60 @@ describe("deriveCapacity", () => {
       expect(capacity.slots).toBe(2);
     }
   );
+});
+
+describe("wouldOvercommitMemory", () => {
+  // Defense in depth for issue #93: cgroup limits cap each container but never
+  // reserve memory, so the host OOMs on overcommit before any one container
+  // hits its cap. The check charges each container (the live set plus the one
+  // about to start) its full per-agent allowance against usable memory
+  // (MemTotal minus the 1 GiB orchestrator reserve deriveCapacity uses).
+  const cx22 = deriveCapacity({ memTotalBytes: 4 * GiB, cpuCount: 2 });
+
+  it.each([
+    { live: 0, overcommit: false },
+    { live: 1, overcommit: false },
+    // The incident: a 2-slot box (usable ~3 GiB, 1200 MiB per agent) fits two
+    // live containers; the third — the review that stacked on two parked
+    // implements on 2026-08-04 — is refused before it can OOM the host.
+    { live: 2, overcommit: true },
+    { live: 3, overcommit: true },
+  ])(
+    "CX22 with $live live container(s) → overcommit=$overcommit",
+    ({ live, overcommit }) => {
+      expect(
+        wouldOvercommitMemory({
+          memTotalBytes: 4 * GiB,
+          perAgentMemory: cx22.perAgentMemory,
+          liveContainers: live,
+        })
+      ).toBe(overcommit);
+    }
+  );
+
+  it("always admits the first container, even on a box too small to fit one (matches deriveCapacity's slot floor of 1)", () => {
+    // 2 GiB box, 1 GiB reserve → ~1 GiB usable, less than a 1200 MiB agent. The
+    // box must still run a single task (its own cgroup cap is the backstop);
+    // only a second start is refused.
+    expect(
+      wouldOvercommitMemory({ memTotalBytes: 2 * GiB, perAgentMemory: 1200 * MiB, liveContainers: 0 })
+    ).toBe(false);
+    expect(
+      wouldOvercommitMemory({ memTotalBytes: 2 * GiB, perAgentMemory: 1200 * MiB, liveContainers: 1 })
+    ).toBe(true);
+  });
+
+  it("a larger per-agent allowance admits fewer containers, in step with the slot divisor", () => {
+    // 2000 MiB per agent yields deriveCapacity slots=1 on the same box — so the
+    // second container (one live, one more) must be refused.
+    const perAgentMemory = 2000 * MiB;
+    expect(
+      wouldOvercommitMemory({ memTotalBytes: 4 * GiB, perAgentMemory, liveContainers: 0 })
+    ).toBe(false);
+    expect(
+      wouldOvercommitMemory({ memTotalBytes: 4 * GiB, perAgentMemory, liveContainers: 1 })
+    ).toBe(true);
+  });
 });
 
 describe("capacity provider", () => {

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -41,6 +41,16 @@ export interface DerivedCapacity {
   cpuQuota: number;
 }
 
+/**
+ * Memory the daemon reports minus the orchestrator reserve (orchestrator +
+ * Caddy + system headroom) — what is actually available for agent containers.
+ * The single source of this figure, shared by slot derivation and the
+ * memory-admission backstop (issue #93) so they can never drift apart.
+ */
+export function usableMemoryBytes(memTotalBytes: number): number {
+  return memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
+}
+
 export function deriveCapacity(
   daemon: DaemonInfo,
   overrides: CapacityOverrides = {}
@@ -51,7 +61,7 @@ export function deriveCapacity(
       ? memoryOverride
       : DEFAULT_AGENT_MEMORY_MB;
   const perAgentMemory = perAgentMb * MiB;
-  const available = daemon.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
+  const available = usableMemoryBytes(daemon.memTotalBytes);
   const byMemory = Math.floor(available / perAgentMemory);
   const capped = Math.min(byMemory, daemon.cpuCount);
   const derived = Number.isFinite(capped) ? Math.max(1, capped) : 1;
@@ -86,7 +96,7 @@ export function wouldOvercommitMemory(input: {
   liveContainers: number;
 }): boolean {
   if (input.liveContainers <= 0) return false;
-  const available = input.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
+  const available = usableMemoryBytes(input.memTotalBytes);
   return (input.liveContainers + 1) * input.perAgentMemory > available;
 }
 
@@ -121,9 +131,7 @@ export async function checkMemoryAdmission(): Promise<{ ok: boolean; reason?: st
       })
     ) {
       const perMb = Math.round(capacity.perAgentMemory / MiB);
-      const usableMb = Math.round(
-        (info.MemTotal - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB) / MiB
-      );
+      const usableMb = Math.round(usableMemoryBytes(info.MemTotal) / MiB);
       return {
         ok: false,
         reason: `${liveContainers} agent container(s) live × ${perMb} MiB + one more exceeds ~${usableMb} MiB usable`,

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -65,6 +65,78 @@ export function deriveCapacity(
 }
 
 /**
+ * Defense in depth for the OOM incident (issue #93): would starting one more
+ * agent container overcommit host memory? Cgroup limits *cap* each container
+ * but never *reserve* its memory, so the host OOMs on overcommit before any
+ * single container hits its own cap — which is exactly how a 2-slot box ended
+ * up with 4 live agent containers and thrashed. Pure, so the arithmetic is
+ * unit-testable; `checkMemoryAdmission` gathers the live numbers from Docker.
+ *
+ * Uses the same figures `deriveCapacity` does: usable memory is the daemon's
+ * reported total minus the orchestrator reserve, and each container is charged
+ * its full per-agent allowance. The first container is always admitted — a box
+ * too small to fit even one still runs a single task (`deriveCapacity` floors
+ * slots at 1 for the same reason), trusting that container's own cgroup cap as
+ * the backstop; the gate only bites once starting *another* would overcommit.
+ */
+export function wouldOvercommitMemory(input: {
+  memTotalBytes: number;
+  perAgentMemory: number;
+  /** Agent containers already holding memory (running, not parked/stopped) */
+  liveContainers: number;
+}): boolean {
+  if (input.liveContainers <= 0) return false;
+  const available = input.memTotalBytes - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB;
+  return (input.liveContainers + 1) * input.perAgentMemory > available;
+}
+
+/**
+ * Ask the daemon how many agent containers are actually *running* and refuse
+ * to start another when the live set plus the newcomer would overcommit host
+ * memory (issue #93). Independent of the in-memory slot count, so it also
+ * catches leaked or drifted containers the slot bookkeeping missed. Parked
+ * containers are `docker stop`ped since #93, so they are correctly absent from
+ * the running set and weigh nothing here.
+ *
+ * Fails open: a Docker probe error logs and allows, so a transient daemon
+ * hiccup never wedges the queue behind a phantom memory ceiling.
+ */
+export async function checkMemoryAdmission(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    const docker = getDocker();
+    const capacity = await getCapacity();
+    const info = await docker.info();
+    // Default listing (no `all`) returns only running containers — the ones
+    // holding memory right now.
+    const running = await docker.listContainers({
+      filters: { name: ["interlude-task-"] },
+    });
+    const liveContainers = running.length;
+
+    if (
+      wouldOvercommitMemory({
+        memTotalBytes: info.MemTotal,
+        perAgentMemory: capacity.perAgentMemory,
+        liveContainers,
+      })
+    ) {
+      const perMb = Math.round(capacity.perAgentMemory / MiB);
+      const usableMb = Math.round(
+        (info.MemTotal - DEFAULT_ORCHESTRATOR_RESERVE_MB * MiB) / MiB
+      );
+      return {
+        ok: false,
+        reason: `${liveContainers} agent container(s) live × ${perMb} MiB + one more exceeds ~${usableMb} MiB usable`,
+      };
+    }
+    return { ok: true };
+  } catch (err) {
+    console.error("[capacity] memory-admission probe failed, allowing start:", err);
+    return { ok: true };
+  }
+}
+
+/**
  * The seam callers consume instead of querying Docker directly — Phase 7's
  * on-demand remote compute answers the same question differently, so the
  * answer is async even though the local provider is not.

--- a/src/lib/orchestrator/init.ts
+++ b/src/lib/orchestrator/init.ts
@@ -135,12 +135,13 @@ async function reapStaleContainers(): Promise<void> {
 
     if (containers.length === 0) return;
 
-    // Get all tasks that should have a live container. Blocked tasks are
-    // parked, not dead: their container is deliberately kept alive holding
-    // its context while the question waits (issue #19). Any task owned by a
-    // live run is likewise protected whatever its own status (issue #24):
-    // recovery must never be fighting cleanup, so while the run is being
-    // worked, only the run's own lifecycle may take its containers.
+    // Get all tasks that should keep their container. Blocked tasks are
+    // parked, not dead: their container is deliberately preserved (stopped to
+    // free memory since #93, but its filesystem and branch state kept) while
+    // the question waits (issue #19), so the reaper must not remove it. Any
+    // task owned by a live run is likewise protected whatever its own status
+    // (issue #24): recovery must never be fighting cleanup, so while the run is
+    // being worked, only the run's own lifecycle may take its containers.
     const activeTasks = await db
       .select({ containerName: tasks.containerName })
       .from(tasks)

--- a/src/lib/orchestrator/queue.ts
+++ b/src/lib/orchestrator/queue.ts
@@ -6,6 +6,7 @@ import { getActiveTasks, isParked, processQueuedMessages, scanForDevServer } fro
 import {
   createLocalCapacityProvider,
   getCapacity,
+  checkMemoryAdmission,
   type CapacityProvider,
 } from "./capacity";
 
@@ -71,7 +72,13 @@ export function startQueue(): void {
           );
         }
 
-        if (await capacityProvider.isSlotAvailable()) {
+        // The slot count gates concurrency; the memory-admission probe is the
+        // backstop against overcommit (issue #93) — it asks the daemon what is
+        // actually running, catching any drift the slot bookkeeping missed
+        // before the host OOMs. Both must clear before a task starts.
+        const slotFree = await capacityProvider.isSlotAvailable();
+        const admission = slotFree ? await checkMemoryAdmission() : { ok: false };
+        if (slotFree && admission.ok) {
           saturationLogged = false;
           processingTasks.add(next.id);
           console.log(
@@ -85,7 +92,9 @@ export function startQueue(): void {
         } else if (!saturationLogged) {
           saturationLogged = true;
           console.log(
-            `[orchestrator] All ${capacityProvider.capacity.slots} slot(s) busy — task ${next.id} waits in queue`
+            !slotFree
+              ? `[orchestrator] All ${capacityProvider.capacity.slots} slot(s) busy — task ${next.id} waits in queue`
+              : `[orchestrator] Memory headroom low (${admission.reason}) — task ${next.id} waits in queue`
           );
         }
       }
@@ -131,6 +140,11 @@ export function startQueue(): void {
         for (const [taskId, entry] of activeTasks) {
           if (entry.state !== "idle") continue;
           if (processingTasks.has(taskId)) continue;
+          // A parked autonomous container is stopped to free memory (#93) —
+          // execing a port scan into it would fail, and its dev server is not
+          // a live preview concern anyway. Only interactive idle sessions are
+          // scanned.
+          if (isParked(entry)) continue;
           scanForDevServer(taskId, entry.container).catch(console.error);
         }
       }

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -53,13 +53,14 @@ export function getActiveTasks() {
 
 /**
  * An idle autonomous container is *parked*: an implement pass waiting on its
- * review verdict, or blocked on a question to the owner (issue #19), keeps
- * its container (so the verdict's fix-up or the owner's answer can be a
- * follow-up turn in the same attempt) but runs no agent process, so it does
- * not hold a slot. An idle interactive session does hold its slot — its dev
- * server and the owner's next message are live concerns. Without this
- * distinction, two parked implements plus their two queued reviews would
- * deadlock a two-slot box.
+ * review verdict, or blocked on a question to the owner (issue #19), keeps its
+ * container (so the verdict's fix-up or the owner's answer can be a follow-up
+ * turn in the same attempt) but runs no agent process, so it does not hold a
+ * slot — and since #93 the container is `docker stop`ped while parked so it
+ * holds no memory either (see parkContainer). An idle interactive session does
+ * hold its slot — its dev server and the owner's next message are live
+ * concerns. Without this distinction, two parked implements plus their two
+ * queued reviews would deadlock a two-slot box.
  */
 export function isParked(entry: { state: string; kind: string }): boolean {
   return entry.state === "idle" && entry.kind !== "interactive";
@@ -618,9 +619,25 @@ export async function processQueuedMessages(
       // when there is no PR. A reviewer's fix-up turn needs neither — its
       // new commits re-enter gate evaluation from the parked state.
       const parkedBlocked = await evaluatePassOutcome(taskId, turnResult.finalMessage);
-      if (!parkedBlocked && !run?.pullRequestNumber) {
-        await finishImplementPass(taskId);
+      if (parkedBlocked) {
+        // Re-blocked mid-drain: parkBlockedRun stopped the container (#93).
+        // Stop draining — the next answer resumes it on a fresh poll, which
+        // restarts the container first. Continuing would exec the next queued
+        // message into a stopped container.
+        break;
       }
+      if (!run?.pullRequestNumber) {
+        // Blocked before its PR was handed over, now healthy: finish the pass.
+        // With a PR this parks (stopping the container, #93); with none it
+        // completes and the container is removed. Either way the pass has
+        // ended this turn, so stop draining rather than exec the next message
+        // into a stopped or removed container — a fresh resume delivers it.
+        await finishImplementPass(taskId);
+        break;
+      }
+      // Healthy fix-up on an already-handed-over PR: the container is still
+      // running and the pass re-enters gate evaluation awaiting review. Drain
+      // any further queued turn before the loop parks it below.
       continue;
     }
 
@@ -992,9 +1009,10 @@ function lastAgentTextMessage(taskId: string): string | null {
 /**
  * Park-or-proceed for an implement pass whose turn just ended (issue #19):
  * ask the reducer about the turn's final message — this turn's, from its
- * TurnResult, never an earlier turn's re-read. Blocked — park the run with
- * its container alive and post the question; returns true. Healthy —
- * returns false and the caller proceeds (park awaiting review, or complete).
+ * TurnResult, never an earlier turn's re-read. Blocked — park the run (its
+ * container stopped to free memory but preserved, #93) and post the question;
+ * returns true. Healthy — returns false and the caller proceeds (park awaiting
+ * review, or complete).
  */
 async function evaluatePassOutcome(
   taskId: string,
@@ -1022,11 +1040,13 @@ async function evaluatePassOutcome(
 }
 
 /**
- * Park a blocked run: the run and task go `blocked`, the container stays
- * alive holding its context, and the question is posted to the project's
- * linked Discord channel — or the fleet channel when the project has none,
- * so no question is silently lost. The posted message becomes the task's
- * interactive message: a reply to it queues the answer as the next turn.
+ * Park a blocked run: the run and task go `blocked`, the container is stopped
+ * to free its memory but preserved (its filesystem and branch state survive a
+ * restart in ~1s, #93), and the question is posted to the project's linked
+ * Discord channel — or the fleet channel when the project has none, so no
+ * question is silently lost. The posted message becomes the task's interactive
+ * message: a reply to it restarts the container and queues the answer as the
+ * next turn.
  */
 async function parkBlockedRun(taskId: string, runId: string, question: string): Promise<void> {
   const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -9,8 +9,10 @@ import {
   execFallbackCommitAndPush,
   removeContainer,
   stopContainer,
+  startContainer,
   type RunningContainer,
 } from "../docker/container-manager";
+import { checkMemoryAdmission } from "./capacity";
 import { createOutputHandler, type TurnResult } from "./output-parser";
 import { parseReviewVerdict } from "./autonomy/verdict";
 import { parseTriageExit } from "./autonomy/triage";
@@ -61,6 +63,51 @@ export function getActiveTasks() {
  */
 export function isParked(entry: { state: string; kind: string }): boolean {
   return entry.state === "idle" && entry.kind !== "interactive";
+}
+
+/**
+ * Free a parked autonomous container's memory (issue #93). A pass awaiting its
+ * review verdict or blocked on a question keeps its container so a fix-up or
+ * answer can resume the *same* attempt — but it runs no agent process, so the
+ * node/dev-server RSS it held while parked was pure overcommit risk: several
+ * parked at once OOM-thrashed the host on 2026-08-04. `docker stop` frees all
+ * of it; the container's filesystem and branch state survive, and
+ * `resumeParkedContainer` restarts it in ~1s when the next turn arrives.
+ * Interactive sessions are never parked (their dev server and next message are
+ * live concerns), so they keep their container. Idempotent — a no-op when the
+ * task has no active entry or is not parked.
+ */
+async function parkContainer(taskId: string): Promise<void> {
+  const entry = activeTasks.get(taskId);
+  if (!entry || !isParked(entry)) return;
+  await stopContainer(entry.container);
+  console.log(`[orchestrator] Parked container for task ${taskId} stopped to free memory`);
+}
+
+/**
+ * Restart a container `parkContainer` stopped, before delivering its next turn
+ * (issue #93). Refuses when the box has no memory headroom — the caller defers
+ * to a later poll rather than overcommit, since resuming a parked container is
+ * not slot-gated. Returns false when the resume was deferred (the container is
+ * left stopped and the queued turn undelivered); true once it is running. A
+ * no-op success for interactive containers, which are never stopped.
+ */
+async function resumeParkedContainer(
+  taskId: string,
+  running: RunningContainer
+): Promise<boolean> {
+  const entry = activeTasks.get(taskId);
+  if (!entry || !isParked(entry)) return true;
+
+  const admission = await checkMemoryAdmission();
+  if (!admission.ok) {
+    console.log(
+      `[orchestrator] Deferring resume of parked task ${taskId} — ${admission.reason}`
+    );
+    return false;
+  }
+  await startContainer(running);
+  return true;
 }
 
 export function getTaskState(taskId: string) {
@@ -431,6 +478,12 @@ export async function processQueuedMessages(
 ): Promise<void> {
   const config = getConfig();
 
+  // Resume a parked autonomous container (#93): it was docker-stopped to free
+  // memory while awaiting its verdict or an answer. Restart it before running
+  // the queued turn — but defer to a later poll if the box has no memory
+  // headroom, leaving the message queued rather than overcommitting.
+  if (!(await resumeParkedContainer(taskId, running))) return;
+
   while (true) {
     // Get current task state. A blocked implement pass is resumable — the
     // queued message is the answer to its question (issue #19).
@@ -573,6 +626,12 @@ export async function processQueuedMessages(
 
     if (task.kind === "interactive") await scanForDevServer(taskId, running);
   }
+
+  // Re-park (#93): a resumed autonomous pass that ended its turn(s) still idle
+  // (awaiting review again after a fix-up, or blocked on a fresh question)
+  // keeps its container for the next turn — stop it again to free memory until
+  // then. A no-op when the task completed, failed, or is interactive.
+  await parkContainer(taskId);
 }
 
 /**
@@ -605,6 +664,10 @@ export async function completeTask(taskId: string): Promise<void> {
 
   try {
     if (running) {
+      // A parked autonomous container is stopped to free memory (#93); a
+      // complete triggered while parked (an owner action) must restart it
+      // before the final push exec. A no-op for a live interactive container.
+      await startContainer(running);
       await execFallbackCommitAndPush(running);
       insertSystemMessage(taskId, `Branch '${task.branch}' pushed.`);
     } else {
@@ -746,6 +809,10 @@ async function finishImplementPass(taskId: string): Promise<void> {
       `Implement pass complete -- PR #${task.pullRequestNumber} ready for review ($${cost})`
     );
   }
+
+  // The pass is now parked awaiting its review verdict — stop the container to
+  // free its memory until a fix-up turn (or its release) arrives (issue #93).
+  await parkContainer(taskId);
 }
 
 /**
@@ -972,6 +1039,11 @@ async function parkBlockedRun(taskId: string, runId: string, question: string): 
   updateTask(taskId, { status: "blocked" });
   insertSystemMessage(taskId, `Run blocked — waiting for an answer: ${question}`);
   console.log(`[autonomy] Run ${runId} blocked on: ${question}`);
+
+  // Parked on the owner's answer — stop the container to free its memory until
+  // the reply lands as the next turn (issue #93). The question below is posted
+  // out-of-band (Discord + the task chat), so nothing needs the container now.
+  await parkContainer(taskId);
 
   const proj = db.select().from(projects).where(eq(projects.id, task.projectId)).get();
   const channelId = proj?.discordChannelId ?? getConfig().discordFleetChannelId;


### PR DESCRIPTION
Closes #93

## Problem

The first multi-ticket autonomous batch OOM-thrashed the CX22 host on 2026-08-04: **4 agent containers live on a 2-slot box**. `occupiedSlots()` deliberately excludes parked containers (a parked implement pass runs no agent process, so it holds no *slot*), but a parked container kept its **memory** — its dev server and node heap. Two implements parked → both slots read free → two review containers started → 4 containers × 1200 MiB against ~3 GiB usable. Cgroup limits *cap* but never *reserve* memory, so the host OOMed on overcommit before any container hit its own cap.

## Fix

**Primary — stop parked autonomous containers, restart on resume.** When an autonomous pass parks (implement awaiting its review verdict, or a run blocked on a question), `docker stop` its container; `docker start` it on resume (a review fix-up turn, an owner's answer, or an owner completing the task). A stopped container keeps its filesystem and branch state, costs ~1s to restart, and holds neither a slot nor RAM — so the no-deadlock property that motivated excluding parked containers from the slot count is preserved. Interactive sessions are never parked (their dev server and next message are live concerns), so they keep today's behavior.

Park seams covered: `finishImplementPass` (awaiting review), `parkBlockedRun` (blocked), and the re-park after a review fix-up turn (`processQueuedMessages`). Resume seams covered: `processQueuedMessages` (fix-up / answer) and `completeTask` (owner completion). The sweep's approve/escalate/merge release path force-removes the stopped container — no exec needed.

**Defense in depth — memory admission.** Before starting any container (fresh pickup *and* resume), `checkMemoryAdmission()` asks the daemon how many agent containers are actually running and refuses to start another when the live set plus the newcomer would exceed usable memory (the same `MemTotal − reserve` and per-agent figures `deriveCapacity` uses, now shared via `usableMemoryBytes()`). Independent of the in-memory slot count, so it also catches drift/leaks. The first container is always admitted (matching `deriveCapacity`'s slot floor of 1); it fails open on a Docker probe error so a daemon hiccup can't wedge the queue.

## Interim mitigation to remove after this ships

`CAPACITY_SLOTS=1` in Doppler `interlude/prd` — remove the override once this is deployed (noted in #93).

## Tests

`wouldOvercommitMemory` is a pure predicate with unit tests covering the incident (a 2-slot box admits 2 live containers, refuses the 3rd), the per-agent-override step, and the small-box floor. Full suite: 462 passing. Lint clean on changed files.

## Self-review

Ran the `/code-review` skill (fixed point `origin/main`, spec = issue #93). The **spec axis** reported the change fully implements #93 with no missing park/resume points. The **standards axis** found one real correctness bug — a mid-drain turn could re-park (stop) the container and then the loop would exec the next queued message into it — now fixed by breaking the drain whenever an implement/repair pass parks mid-loop (the next turn arrives via a fresh resume that restarts the container first). Also addressed: stale "container stays alive" comments and the triplicated usable-memory arithmetic.

Accepted residuals (noted, not fixed here):
- **Memory-gate TOCTOU / fairness:** pickup and resume each probe memory independently within one 2s poll, and a resume is not prioritized over new pickups. Both are latency/fairness concerns on a memory-tight box, never a deadlock (memory always frees as running work terminates), and the primary stop-on-park fix is the real guard — this probe is belt-and-suspenders.
- **`completeTask` starts without a memory check:** an owner-initiated terminal action that does one final push then removes the container; a momentary overcommit there is acceptable and asymmetric by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
