### PR TITLE
Infra-killed passes burn attempts and format-retries: classify container deaths as interruptions

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -199,6 +199,14 @@ answer it, or leave it; it doesn't need cancelling to free a slot.)
 - Review passes carry their own **~$5**; triage a small allowance with a low turn cap.
 - **3 attempts**, then the loop swaps `ready-for-agent` for **`ready-for-human`**,
   comments a summary and pings Discord.
+- **Interruptions don't count as attempts.** A run lost to an orchestrator restart
+  *or* to a container that died before finishing (OOM / exit 137 / docker error, i.e.
+  no terminal agent result) is marked `interrupted`, not `failed`: the sweep re-claims
+  the ticket without consuming an attempt. Re-claims are still bounded
+  (`MAX_INTERRUPTIONS_PER_TICKET`, 5), so a ticket that reliably kills its container
+  eventually routes to `ready-for-human` like an exhausted one. A review pass that
+  dies the same way re-queues a fresh replacement instead of burning its one
+  format-retry.
 - **$500/day** estate-wide autonomous cap pauses pickup (announced once, shown on
   the dashboard, resets at local midnight). Interactive work is exempt by
   construction (it has no run).

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -486,7 +486,8 @@ export async function notifyAttemptsExhausted(
         ? new EmbedBuilder()
             .setTitle(`Interruption bound hit — ${payload.issueRef} needs you`)
             .setDescription(
-              `${payload.interruptions} runs lost to orchestrator restarts ` +
+              `${payload.interruptions} runs lost to interruptions — restarts or ` +
+                `containers that died before finishing ` +
                 `($${payload.totalSpendUsd.toFixed(2)} autonomous spend). Re-claims are ` +
                 `bounded, so the ticket is now \`ready-for-human\`; the story is on the issue.`
             )

--- a/src/lib/orchestrator/autonomy/__tests__/pass-output.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/pass-output.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { finalPassMessage, passProducedResult } from "../pass-output";
+
+// Fixtures follow the shape of __tests__/stream-fixture.ndjson: the raw
+// stream-json a pass emits, ending (when it finishes cleanly) in a `result`
+// event whose `result` field is the turn's final message.
+function fixture(name: string): string {
+  return fs.readFileSync(path.join(__dirname, "fixtures", name), "utf8");
+}
+
+describe("finalPassMessage", () => {
+  it("extracts the final message from a clean result event", () => {
+    expect(finalPassMessage(fixture("verdict-approve.ndjson"))).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("fails on a stream that never reached a result event", () => {
+    expect(finalPassMessage(fixture("verdict-truncated.ndjson"))).toMatchObject({
+      ok: false,
+    });
+  });
+});
+
+// The classifier the interruption-vs-failure split hangs on (issue #97): a
+// stream with a terminal `result` event means the agent process ran to a
+// terminal state, so any downstream parse failure is the work's; a stream
+// with none means the container died before finishing (OOM / docker error /
+// lost stream), which must not be charged to the attempt or format-retry
+// budget. The boundary is exactly the errored-turn vs. truncated fixtures:
+// both parse as unparseable verdicts, but only one is an infra death.
+describe("passProducedResult", () => {
+  it("is true for a clean run that ended in a result event", () => {
+    expect(passProducedResult(fixture("verdict-approve.ndjson"))).toBe(true);
+  });
+
+  it("is true for an errored turn that still emitted a result event", () => {
+    // error_max_turns is the work's own doing — a terminal result arrived, so
+    // this is a format-slip-shaped failure, not an infra death. It must keep
+    // consuming the bounded format-retry, not re-queue freely.
+    expect(passProducedResult(fixture("verdict-errored-turn.ndjson"))).toBe(true);
+  });
+
+  it("is false for a stream truncated before any result event", () => {
+    // The #137 shape: the container died mid-review with no result event. The
+    // pass is unparseable, but as an infra death it must re-queue rather than
+    // burn the format-retry.
+    expect(passProducedResult(fixture("verdict-truncated.ndjson"))).toBe(false);
+  });
+
+  it("is false for empty output", () => {
+    expect(passProducedResult("")).toBe(false);
+  });
+
+  it("ignores interleaved non-JSON noise while scanning for the result event", () => {
+    const noisy =
+      'some stderr warning that is not json\n' +
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}\n' +
+      '{"type":"result","subtype":"success","is_error":false,"result":"VERDICT: approve","total_cost_usd":1.2}\n';
+    expect(passProducedResult(noisy)).toBe(true);
+  });
+});

--- a/src/lib/orchestrator/autonomy/pass-output.ts
+++ b/src/lib/orchestrator/autonomy/pass-output.ts
@@ -10,6 +10,30 @@ export type FinalPassMessage =
   | { ok: true; message: string }
   | { ok: false; reason: string };
 
+/**
+ * Whether the pass emitted a terminal `result` event at all — the signal that
+ * separates an infra death from a work failure (issue #97). A stream carrying
+ * a result event means the agent process ran to a terminal state (whatever it
+ * then said, or however it errored): any parse failure downstream is the
+ * work's — a format slip, an empty verdict. No result event means the
+ * container exited without finishing (OOM / exit 137, docker error, a lost
+ * stream), which is the platform's fault, not the work's, so it must not be
+ * charged to the attempt or format-retry budget.
+ */
+export function passProducedResult(ndjson: string): boolean {
+  for (const line of ndjson.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const event = JSON.parse(trimmed) as Record<string, unknown>;
+      if (event.type === "result") return true;
+    } catch {
+      // Interleaved non-JSON output (stderr noise) is not the pass's problem
+    }
+  }
+  return false;
+}
+
 export function finalPassMessage(ndjson: string): FinalPassMessage {
   let result: Record<string, unknown> | null = null;
 

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -1746,9 +1746,10 @@ async function executeExhaust(action: Extract<Action, { type: "exhaust" }>): Pro
     );
     await commentOnIssue(
       action.issueRef,
-      `${action.interruptionsMade} runs on this ticket were lost to orchestrator ` +
-        `restarts. Interruptions never consume attempts, but re-claims are bounded — ` +
-        `swapping \`${ARMING_LABEL}\` for \`${READY_FOR_HUMAN_LABEL}\`.\n\n` +
+      `${action.interruptionsMade} runs on this ticket were lost to interruptions ` +
+        `— an orchestrator restart, or a container that died before finishing ` +
+        `(OOM / docker error). Interruptions never consume attempts, but re-claims ` +
+        `are bounded — swapping \`${ARMING_LABEL}\` for \`${READY_FOR_HUMAN_LABEL}\`.\n\n` +
         (attemptLines.length > 0 ? `Failed attempts so far:\n${attemptLines.join("\n")}\n\n` : "") +
         `Total autonomous spend on this ticket: $${totalSpendUsd.toFixed(2)}.`
     );

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -459,13 +459,7 @@ export async function startTask(taskId: string): Promise<void> {
       }).catch(console.error);
     }
 
-    if (running) {
-      activeTasks.delete(taskId);
-      if (!getConfig().keepContainers) {
-        await removeContainer(running);
-        updateTask(taskId, { containerId: null });
-      }
-    }
+    await removeTaskContainer(taskId, running);
   }
 }
 
@@ -937,16 +931,11 @@ async function failImplementAttempt(
     );
   }
 
-  const entry = activeTasks.get(taskId);
-  activeTasks.delete(taskId);
-  if (entry && !getConfig().keepContainers) {
-    await removeContainer(entry.container);
-    updateTask(taskId, { containerId: null });
-  }
+  await removeTaskContainer(taskId, activeTasks.get(taskId)?.container ?? null);
 }
 
 /**
- * Interrupt an implement attempt whose container died before finishing (issue
+ * Interrupt an implement pass whose container died before finishing (issue
  * #97): a mid-turn OOM / docker error / lost stream, not a failed attempt. The
  * run is marked `interrupted` (bumping the interruption count, never a strike),
  * the task fails, the owner learns why on the issue, and the container goes
@@ -963,26 +952,24 @@ async function interruptImplementPass(
   const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();
   const run = db.select().from(runs).where(eq(runs.id, runId)).get();
 
-  insertSystemMessage(taskId, `Attempt interrupted: ${reason}`);
+  insertSystemMessage(taskId, `Pass interrupted: ${reason}`);
   updateTask(taskId, { status: "failed", containerStatus: null });
   syncRunCost(runId);
   interruptRun(runId, reason);
 
   if (task?.githubIssue) {
-    await commentOnIssue(
+    // Fire-and-forget: one call site awaits this from inside startTask's try,
+    // so a rejected comment must not throw back into the catch and re-run the
+    // whole interruption (a duplicate comment, a second count bump).
+    commentOnIssue(
       task.githubIssue,
       `Run interrupted (attempt ${run?.attempt ?? "?"}): ${reason}. ` +
         `Container deaths don't consume an attempt — the sweep re-claims this ` +
         `ticket (bounded). Work so far is pushed to \`${task.branch}\`.`
-    );
+    ).catch(console.error);
   }
 
-  const entry = activeTasks.get(taskId);
-  activeTasks.delete(taskId);
-  if (entry && !getConfig().keepContainers) {
-    await removeContainer(entry.container);
-    updateTask(taskId, { containerId: null });
-  }
+  await removeTaskContainer(taskId, activeTasks.get(taskId)?.container ?? null);
 }
 
 /**
@@ -1021,11 +1008,7 @@ async function finishReviewPass(
       `[orchestrator] Review task ${taskId} died without a result event — ` +
         `replacement will be queued (issue #97)`
     );
-    activeTasks.delete(taskId);
-    if (!getConfig().keepContainers) {
-      await removeContainer(running);
-      updateTask(taskId, { containerId: null });
-    }
+    await removeTaskContainer(taskId, running);
     return;
   }
 
@@ -1087,17 +1070,31 @@ export async function releaseParkedImplementTask(taskId: string, note: string): 
   await teardownTaskContainer(taskId, activeTasks.get(taskId)?.container ?? null);
 }
 
+/**
+ * Drop a task's in-memory session entry and remove its container (unless kept
+ * for debugging). The shared teardown behind every terminal path — completion,
+ * a failed attempt, an interruption, a reaped review — that must not leave a
+ * dead container holding memory or a phantom slot. The caller has already set
+ * the task's terminal status; this only lets go of the container.
+ */
+async function removeTaskContainer(
+  taskId: string,
+  running: RunningContainer | null
+): Promise<void> {
+  activeTasks.delete(taskId);
+  if (running && !getConfig().keepContainers) {
+    await removeContainer(running);
+    updateTask(taskId, { containerId: null });
+  }
+}
+
 /** Record completion and remove the container (unless kept for debugging). */
 async function teardownTaskContainer(
   taskId: string,
   running: RunningContainer | null
 ): Promise<void> {
   updateTask(taskId, { status: "completed", containerStatus: null });
-  activeTasks.delete(taskId);
-  if (running && !getConfig().keepContainers) {
-    await removeContainer(running);
-    updateTask(taskId, { containerId: null });
-  }
+  await removeTaskContainer(taskId, running);
 }
 
 /** A run's spend is the sum over the tasks it owns — implement pass plus

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -16,6 +16,7 @@ import { checkMemoryAdmission } from "./capacity";
 import { createOutputHandler, type TurnResult } from "./output-parser";
 import { parseReviewVerdict } from "./autonomy/verdict";
 import { parseTriageExit } from "./autonomy/triage";
+import { passProducedResult } from "./autonomy/pass-output";
 import {
   DEFAULT_REPAIR_BUDGET_USD,
   DEFAULT_REVIEW_BUDGET_USD,
@@ -223,6 +224,11 @@ export async function startTask(taskId: string): Promise<void> {
   }
 
   let running: RunningContainer | null = null;
+  // Whether the initial turn reached a terminal agent result (a `result`
+  // event). Stays false if the container dies mid-turn — the signal the catch
+  // block uses to tell an infra death (interruption) from a work failure
+  // (issue #97).
+  let producedResult = false;
 
   try {
     // Create container. Review and triage passes receive no credential beyond
@@ -293,6 +299,10 @@ export async function startTask(taskId: string): Promise<void> {
       effort: passEffort,
     });
 
+    // A terminal `result` event arrived — the turn ran to completion, so any
+    // failure from here is the work's, not the container's (issue #97).
+    producedResult = turnResult.subtype !== null;
+
     // Store session ID and cost
     updateTask(taskId, {
       sessionId: turnResult.sessionId,
@@ -320,6 +330,21 @@ export async function startTask(taskId: string): Promise<void> {
     await runPostTurnCommitAndPush(taskId, running);
 
     if (isImplementShaped) {
+      // A turn that returned no terminal result event died ungracefully
+      // mid-flight (the process exited before finishing rather than throwing) —
+      // an interruption, not a spent attempt (issue #97). Checked before
+      // exhaustion: with no result there is no trustworthy cost or subtype to
+      // judge exhaustion from, and the branch is pushed after every turn so any
+      // work survives the re-claim. Repair passes are never attempts, so this
+      // only diverts a real implement pass.
+      if (isImplementPass && run && !producedResult) {
+        await interruptImplementPass(
+          taskId,
+          run.id,
+          "container exited without a terminal result"
+        );
+        return;
+      }
       // Exhaustion first (issue #18) — but only for a real implement attempt.
       // A repair pass (issue #54) is never an attempt, so a repair that spent
       // its budget without clearing the conflict still parks: the sweep's
@@ -347,6 +372,20 @@ export async function startTask(taskId: string): Promise<void> {
     await scanForDevServer(taskId, running);
     await postIdleNotification(taskId);
   } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+
+    // An implement pass that threw before delivering a terminal result died to
+    // the container, not to bad work (issue #97): a mid-turn OOM (exit 137),
+    // docker error, or lost stream. Route it to the interruption bound rather
+    // than the attempt budget — its own handler records the ledger, messages
+    // the issue and cleans up, so return before the generic failure tail
+    // (which would announce a failure and re-remove the container).
+    if (isImplementPass && task.runId && !producedResult) {
+      insertSystemMessage(taskId, `Error: ${reason}`);
+      await interruptImplementPass(taskId, task.runId, `container error: ${reason}`);
+      return;
+    }
+
     // A triage pass that died delivered no exit. Store the failure as an
     // unparseable result so the fail-closed path (nothing applied, the
     // owner told once, needs-triage kept) runs instead of a silent retry.
@@ -367,42 +406,44 @@ export async function startTask(taskId: string): Promise<void> {
         ? {
             triageResult: {
               kind: "unparseable" as const,
-              reason: `triage pass failed: ${err instanceof Error ? err.message : String(err)}`,
+              reason: `triage pass failed: ${reason}`,
             },
           }
         : {}),
     });
     if (task.runId) {
       if (isReviewPass) {
-        // A review pass that died is not a failed attempt — the implement
-        // work is intact. Store the failure as an unparseable verdict so
-        // the fail-closed path (no merge, human-signoff, owner told) runs —
-        // unless the sweep already reaped this pass and queued a replacement.
-        if (!alreadyReaped) {
+        // A review pass that died is not a failed attempt — the implement work
+        // is intact. If a terminal result arrived, the failure is the review's
+        // own: store it as an unparseable verdict so the fail-closed path (no
+        // merge, human-signoff, owner told) runs. If none did — an infra death
+        // (OOM, docker error, lost stream) — leave the result null so the sweep
+        // queues a fresh replacement review (issue #97), consuming no
+        // format-retry, exactly the #95 reaper's recovery. Never write over a
+        // verdict the sweep already reaped and replaced (issue #95).
+        if (producedResult && !alreadyReaped) {
           db.update(runs)
             .set({
               reviewResult: {
                 kind: "unparseable",
-                reason: `review pass failed: ${err instanceof Error ? err.message : String(err)}`,
+                reason: `review pass failed: ${reason}`,
               },
             })
             .where(eq(runs.id, task.runId))
             .run();
         }
       } else {
-        finishRun(
-          task.runId,
-          "failed",
-          `container error: ${err instanceof Error ? err.message : String(err)}`
-        );
+        finishRun(task.runId, "failed", `container error: ${reason}`);
       }
     }
-    insertSystemMessage(
-      taskId,
-      `Error: ${err instanceof Error ? err.message : String(err)}`
-    );
+    insertSystemMessage(taskId, `Error: ${reason}`);
 
-    if (task.githubIssue) {
+    // An infra death of a review pass auto-recovers — the sweep re-queues a
+    // replacement — so it is not a failure to announce on the issue or in
+    // Discord (issue #97). Every other death here is a genuine failure.
+    const reviewInfraDeath = isReviewPass && !producedResult;
+
+    if (task.githubIssue && !reviewInfraDeath) {
       const domain = process.env.DOMAIN ?? "interludes.co.uk";
       commentOnIssue(
         task.githubIssue,
@@ -410,11 +451,11 @@ export async function startTask(taskId: string): Promise<void> {
       ).catch(console.error);
     }
 
-    if (proj.discordChannelId) {
+    if (proj.discordChannelId && !reviewInfraDeath) {
       notifyTaskFailed(proj.discordChannelId, {
         id: taskId,
         title: task.title,
-        error: err instanceof Error ? err.message : String(err),
+        error: reason,
       }).catch(console.error);
     }
 
@@ -905,6 +946,46 @@ async function failImplementAttempt(
 }
 
 /**
+ * Interrupt an implement attempt whose container died before finishing (issue
+ * #97): a mid-turn OOM / docker error / lost stream, not a failed attempt. The
+ * run is marked `interrupted` (bumping the interruption count, never a strike),
+ * the task fails, the owner learns why on the issue, and the container goes
+ * away. The branch was pushed after every turn, so any work survives for the
+ * re-claim the sweep queues without consuming an attempt. Mirrors
+ * `failImplementAttempt` but routes to the interruption bound (issue #24)
+ * rather than the attempt budget.
+ */
+async function interruptImplementPass(
+  taskId: string,
+  runId: string,
+  reason: string
+): Promise<void> {
+  const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get();
+
+  insertSystemMessage(taskId, `Attempt interrupted: ${reason}`);
+  updateTask(taskId, { status: "failed", containerStatus: null });
+  syncRunCost(runId);
+  interruptRun(runId, reason);
+
+  if (task?.githubIssue) {
+    await commentOnIssue(
+      task.githubIssue,
+      `Run interrupted (attempt ${run?.attempt ?? "?"}): ${reason}. ` +
+        `Container deaths don't consume an attempt — the sweep re-claims this ` +
+        `ticket (bounded). Work so far is pushed to \`${task.branch}\`.`
+    );
+  }
+
+  const entry = activeTasks.get(taskId);
+  activeTasks.delete(taskId);
+  if (entry && !getConfig().keepContainers) {
+    await removeContainer(entry.container);
+    updateTask(taskId, { containerId: null });
+  }
+}
+
+/**
  * End of a review pass: parse the verdict from the raw stream, store it on
  * the run for the sweep's next decision, and tear the container down. A
  * review pass never pushes, opens PRs, or posts anything itself.
@@ -916,6 +997,37 @@ async function finishReviewPass(
   rawStream: string
 ): Promise<void> {
   const verdict = parseReviewVerdict(rawStream);
+
+  // An unparseable verdict with no terminal result event in the stream is an
+  // infra death (issue #97): the container exited mid-review (OOM / docker
+  // error / lost stream), it did not merely mis-format a real review. Storing
+  // it as an unparseable verdict would burn the one bounded format-retry meant
+  // for genuine format slips (issue #89). Instead mark the pass `failed` and
+  // leave the verdict unstored, so the sweep queues a fresh replacement review
+  // — the same recovery the #95 reaper gives a hung review container, consuming
+  // no retry. The `running`-status guard mirrors the store below: a pass the
+  // sweep already reaped and replaced (#95) must not be touched again.
+  if (verdict.kind === "unparseable" && !passProducedResult(rawStream)) {
+    if (taskStatus(taskId) === "running") {
+      updateTask(taskId, { status: "failed", containerStatus: null });
+      insertSystemMessage(
+        taskId,
+        `Review pass produced no result event (container died mid-review): ` +
+          `${verdict.reason}. Marking it failed so a replacement review is ` +
+          `queued — no format-retry consumed.`
+      );
+    }
+    console.log(
+      `[orchestrator] Review task ${taskId} died without a result event — ` +
+        `replacement will be queued (issue #97)`
+    );
+    activeTasks.delete(taskId);
+    if (!getConfig().keepContainers) {
+      await removeContainer(running);
+      updateTask(taskId, { containerId: null });
+    }
+    return;
+  }
 
   // Only store the verdict if this pass is still the run's live review. If the
   // sweep reaped it as dead (container gone, task no longer `running` — issue
@@ -1316,6 +1428,33 @@ function taskStatus(taskId: string): string | null {
 function finishRun(runId: string, status: "failed" | "cancelled", reason?: string): void {
   db.update(runs)
     .set({ status, finishedAt: new Date(), ...(reason ? { failureReason: reason } : {}) })
+    .where(eq(runs.id, runId))
+    .run();
+}
+
+/**
+ * Terminalize a run as `interrupted` (issue #97): an in-flight pass whose
+ * container died without delivering a terminal agent result — OOM (exit 137),
+ * a docker error, a stream lost to host pressure — is the platform's fault,
+ * not the work's. Exactly like a restart-recovery interruption (issue #24) it
+ * counts against the interruption bound, never the attempt budget, so the
+ * sweep re-claims the ticket without consuming an attempt. The re-claim is
+ * still bounded (MAX_INTERRUPTIONS_PER_TICKET) so a ticket that reliably
+ * crashes its container eventually routes to a human instead of looping.
+ */
+function interruptRun(runId: string, reason: string): void {
+  const run = db
+    .select({ interruptionCount: runs.interruptionCount })
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .get();
+  db.update(runs)
+    .set({
+      status: "interrupted",
+      failureReason: reason,
+      interruptionCount: (run?.interruptionCount ?? 0) + 1,
+      finishedAt: new Date(),
+    })
     .where(eq(runs.id, runId))
     .run();
 }


### PR DESCRIPTION
Closes #97

## What was wrong

A pass whose container died while the orchestrator stayed up was charged exactly as if the agent had produced bad work:

- In the 2026-08-04 OOM incident, LPS **#140/#142** implement passes were host-OOM-killed before any recorded work (`status: failed, attempt: 1, $0`) — each burned one of the ticket's 3 attempts.
- **#137**'s bounded verdict format-retry (#89/#92) was consumed by a review pass that died with "review pass output has no result event" — an infra death, not a formatting failure.

Restart recovery (#24) already embodied the right principle — an interruption that isn't the work's fault re-claims **without consuming an attempt**, bounded by `MAX_INTERRUPTIONS_PER_TICKET` — but it only covered orchestrator restarts.

## The fix

Classify in-flight pass deaths by whether a **terminal agent `result` event** arrived (new pure `passProducedResult`, the boundary the issue names: "no result event, exit 137, docker error"):

- **Implement pass, no terminal result** (thrown mid-turn, or a non-throwing turn that emitted no result event): mark the run `interrupted`, not `failed`. It counts toward the interruption bound, so the sweep re-claims the ticket without consuming an attempt — still bounded, so a ticket that reliably kills its container routes to `ready-for-human` like an exhausted one. A terminal result that *then* failed (budget/turn exhaustion, a post-turn push error) is still a real failed attempt.
- **Review pass, no terminal result**: leave the verdict unstored and mark the pass failed so the sweep queues a fresh replacement review — the same recovery the **#95** reaper already gives a hung review container (its comment explicitly named #97 as the generalization), consuming no format-retry. A genuine format slip (result present, no `VERDICT:` line) still spends the retry as before.

Infra deaths auto-recover, so they no longer announce a "task failed" on the issue or in Discord. The exhaust/Discord/runbook wording for the interruption bound now names container deaths alongside restarts.

The manual recipe (delete the runs rows and re-arm) stays as the escape hatch; the ledger now gets this right unattended.

## Boundary, made explicit

`passProducedResult` returns **true** whenever a `result` event exists — even `is_error` / `error_max_turns` — so an errored-but-terminal turn stays a genuine failure/format-slip (pinned by the `verdict-errored-turn` vs `verdict-truncated` fixtures, the two shapes that both parse as unparseable verdicts). Only a stream with no `result` event at all is an interruption.

## Scope notes (from self-review with `/code-review`)

- **Setup failures** (container provisioning / clone before the first turn) now also classify as interruptions rather than failed attempts — a deliberate, in-spirit generalization of "not the work's fault," still bounded.
- **Repair passes** (#54) are unchanged: a repair infra death still fails via `finishRun` — repairs are never attempts, and their run is a live `reviewing`/`gated` one, out of scope here.
- Reworded exhaustion messages (Discord + issue comment + runbook) are a justified consequence of interruptions now having a second source.
- I **kept `passProducedResult(rawStream)` self-contained in `finishReviewPass`** rather than threading the caller's flag in — the function already parses the verdict from the same stream, so checking it for a result event is cohesive. I **declined** merging `interruptImplementPass` with `failImplementAttempt` into one parameterized skeleton — their semantics (interrupt-no-attempt vs fail-and-consume) and messaging differ enough that a shared skeleton would over-couple; the shared teardown was extracted instead (`removeTaskContainer`).

## Tests / limits

- New unit tests pin `passProducedResult` (the load-bearing new logic) against the existing stream fixtures; full suite green (480 passing), lint + tsc clean on changed files.
- The DB-transition glue (`interruptImplementPass` marking the run interrupted; the review re-queue) is not directly unit-tested — `turn-manager.ts` has no test harness in this repo (heavy DB + Docker I/O), so this matches the norm. The reducer side (interrupted runs → re-claim without an attempt) is already covered in `decide.test.ts`, and `passProducedResult` is covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
