### PR TITLE
Generation sessions exist as a class (#61)

### DIFF
--- a/drizzle/0017_ordinary_vance_astro.sql
+++ b/drizzle/0017_ordinary_vance_astro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tasks` ADD `session_skill` text;--> statement-breakpoint
+ALTER TABLE `tasks` ADD `session_issue` text;

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,602 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "72a82044-b9b4-4f06-be45-13e408e3b5d0",
+  "prevId": "bcb2718c-7d82-449d-95c7-847f551cf116",
+  "tables": {
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doppler_token": {
+          "name": "doppler_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "autonomy_enabled": {
+          "name": "autonomy_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preflight_status": {
+          "name": "preflight_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preflight_reason": {
+          "name": "preflight_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claimed'"
+        },
+        "budget_usd": {
+          "name": "budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_categories": {
+          "name": "gate_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "review_verdict": {
+          "name": "review_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_result": {
+          "name": "review_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_cycle_count": {
+          "name": "review_cycle_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "review_unparseable_count": {
+          "name": "review_unparseable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "integration_count": {
+          "name": "integration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "interruption_count": {
+          "name": "interruption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_question": {
+          "name": "blocked_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "github_issue": {
+          "name": "github_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'interactive'"
+        },
+        "session_skill": {
+          "name": "session_skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_issue": {
+          "name": "session_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_status": {
+          "name": "container_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "triage_result": {
+          "name": "triage_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_port": {
+          "name": "dev_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "container_name": {
+          "name": "container_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_subdomain": {
+          "name": "preview_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_run_id_runs_id_fk": {
+          "name": "tasks_run_id_runs_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1786665600000,
       "tag": "0016_review_unparseable_count",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1786752000000,
+      "tag": "0017_ordinary_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/__tests__/interactive-flow.test.ts
+++ b/src/app/api/__tests__/interactive-flow.test.ts
@@ -65,6 +65,55 @@ describe("interactive chat flow API against the migrated schema", () => {
     expect(rows[0].kind).toBe("interactive");
     expect(rows[0].runId).toBeNull();
     expect(rows[0].status).toBe("queued");
+    // An ordinary chat task is not a generation session (issue #61).
+    expect(rows[0].sessionSkill).toBeNull();
+    expect(rows[0].sessionIssue).toBeNull();
+  });
+
+  it("records a generation session's skill and issue anchor, kind still interactive (#61)", async () => {
+    const projectRes = await postProject(
+      jsonRequest("http://test/api/projects", { name: "Smoke" })
+    );
+    const { id: projectId } = await projectRes.json();
+
+    const created = await postTask(
+      jsonRequest("http://test/api/tasks", {
+        title: "Grill the fleet dashboard",
+        projectId,
+        sessionSkill: "grill-me",
+        sessionIssue: "lennons301/interlude#61",
+      })
+    );
+    expect(created.status).toBe(201);
+
+    // Re-read the persisted row: a session stays interactive with no run —
+    // spend exemption holds by construction — and the anchor lives in
+    // sessionIssue, never githubIssue (which drives implement-lifecycle).
+    const res = await getTasks(
+      new Request(`http://test/api/tasks?projectId=${projectId}`)
+    );
+    const [task] = await res.json();
+    expect(task.sessionSkill).toBe("grill-me");
+    expect(task.sessionIssue).toBe("lennons301/interlude#61");
+    expect(task.kind).toBe("interactive");
+    expect(task.runId).toBeNull();
+    expect(task.githubIssue).toBeNull();
+  });
+
+  it("rejects an unknown session skill", async () => {
+    const projectRes = await postProject(
+      jsonRequest("http://test/api/projects", { name: "Smoke" })
+    );
+    const { id: projectId } = await projectRes.json();
+
+    const res = await postTask(
+      jsonRequest("http://test/api/tasks", {
+        title: "Bad session",
+        projectId,
+        sessionSkill: "not-a-real-skill",
+      })
+    );
+    expect(res.status).toBe(400);
   });
 
   it("still validates input", async () => {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { tasks } from "@/db/schema";
+import { SESSION_SKILLS, tasks, type SessionSkill } from "@/db/schema";
 import { newId } from "@/lib/ulid";
 import { desc, eq } from "drizzle-orm";
 
@@ -24,10 +24,14 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const body = await request.json();
-  const { title, description, projectId } = body as {
+  const { title, description, projectId, sessionSkill, sessionIssue } = body as {
     title: string;
     description?: string;
     projectId: string;
+    // A generation session's skill (issue #61); omitted for a plain chat task.
+    sessionSkill?: string;
+    // Optional issue anchor (owner/repo#n) passed through to the session.
+    sessionIssue?: string;
   };
 
   if (!title?.trim()) {
@@ -36,8 +40,20 @@ export async function POST(request: Request) {
   if (!projectId) {
     return NextResponse.json({ error: "projectId is required" }, { status: 400 });
   }
+  if (
+    sessionSkill !== undefined &&
+    !SESSION_SKILLS.includes(sessionSkill as SessionSkill)
+  ) {
+    return NextResponse.json(
+      {
+        error: `sessionSkill must be one of: ${SESSION_SKILLS.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
 
   const now = new Date();
+  // Kind stays `interactive` — a session is a first-class chat task, not a run.
   const task = {
     id: newId(),
     projectId,
@@ -45,6 +61,8 @@ export async function POST(request: Request) {
     description: description?.trim() ?? "",
     status: "queued" as const,
     githubIssue: null,
+    sessionSkill: (sessionSkill as SessionSkill | undefined) ?? null,
+    sessionIssue: sessionIssue?.trim() || null,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/components/fleet/running-list.tsx
+++ b/src/components/fleet/running-list.tsx
@@ -39,7 +39,12 @@ function RunCard({ card, now }: { card: RunningCard; now: number }) {
           {card.projectName}
           {card.ticket && <span className="text-fl-ink"> {card.ticket}</span>}
         </span>
-        <Chip tone={MODE_TONE[card.mode]}>{card.mode}</Chip>
+        {/* A generation session reads as "session · grill-me", not the bare
+            "interactive" mode, so grilling is distinct from an agent driving
+            (issue #61). */}
+        <Chip tone={MODE_TONE[card.mode]}>
+          {card.sessionSkill ? `session · ${card.sessionSkill}` : card.mode}
+        </Chip>
       </div>
 
       <p className="truncate text-sm text-fl-ink">{card.title}</p>

--- a/src/db/__tests__/runs-ledger.test.ts
+++ b/src/db/__tests__/runs-ledger.test.ts
@@ -86,7 +86,7 @@ describe("runs ledger schema (fresh from-migrations DB)", () => {
     expect(run.finishedAt).toEqual(finishedAt);
   });
 
-  it("defaults tasks to kind interactive with no run", () => {
+  it("defaults tasks to kind interactive with no run and no session skill", () => {
     db.insert(schema.tasks)
       .values({
         id: "t1",
@@ -100,6 +100,28 @@ describe("runs ledger schema (fresh from-migrations DB)", () => {
     const task = db.select().from(schema.tasks).get()!;
     expect(task.kind).toBe("interactive");
     expect(task.runId).toBeNull();
+    expect(task.sessionSkill).toBeNull();
+    expect(task.sessionIssue).toBeNull();
+  });
+
+  it("records a generation session as an interactive task with no run (#61)", () => {
+    db.insert(schema.tasks)
+      .values({
+        id: "t-session",
+        projectId: "p1",
+        title: "Grill a fresh idea",
+        sessionSkill: "grill-me",
+        sessionIssue: "owner/repo#61",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .run();
+
+    const task = db.select().from(schema.tasks).get()!;
+    expect(task.kind).toBe("interactive");
+    expect(task.runId).toBeNull();
+    expect(task.sessionSkill).toBe("grill-me");
+    expect(task.sessionIssue).toBe("owner/repo#61");
   });
 
   it("links a task to its run and enforces the foreign key", () => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,20 @@
 import { int, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
+// Generation-session skills (issue #61): the estate's ticket-loop generation
+// half, runnable from an interactive session. The single source of truth for
+// the runtime list — the DB column enum, the task-creation API's validation,
+// and the fleet dashboard's own decoupled union all answer to this tuple.
+export const SESSION_SKILLS = [
+  "grill-me",
+  "grill-with-docs",
+  "triage",
+  "to-spec",
+  "to-tickets",
+  "wayfinder",
+] as const;
+
+export type SessionSkill = (typeof SESSION_SKILLS)[number];
+
 export const projects = sqliteTable("projects", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
@@ -124,6 +139,19 @@ export const tasks = sqliteTable("tasks", {
   })
     .notNull()
     .default("interactive"),
+  // Generation sessions (issue #61): a non-null value makes an interactive task
+  // a first-class generation session running one of the estate's generation
+  // skills. Null = an ordinary chat task. Kind stays `interactive` and no run
+  // row exists, so spend-cap exemption and the autonomy reducer are unchanged
+  // by construction. Distinct from the autonomous `kind=triage` pass: a
+  // `sessionSkill=triage` session is a human-driven, runless triage.
+  sessionSkill: text("session_skill", { enum: SESSION_SKILLS }),
+  // The GitHub issue a session is anchored to (owner/repo#n), passed through so
+  // the session can open with the issue as context. Deliberately separate from
+  // `githubIssue`, which drives implement-lifecycle machinery (issue comments,
+  // a `Closes #n` draft PR) that an anchored generation session must not
+  // trigger.
+  sessionIssue: text("session_issue"),
   runId: text("run_id").references(() => runs.id),
   containerId: text("container_id"),
   branch: text("branch"),

--- a/src/lib/fleet/__tests__/digest.test.ts
+++ b/src/lib/fleet/__tests__/digest.test.ts
@@ -79,6 +79,8 @@ function makeTask(overrides: Partial<FleetTaskRow> = {}): FleetTaskRow {
     projectId: "proj-1",
     runId: null,
     kind: "interactive",
+    sessionSkill: null,
+    sessionIssue: null,
     title: "Polish the header",
     status: "running",
     containerStatus: "idle",
@@ -246,6 +248,26 @@ describe("renderDailyDigest — in flight", () => {
       "lemons #34 · Add pagination to the list · attempt 2/3 · $7.80 of $20.00",
       "lemons #35 · lennons301/lemons#35 · attempt 1/3 · $3.00 of $20.00 · supervised",
       "interlude · Polish the header · interactive · $1.23",
+    ]);
+  });
+
+  it("labels a generation session by its skill, not 'interactive' (issue #61)", () => {
+    const content = render({
+      projects: [makeProject({ id: "p1", name: "interlude" })],
+      tasks: [
+        makeTask({
+          id: "t-session",
+          projectId: "p1",
+          title: "Grill a fresh idea",
+          sessionSkill: "grill-me",
+          containerStatus: "idle",
+          totalCostUsd: 2.4,
+        }),
+      ],
+    });
+
+    expect(section(content, "In flight")).toEqual([
+      "interlude · Grill a fresh idea · session grill-me · $2.40",
     ]);
   });
 

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -66,6 +66,8 @@ function makeTask(overrides: Partial<FleetTaskRow> = {}): FleetTaskRow {
     projectId: "proj-1",
     runId: null,
     kind: "interactive",
+    sessionSkill: null,
+    sessionIssue: null,
     title: "Polish the header",
     status: "running",
     containerStatus: "idle",
@@ -805,6 +807,7 @@ describe("buildFleetView — running", () => {
         ticket: "#34",
         title: "Add pagination to the list",
         mode: "afk",
+        sessionSkill: null,
         phases: [
           { name: "implement", state: "current" },
           { name: "review", state: "todo" },
@@ -871,6 +874,7 @@ describe("buildFleetView — running", () => {
         ticket: null,
         title: "Polish the header",
         mode: "interactive",
+        sessionSkill: null,
         phases: null,
         attempt: null,
         turns: 3,
@@ -878,6 +882,57 @@ describe("buildFleetView — running", () => {
         spend: { usd: 1.23, budgetUsd: null },
       },
     ]);
+  });
+
+  it("labels a generation session with its skill and issue anchor (issue #61)", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "interlude" })],
+        tasks: [
+          makeTask({
+            id: "t1",
+            projectId: "p1",
+            title: "Grill the fleet dashboard",
+            sessionSkill: "grill-me",
+            // The anchor lives in sessionIssue, never githubIssue, on a session.
+            sessionIssue: "lennons301/interlude#61",
+            containerStatus: "idle",
+            turns: 2,
+            createdAt: TODAY_9AM,
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toHaveLength(1);
+    const card = view.running[0];
+    // Still an interactive session — a skill doesn't change the mode — but the
+    // dashboard reads the skill to label it distinctly from a plain chat task.
+    expect(card.mode).toBe("interactive");
+    expect(card.sessionSkill).toBe("grill-me");
+    expect(card.ticket).toBe("#61");
+  });
+
+  it("does not treat an autonomous triage pass as a generation session (issue #61)", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1", name: "interlude" })],
+        tasks: [
+          makeTask({
+            id: "t-triage",
+            projectId: "p1",
+            kind: "triage",
+            title: "Triage: something",
+            containerStatus: "running",
+            createdAt: TODAY_9AM,
+          }),
+        ],
+      })
+    );
+
+    expect(view.running).toHaveLength(1);
+    expect(view.running[0].mode).toBe("triage");
+    expect(view.running[0].sessionSkill).toBeNull();
   });
 
   it("picks a run's live pass as its face, ignoring a finished pass with a stale container_status", () => {
@@ -1149,6 +1204,7 @@ describe("buildFleetView — running", () => {
         ticket: "#90",
         title: "Triage: Add auth",
         mode: "triage",
+        sessionSkill: null,
         phases: null,
         attempt: null,
         turns: 1,

--- a/src/lib/fleet/digest.ts
+++ b/src/lib/fleet/digest.ts
@@ -88,7 +88,12 @@ function runningLine(card: RunningCard): string {
     : card.projectName;
   const parts = [where, card.title];
   if (card.mode === "interactive") {
-    parts.push("interactive", usd(card.spend.usd));
+    // A generation session reads as "session grill-me", not "interactive", so
+    // the digest distinguishes grilling from a plain chat task (issue #61).
+    parts.push(
+      card.sessionSkill ? `session ${card.sessionSkill}` : "interactive",
+      usd(card.spend.usd)
+    );
   } else {
     if (card.attempt) {
       parts.push(`attempt ${card.attempt.current}/${card.attempt.max}`);

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -82,11 +82,26 @@ export interface FleetRunRow {
   finishedAt: Date | null;
 }
 
+/** Generation-session skills (issue #61) — kept as a decoupled union here, in
+ * step with the row types the view defines rather than importing from the DB
+ * schema. Its single runtime source of truth is SESSION_SKILLS in the schema. */
+export type SessionSkill =
+  | "grill-me"
+  | "grill-with-docs"
+  | "triage"
+  | "to-spec"
+  | "to-tickets"
+  | "wayfinder";
+
 export interface FleetTaskRow {
   id: string;
   projectId: string;
   runId: string | null;
   kind: "interactive" | "implement" | "review" | "triage" | "repair";
+  /** Non-null marks an interactive task as a generation session (issue #61) */
+  sessionSkill: SessionSkill | null;
+  /** GitHub issue the session is anchored to (owner/repo#n), or null */
+  sessionIssue: string | null;
   title: string;
   status: "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
   containerStatus: "setup" | "running" | "idle" | "completing" | null;
@@ -137,6 +152,10 @@ export interface RunningCard {
   /** Card kind: afk = full autonomy, supervised = forced human-signoff,
    * interactive = a chat session, triage = a read-only triage pass (#90) */
   mode: "afk" | "supervised" | "interactive" | "triage";
+  /** Non-null on a generation session (issue #61): the dashboard and digest
+   * label it "session · <skill>" to distinguish it from a plain chat task.
+   * Always null for afk/supervised/triage cards. */
+  sessionSkill: SessionSkill | null;
   /** implement ▸ review ▸ merge pipeline; null for standalone interactive
    * sessions and triage passes, which sit outside the ticket pipeline */
   phases: { name: "implement" | "review" | "merge"; state: PhaseState }[] | null;
@@ -519,6 +538,7 @@ export function buildFleetView(rows: FleetRows): FleetView {
         ticket: ticketLabel(run.githubIssue),
         title: pass?.title ?? run.githubIssue,
         mode: run.mode === "autonomous" ? ("afk" as const) : ("supervised" as const),
+        sessionSkill: null,
         phases: phasePipeline(reviewing),
         attempt: { current: run.attempt, max: MAX_ATTEMPTS },
         turns: pass?.turns ?? 0,
@@ -539,9 +559,14 @@ export function buildFleetView(rows: FleetRows): FleetView {
       taskId: task.id,
       runId: null,
       projectName: projectName(task.projectId),
-      ticket: ticketLabel(task.githubIssue),
+      // A generation session shows the issue it's anchored to (issue #61); the
+      // anchor lives in sessionIssue, never githubIssue, on an interactive task.
+      ticket: ticketLabel(task.githubIssue ?? task.sessionIssue),
       title: task.title,
       mode: triage ? "triage" : "interactive",
+      // Only an interactive session carries a skill; the autonomous triage pass
+      // (kind=triage) is never a generation session.
+      sessionSkill: triage ? null : task.sessionSkill,
       phases: null,
       attempt: null,
       turns: task.turns,

--- a/src/lib/fleet/rows.ts
+++ b/src/lib/fleet/rows.ts
@@ -97,6 +97,8 @@ export async function loadFleetRows(now: Date): Promise<FleetRows> {
       projectId: t.projectId,
       runId: t.runId,
       kind: t.kind,
+      sessionSkill: t.sessionSkill,
+      sessionIssue: t.sessionIssue,
       title: t.title,
       status: t.status,
       containerStatus: t.containerStatus,


### PR DESCRIPTION
Closes #61

Makes a generation session a first-class concept the platform can see, without disturbing interactive-task semantics.

## What changed

- **Schema** (`src/db/schema.ts`, migration `0017`): `tasks` gains two nullable columns.
  - `sessionSkill` — enum `grill-me | grill-with-docs | triage | to-spec | to-tickets | wayfinder`. A non-null value marks an interactive task as a generation session. `SESSION_SKILLS` is the single runtime source of truth for the list.
  - `sessionIssue` — the GitHub issue (owner/repo#n) a session is anchored to, passed through so a later ticket can open the session with the issue as context.
  - Task `kind` stays `interactive` and no run row is created, so spend-cap exemption and the autonomy reducer are unchanged **by construction** — no edits to `spend.ts` or `decideNext`.
- **API** (`POST /api/tasks`): accepts an optional `sessionSkill` (validated against `SESSION_SKILLS`, `400` on an unknown value) and an optional `sessionIssue` anchor. Omitting both yields an ordinary chat task, unchanged.
- **Fleet dashboard + digest**: `buildFleetView` surfaces a session's skill on its `RunningCard`; the dashboard chip and the daily digest read as `session · <skill>` instead of the bare `interactive`. An anchored session shows its issue as the card ticket. The autonomous `kind=triage` pass is untouched and never reads as a generation session.

## Design note: why the anchor is its own column

The issue anchor is stored in a new `sessionIssue` column rather than reusing `tasks.githubIssue`. `githubIssue` drives implement-lifecycle machinery in `turn-manager.ts` gated only on the field being set — a `Closes #n` PR body and "Draft PR opened" issue comments. Interactive tasks do push branches and auto-open draft PRs, so reusing `githubIssue` for an anchor would make a grilling session comment on, and auto-close on merge, the very issue it is only *thinking about*. A separate column keeps the anchor as pure context.

## Acceptance criteria

- [x] A session created via the API records its session skill and appears on the dashboard labelled as a session
- [x] Ordinary interactive tasks are unaffected (null session skill, unchanged display)
- [x] No changes to spend exemption or reducer behaviour — sessions have no run row
- [x] Migration generated and applied (`0017`, journal `when` bumped +1 day past `0016` per the repo's migration convention)

## Self-review notes (code-review skill, fixed point `origin/main`)

Both axes came back clean; I acted on nothing because the flagged items are intentional or out of scope, but recording them here rather than silently ignoring:

- **Runtime consumption is a sibling ticket.** Nothing in the session *runtime* yet reads `sessionSkill`/`sessionIssue` (no skill install, no `gh` token, no issue-as-opening-context). #61 is "sessions exist as a class"; the parent #50 batch owns the container capability additions. The AC here do not require invocation.
- **Digest + anchor-as-ticket are slightly beyond the literal "fleet dashboard" wording**, but flow from the shared `buildFleetView` read model whose whole point is that the dashboard and digest can never disagree. Deliberate.
- **`SessionSkill` is declared twice** (schema tuple + a decoupled union in `fleet-view.ts`). This matches the established idiom in that file (`kind`/`status`/`containerStatus` are all re-declared inline rather than imported from the schema), and `rows.ts` assigning the schema type into `FleetTaskRow` makes tsc catch divergence.
- **Chip renders lowercase** (`session · grill-me`) — the fleet chip's design language lowercases every chip; the ticket's `Session · grill-me` is an illustrative `e.g.`

## Validation

- `vitest run` — 486 passing (added tests: schema round-trip, API accept + reject, dashboard label, digest label, triage-vs-session distinction).
- `eslint` clean on all changed files.
- `tsc --noEmit` clean on all changed files. (Two pre-existing tsc errors remain in the untouched `container-manager.test.ts`, present on `origin/main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)