### PR TITLE
Duplicate concurrent review passes queued for one run (#95)

### DIFF
--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -432,14 +432,20 @@ export async function startContainer(
   }
 }
 
-export async function removeContainer(
-  running: RunningContainer
-): Promise<void> {
+/** Force-remove a container, idempotently — an already-gone container is not
+ * an error. Shared by the handle- and name-based removers below. */
+async function forceRemove(container: Docker.Container): Promise<void> {
   try {
-    await running.container.remove({ force: true });
+    await container.remove({ force: true });
   } catch {
     // Already removed
   }
+}
+
+export async function removeContainer(
+  running: RunningContainer
+): Promise<void> {
+  await forceRemove(running.container);
 }
 
 /**
@@ -461,12 +467,7 @@ export async function isContainerRunning(name: string): Promise<boolean> {
 }
 
 /** Force-remove a container by name — for reaping a dead pass's container
- * whose `RunningContainer` handle the orchestrator no longer holds (issue #95).
- * Idempotent: an already-gone container is not an error. */
+ * whose `RunningContainer` handle the orchestrator no longer holds (issue #95). */
 export async function removeContainerByName(name: string): Promise<void> {
-  try {
-    await getDocker().getContainer(name).remove({ force: true });
-  } catch {
-    // Already removed
-  }
+  await forceRemove(getDocker().getContainer(name));
 }

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -441,3 +441,32 @@ export async function removeContainer(
     // Already removed
   }
 }
+
+/**
+ * Whether a container (by name) is still running, for the ungraceful-death
+ * reaper (issue #95). Fail-safe on the side of not touching a live pass: a
+ * container the daemon has definitively lost (404) or that has exited returns
+ * false so its stale `running` task can be reaped; any *other* daemon error
+ * (a busy or briefly unreachable socket under memory pressure) returns true —
+ * assume live and let the next sweep retry, so a transient hiccup can never
+ * terminalize a pass that is genuinely still working.
+ */
+export async function isContainerRunning(name: string): Promise<boolean> {
+  try {
+    const info = await getDocker().getContainer(name).inspect();
+    return info.State?.Running === true;
+  } catch (err) {
+    return (err as { statusCode?: number })?.statusCode !== 404;
+  }
+}
+
+/** Force-remove a container by name — for reaping a dead pass's container
+ * whose `RunningContainer` handle the orchestrator no longer holds (issue #95).
+ * Idempotent: an already-gone container is not an error. */
+export async function removeContainerByName(name: string): Promise<void> {
+  try {
+    await getDocker().getContainer(name).remove({ force: true });
+  } catch {
+    // Already removed
+  }
+}

--- a/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import { createTestDb } from "@/test/create-test-db";
+import { inFlightReviewTaskId, reapDeadReviewTasks } from "../review-tasks";
+import { decideNext, passOutcomeSnapshot, type AutonomySnapshot } from "../decide";
+
+type Db = ReturnType<typeof createTestDb>["db"];
+
+const ISSUE_REF = "owner/repo#141";
+
+/** A run parked in `reviewing` (auto-merge armed) awaiting its review pass. */
+function seedReviewingRun(db: Db): void {
+  db.insert(schema.projects).values({ id: "p1", name: "Test", createdAt: new Date() }).run();
+  db.insert(schema.runs)
+    .values({
+      id: "run-1",
+      projectId: "p1",
+      githubIssue: ISSUE_REF,
+      attempt: 1,
+      mode: "autonomous",
+      status: "reviewing",
+      budgetUsd: 20,
+      pullRequestNumber: 144,
+      claimedAt: new Date(),
+    })
+    .run();
+  // The parked implement pass keeps its (stopped) container while its PR is
+  // reviewed — it stays `running`, and is never a review task.
+  db.insert(schema.tasks)
+    .values({
+      id: "task-implement",
+      projectId: "p1",
+      title: "Implement pass",
+      kind: "implement",
+      runId: "run-1",
+      status: "running",
+      containerName: "interlude-task-implement",
+      githubIssue: ISSUE_REF,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .run();
+}
+
+/** A review task for run-1 in the given state. */
+function seedReviewTask(
+  db: Db,
+  opts: { id?: string; status?: "queued" | "running"; containerName?: string | null } = {}
+): string {
+  const id = opts.id ?? "task-review";
+  db.insert(schema.tasks)
+    .values({
+      id,
+      projectId: "p1",
+      title: "Review PR #144",
+      kind: "review",
+      runId: "run-1",
+      status: opts.status ?? "running",
+      containerName: opts.containerName === undefined ? "interlude-task-review" : opts.containerName,
+      branch: "agent/issue-141",
+      githubIssue: ISSUE_REF,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .run();
+  return id;
+}
+
+/** A minimal, otherwise-inert snapshot with just this run awaiting review, so
+ * the only decision on the table is whether to queue its review pass. */
+function awaitingReviewSnapshot(hasReviewTask: boolean): AutonomySnapshot {
+  const base = passOutcomeSnapshot(new Date(2026, 7, 5), {
+    runId: "run-1",
+    taskId: "task-implement",
+    issueRef: ISSUE_REF,
+    finalMessage: null,
+  });
+  return {
+    ...base,
+    completedPasses: [],
+    awaitingReview: [
+      { runId: "run-1", issueRef: ISSUE_REF, prNumber: 144, armed: true, hasReviewTask },
+    ],
+  };
+}
+
+const alwaysGone = async () => false;
+const alwaysLive = async () => true;
+
+describe("review-pass in-flight + ungraceful-death reaping (issue #95)", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = createTestDb().db;
+    seedReviewingRun(db);
+  });
+
+  it("reaps a review pass that died without a status transition, then queues exactly one replacement", async () => {
+    const taskId = seedReviewTask(db, { status: "running" });
+
+    // Before the reaper the stuck-`running` task reads as in flight — so a
+    // naive re-queue would either stall (never replacing it) or race a
+    // duplicate against it.
+    expect(inFlightReviewTaskId(db, "run-1")).toBe(taskId);
+
+    // Container confirmed gone: the reaper marks the task terminal.
+    const reaped = await reapDeadReviewTasks(db, alwaysGone);
+    expect(reaped).toEqual([{ taskId, containerName: "interlude-task-review" }]);
+    expect(db.select().from(schema.tasks).where(eq(schema.tasks.id, taskId)).get()!.status).toBe(
+      "failed"
+    );
+
+    // With the dead pass terminalized, no review is in flight — the reducer
+    // queues one deliberate replacement, not zero and not two.
+    expect(inFlightReviewTaskId(db, "run-1")).toBeNull();
+    const startReviews = decideNext(awaitingReviewSnapshot(false)).filter(
+      (a) => a.type === "startReview"
+    );
+    expect(startReviews).toEqual([
+      { type: "startReview", runId: "run-1", issueRef: ISSUE_REF, prNumber: 144, armed: true },
+    ]);
+  });
+
+  it("leaves a live review pass alone — it stays in flight and no second is queued", async () => {
+    const taskId = seedReviewTask(db, { status: "running" });
+
+    const reaped = await reapDeadReviewTasks(db, alwaysLive);
+    expect(reaped).toEqual([]);
+    expect(db.select().from(schema.tasks).where(eq(schema.tasks.id, taskId)).get()!.status).toBe(
+      "running"
+    );
+
+    expect(inFlightReviewTaskId(db, "run-1")).toBe(taskId);
+    const startReviews = decideNext(awaitingReviewSnapshot(true)).filter(
+      (a) => a.type === "startReview"
+    );
+    expect(startReviews).toEqual([]);
+  });
+
+  it("counts a queued (not yet started) review as in flight", async () => {
+    const taskId = seedReviewTask(db, { status: "queued", containerName: null });
+    // A queued task has no container — the reaper never touches it...
+    expect(await reapDeadReviewTasks(db, alwaysGone)).toEqual([]);
+    // ...and it still blocks a second queueing.
+    expect(inFlightReviewTaskId(db, "run-1")).toBe(taskId);
+  });
+
+  it("does not reap a review pass still provisioning its container (running, no name yet)", async () => {
+    const taskId = seedReviewTask(db, { status: "running", containerName: null });
+    expect(await reapDeadReviewTasks(db, alwaysGone)).toEqual([]);
+    expect(db.select().from(schema.tasks).where(eq(schema.tasks.id, taskId)).get()!.status).toBe(
+      "running"
+    );
+  });
+
+  it("reaps only once — a queued replacement is not itself reaped or double-queued", async () => {
+    seedReviewTask(db, { id: "task-review-1", status: "running" });
+    await reapDeadReviewTasks(db, alwaysGone);
+
+    // The sweep queued a replacement (kept `queued` here — no slot yet).
+    seedReviewTask(db, { id: "task-review-2", status: "queued", containerName: null });
+
+    // A second sweep: the replacement has no container, so nothing is reaped,
+    // and it counts as in flight so no third review is queued.
+    expect(await reapDeadReviewTasks(db, alwaysGone)).toEqual([]);
+    expect(inFlightReviewTaskId(db, "run-1")).toBe("task-review-2");
+    const startReviews = decideNext(awaitingReviewSnapshot(true)).filter(
+      (a) => a.type === "startReview"
+    );
+    expect(startReviews).toEqual([]);
+  });
+});

--- a/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import * as schema from "@/db/schema";
 import { createTestDb } from "@/test/create-test-db";
-import { inFlightReviewTaskId, reapDeadReviewTasks } from "../review-tasks";
+import { inFlightReviewTaskId, reapDeadReviewTasks, type Db } from "../review-tasks";
 import { decideNext, passOutcomeSnapshot, type AutonomySnapshot } from "../decide";
-
-type Db = ReturnType<typeof createTestDb>["db"];
 
 const ISSUE_REF = "owner/repo#141";
 

--- a/src/lib/orchestrator/autonomy/review-tasks.ts
+++ b/src/lib/orchestrator/autonomy/review-tasks.ts
@@ -27,7 +27,9 @@ import * as schema from "@/db/schema";
 import { messages, tasks } from "@/db/schema";
 import { newId } from "../../ulid";
 
-type Db = BetterSQLite3Database<typeof schema>;
+/** The injected database handle — the app singleton in the sweep, an
+ * in-memory one in tests. Exported so both sides name the seam the same way. */
+export type Db = BetterSQLite3Database<typeof schema>;
 
 /**
  * The id of a review task for this run that is still in flight — `queued` or

--- a/src/lib/orchestrator/autonomy/review-tasks.ts
+++ b/src/lib/orchestrator/autonomy/review-tasks.ts
@@ -1,0 +1,118 @@
+/**
+ * Review-pass task bookkeeping shared by the sweep (issue #95).
+ *
+ * Two mechanisms that must work together so a run has *exactly one* review
+ * pass in flight — never zero when one is owed, never two racing the same PR:
+ *
+ *  1. `inFlightReviewTaskId` — the idempotency rule. Before queueing a review
+ *     pass, any review task for the same run that is still `queued` or
+ *     `running` counts as in flight, so `decideNext` does not queue a second.
+ *
+ *  2. `reapDeadReviewTasks` — the ungraceful-death path. A review container
+ *     OOM-killed or lost while the daemon hangs can leave its task stuck
+ *     `running` with no status transition (observed in the 2026-08-04 incident,
+ *     #93/#96). Keyed on task status alone, rule 1 would then read that dead
+ *     pass as live forever: the run stalls, and any path that does re-queue
+ *     races a duplicate. This marks such a task terminal (`failed`) once its
+ *     container is confirmed gone, so the next sweep's rule-1 check queues one
+ *     deliberate replacement rather than stalling or racing.
+ *
+ * DB-only by design (no Docker/GitHub imports): the container-liveness probe
+ * is injected so the sweep passes the real daemon check and tests pass a fake.
+ */
+
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { and, eq, inArray } from "drizzle-orm";
+import * as schema from "@/db/schema";
+import { messages, tasks } from "@/db/schema";
+import { newId } from "../../ulid";
+
+type Db = BetterSQLite3Database<typeof schema>;
+
+/**
+ * The id of a review task for this run that is still in flight — `queued` or
+ * `running` — or null if there is none. This is the check that keeps review
+ * queueing idempotent across sweeps (issue #45, hardened by #95): while it
+ * returns non-null, `decideNext` leaves `hasReviewTask` true and queues no
+ * second pass. A dead-but-stuck-`running` task is only cleared by
+ * `reapDeadReviewTasks` — until then it correctly reads as in flight here.
+ */
+export function inFlightReviewTaskId(db: Db, runId: string): string | null {
+  const task = db
+    .select({ id: tasks.id })
+    .from(tasks)
+    .where(
+      and(
+        eq(tasks.runId, runId),
+        eq(tasks.kind, "review"),
+        inArray(tasks.status, ["queued", "running"])
+      )
+    )
+    .get();
+  return task?.id ?? null;
+}
+
+/** A review task the reaper terminalized — returned so the caller can drop its
+ * in-memory session entry and remove the dead container. */
+export interface ReapedReviewTask {
+  taskId: string;
+  containerName: string | null;
+}
+
+/**
+ * Mark review tasks stuck `running` whose container is gone as `failed`, the
+ * ungraceful-death half of the exactly-one-review invariant (issue #95).
+ *
+ * `isContainerLive` is the injected liveness probe (the real Docker inspect in
+ * the sweep, a fake in tests). Only a task whose container the probe reports
+ * *not* live is reaped; a task still provisioning (no container name yet) and
+ * any task whose probe is inconclusive are left alone, so a genuinely working
+ * review pass is never terminalized out from under itself. Marking a review
+ * task `failed` does not fail the run or consume an attempt — a review death is
+ * infra, not bad work (cf. #97); it only frees rule 1 to queue one replacement.
+ *
+ * Returns the reaped tasks so the caller can remove their containers and clear
+ * their session entries; the DB transition here is what the next sweep reads.
+ */
+export async function reapDeadReviewTasks(
+  db: Db,
+  isContainerLive: (containerName: string) => Promise<boolean>
+): Promise<ReapedReviewTask[]> {
+  const running = db
+    .select({ id: tasks.id, containerName: tasks.containerName })
+    .from(tasks)
+    .where(and(eq(tasks.kind, "review"), eq(tasks.status, "running")))
+    .all();
+
+  const reaped: ReapedReviewTask[] = [];
+  for (const task of running) {
+    // No container name yet: the row went `running` before its container was
+    // created (startTask sets the status first). It is provisioning, not dead.
+    if (!task.containerName) continue;
+    if (await isContainerLive(task.containerName)) continue;
+
+    const now = new Date();
+    db.update(tasks)
+      .set({ status: "failed", containerId: null, containerStatus: null, updatedAt: now })
+      .where(eq(tasks.id, task.id))
+      .run();
+    db.insert(messages)
+      .values({
+        id: newId(),
+        taskId: task.id,
+        role: "system",
+        type: "system",
+        content: JSON.stringify({
+          text:
+            "Review pass container was lost (OOM / daemon error) with the task " +
+            "still marked running — marking it failed so a single replacement " +
+            "review can be queued.",
+        }),
+        createdAt: now,
+      })
+      .run();
+
+    reaped.push({ taskId: task.id, containerName: task.containerName });
+  }
+  return reaped;
+}

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -206,7 +206,9 @@ async function reapOrphanedReviewPasses(): Promise<void> {
   for (const task of reaped) {
     getActiveTasks().delete(task.taskId);
     if (task.containerName) await removeContainerByName(task.containerName);
-    console.error(
+    // An anomaly worth surfacing (a container died ungracefully) but not a
+    // sweep failure — the reaper is recovering it cleanly.
+    console.warn(
       `[autonomy] Reaped review task ${task.taskId}: container gone but task still ` +
         `running — marked failed so a single replacement review can be queued`
     );

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -38,6 +38,7 @@ import {
   notifyTriageRecommendation,
 } from "../../discord/notifications";
 import { recordBacklog } from "../../fleet/backlog";
+import { isContainerRunning, removeContainerByName } from "../../docker/container-manager";
 import { getCapacity } from "../capacity";
 import { occupiedSlots } from "../queue";
 import { startOfLocalDay, todayAutonomousSpendUsd } from "../spend";
@@ -80,6 +81,7 @@ import {
   buildTriagePrompt,
   type PriorAttempt,
 } from "./workflow";
+import { inFlightReviewTaskId, reapDeadReviewTasks } from "./review-tasks";
 import {
   DAILY_AUTONOMOUS_CAP_USD,
   MAX_ATTEMPTS,
@@ -169,6 +171,7 @@ export async function runAutonomySweep(): Promise<void> {
   sweeping = true;
 
   try {
+    await reapOrphanedReviewPasses();
     const snapshot = await gatherSnapshot(new Date());
     const actions = decideNext(snapshot);
     await executeActions(actions);
@@ -182,6 +185,31 @@ export async function runAutonomySweep(): Promise<void> {
     }
   } finally {
     sweeping = false;
+  }
+}
+
+/**
+ * The ungraceful-death half of the exactly-one-review invariant (issue #95),
+ * run before every gather. A review pass whose container was OOM-killed or lost
+ * while the daemon hung can leave its task stuck `running` with no status
+ * transition; keyed on task status alone, the in-flight check would read it as
+ * live forever — the run stalls, and any re-queue races a duplicate. Confirm
+ * each such task's container is actually gone (the Docker probe fails safe:
+ * only a definitively dead container is reaped, a transient daemon error is
+ * left for the next sweep), mark it `failed`, then drop its in-memory session
+ * entry and remove the dead container so it holds neither a phantom slot nor
+ * leaked memory — the ordinary reaper protects live-run containers, so nothing
+ * else would clean this one up while the run is still `reviewing`.
+ */
+async function reapOrphanedReviewPasses(): Promise<void> {
+  const reaped = await reapDeadReviewTasks(db, isContainerRunning);
+  for (const task of reaped) {
+    getActiveTasks().delete(task.taskId);
+    if (task.containerName) await removeContainerByName(task.containerName);
+    console.error(
+      `[autonomy] Reaped review task ${task.taskId}: container gone but task still ` +
+        `running — marked failed so a single replacement review can be queued`
+    );
   }
 }
 
@@ -500,24 +528,17 @@ async function gatherReviewState(allRuns: Array<typeof runs.$inferSelect>): Prom
     // armed approval auto-merging) or on a human (a gated PR) — nothing to do.
     if (run.reviewVerdict != null) continue;
 
-    const reviewTask = db
-      .select({ id: tasks.id })
-      .from(tasks)
-      .where(
-        and(
-          eq(tasks.runId, run.id),
-          eq(tasks.kind, "review"),
-          inArray(tasks.status, ["queued", "running"])
-        )
-      )
-      .get();
-
+    // A review task queued or running for this run means one is already in
+    // flight — don't queue a second (issue #45). A dead-but-stuck-`running`
+    // task is cleared by reapOrphanedReviewPasses before this gather, so it
+    // stops reading as in flight and the run gets one deliberate replacement
+    // rather than stalling here forever (issue #95).
     awaitingReview.push({
       runId: run.id,
       issueRef: run.githubIssue,
       prNumber: run.pullRequestNumber!,
       armed,
-      hasReviewTask: reviewTask != null,
+      hasReviewTask: inFlightReviewTaskId(db, run.id) != null,
     });
   }
 

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -356,6 +356,13 @@ export async function startTask(taskId: string): Promise<void> {
     const storedExit = isTriagePass
       ? db.select().from(tasks).where(eq(tasks.id, taskId)).get()?.triageResult
       : null;
+    // A review pass the sweep already reaped as dead (issue #95) is `failed`
+    // before this catch runs — the reaper queued its replacement, so this
+    // dead pass must not store a verdict over it below.
+    const alreadyReaped =
+      isReviewPass &&
+      db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, taskId)).get()?.status ===
+        "failed";
     updateTask(taskId, {
       status: "failed",
       containerStatus: null,
@@ -372,16 +379,19 @@ export async function startTask(taskId: string): Promise<void> {
       if (isReviewPass) {
         // A review pass that died is not a failed attempt — the implement
         // work is intact. Store the failure as an unparseable verdict so
-        // the fail-closed path (no merge, human-signoff, owner told) runs.
-        db.update(runs)
-          .set({
-            reviewResult: {
-              kind: "unparseable",
-              reason: `review pass failed: ${err instanceof Error ? err.message : String(err)}`,
-            },
-          })
-          .where(eq(runs.id, task.runId))
-          .run();
+        // the fail-closed path (no merge, human-signoff, owner told) runs —
+        // unless the sweep already reaped this pass and queued a replacement.
+        if (!alreadyReaped) {
+          db.update(runs)
+            .set({
+              reviewResult: {
+                kind: "unparseable",
+                reason: `review pass failed: ${err instanceof Error ? err.message : String(err)}`,
+              },
+            })
+            .where(eq(runs.id, task.runId))
+            .run();
+        }
       } else {
         finishRun(
           task.runId,
@@ -910,7 +920,12 @@ async function finishReviewPass(
 ): Promise<void> {
   const verdict = parseReviewVerdict(rawStream);
 
-  if (runId) {
+  // Only store the verdict if this pass is still the run's live review. If the
+  // sweep reaped it as dead (container gone, task no longer `running` — issue
+  // #95) while its turn was hung, a replacement review may already be in
+  // flight; writing this pass's verdict now would clobber it.
+  const current = db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, taskId)).get();
+  if (runId && current?.status === "running") {
     db.update(runs).set({ reviewResult: verdict }).where(eq(runs.id, runId)).run();
   }
 

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -359,10 +359,7 @@ export async function startTask(taskId: string): Promise<void> {
     // A review pass the sweep already reaped as dead (issue #95) is `failed`
     // before this catch runs — the reaper queued its replacement, so this
     // dead pass must not store a verdict over it below.
-    const alreadyReaped =
-      isReviewPass &&
-      db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, taskId)).get()?.status ===
-        "failed";
+    const alreadyReaped = isReviewPass && taskStatus(taskId) === "failed";
     updateTask(taskId, {
       status: "failed",
       containerStatus: null,
@@ -924,8 +921,7 @@ async function finishReviewPass(
   // sweep reaped it as dead (container gone, task no longer `running` — issue
   // #95) while its turn was hung, a replacement review may already be in
   // flight; writing this pass's verdict now would clobber it.
-  const current = db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, taskId)).get();
-  if (runId && current?.status === "running") {
+  if (runId && taskStatus(taskId) === "running") {
     db.update(runs).set({ reviewResult: verdict }).where(eq(runs.id, runId)).run();
   }
 
@@ -1305,6 +1301,15 @@ function updateTask(
     .set({ ...fields, updatedAt: new Date() })
     .where(eq(tasks.id, taskId))
     .run();
+}
+
+/** A task's current status, or null if it has vanished — used to tell whether
+ * a review pass was reaped out from under itself (issue #95). */
+function taskStatus(taskId: string): string | null {
+  return (
+    db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, taskId)).get()?.status ??
+    null
+  );
 }
 
 /** Terminalize a run: failed consumes an attempt, cancelled does not. */


### PR DESCRIPTION
Closes #95

## Problem

During the 2026-08-04 OOM incident, one run had **two review tasks running simultaneously** for the same PR — duplicate spend, racing verdicts, and extra memory pressure exactly when the box could least afford it.

The sweep's in-flight-review check keys on task status (`kind = review AND status IN (queued, running)`). A review pass whose container is OOM-killed or lost while the daemon hangs can leave its task stuck `running` with **no status transition** (corroborated by #96's "stale `running` rows after ungraceful container deaths"). Keyed on task status alone, that dead-but-stuck task reads as live forever: the run either **stalls** (never replaced), or — once anything re-queues — **races a duplicate** against its own PR.

## Fix

Pair the existing idempotency rule with an ungraceful-death path, so a run has *exactly one* review in flight — never zero when one is owed, never two racing.

- **`inFlightReviewTaskId`** — extract the in-flight check (issue #45) into a shared, tested helper so "an existing review task queued/running counts as in flight" is explicit.
- **`reapDeadReviewTasks`** — before each gather, confirm each running review task's container is actually gone (Docker probe fails safe: only a *definitively* dead container is reaped; a transient daemon error is left for the next sweep), mark it `failed`, drop its in-memory session entry and remove the dead container. The next sweep's in-flight check then queues exactly one deliberate replacement.
- **Verdict-store guards** in `finishReviewPass` and the review-pass catch, so a reaped-then-unhung pass can't clobber its replacement's run with a stale verdict (prevents the spec's "racing verdicts for the same PR").

Marking a review task `failed` does not fail the run or consume an attempt — a review death is infra, not bad work. Attempt/budget accounting for infra deaths is deliberately left to sibling **#97**.

New module `src/lib/orchestrator/autonomy/review-tasks.ts` is DB-only (no Docker/GitHub imports); the container-liveness probe is injected so the sweep passes the real daemon check and tests pass a fake.

## Test

`review-tasks.test.ts` pins the spec's requested scenario — *review pass dies without a status transition → exactly one replacement queued* (not zero, not two) — plus: a live review is left alone and no second is queued; queued/provisioning passes aren't reaped; the queued replacement isn't itself reaped or double-queued.

## Validation

- `vitest run` — 24 files, 473 tests pass.
- ESLint clean on all changed files.
- `tsc --noEmit` introduces no new errors (the two pre-existing errors are in an untouched test file, present on `main`).

## Self-review

Ran `/code-review` against `origin/main` with issue #95 as the spec. **Spec axis**: faithful and correct — no missing/wrong requirements; the memory-cleanup and verdict-guard additions were confirmed to serve the ticket's stated Impact, and false-positive safety (never reaping a healthy finishing pass) was verified. **Standards axis**: no hard violations; acted on all three duplication/consistency judgement calls in the follow-up commit.
