### PR TITLE
Autonomy: detect BLOCKED: marker on any line, not just the first (#107)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -151,7 +151,8 @@ chat/preview is never affected.
 ### 4. Answer a blocked agent from Discord
 
 When an agent hits a decision the ticket doesn't settle, it emits
-`BLOCKED: <question>` as the first line of its turn. The orchestrator parks the
+`BLOCKED: <question>` on its own line (a short lead-in above it is fine — the
+detector scans every line, not just the first). The orchestrator parks the
 run (status `blocked`, container kept alive but **holding no slot**) and posts the
 question to the project's linked Discord channel — or, if the project has none, to
 the fleet channel (`DISCORD_FLEET_CHANNEL_ID`).

--- a/docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md
+++ b/docs/specs/2026-07-30-phase5-autonomous-ticket-loop-design.md
@@ -529,6 +529,11 @@ fleet channel. My reply becomes a queued user message on the task and the
 existing queue delivers it as the next turn — the Phase 4 idle-and-reply plumbing
 carries this whole feature.
 
+> **Superseded by #107/#106 (2026-08-10):** the detector now matches `BLOCKED:`
+> at the start of *any* line, not first-line-only. The false-negative rationale
+> above was overturned — a missed marker did **not** merely idle the task; it
+> left the run a permanent non-terminal ghost (#106).
+
 Supervised mode (from a `checkpoint:` directive) runs the implement pass
 normally, then forces `human-signoff` regardless of gate matches and pings me
 with the checkpoint text. It reuses the gate machinery rather than adding a

--- a/src/lib/orchestrator/autonomy/__tests__/blocked.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/blocked.test.ts
@@ -7,13 +7,52 @@ describe("detectBlockedQuestion — positive cases", () => {
       detectBlockedQuestion("BLOCKED: Should retries be configurable or fixed at 3?")
     ).toBe("Should retries be configurable or fixed at 3?");
   });
-});
 
-describe("detectBlockedQuestion — negative cases (biased toward false negatives)", () => {
-  it("ignores the marker mid-message", () => {
+  it("detects the marker after a preamble paragraph — narrate-then-BLOCKED (issue #107)", () => {
+    // The real moontide #32 message: a preamble line, a blank line, then the
+    // marker. First-line-only detection returned null and the run dangled.
+    const moontide =
+      "The ticket's premise doesn't hold, and the resolution changes the " +
+      "deliverable materially, so I'm stopping rather than guessing.\n\n" +
+      "BLOCKED: `README.md` is not empty — it's a deliberate 89-line README. " +
+      "Should I cut it down to the minimal three-section README the ticket " +
+      "specifies (deleting the existing content)?";
+
+    expect(detectBlockedQuestion(moontide)).toBe(
+      "`README.md` is not empty — it's a deliberate 89-line README. Should I " +
+        "cut it down to the minimal three-section README the ticket specifies " +
+        "(deleting the existing content)?"
+    );
+  });
+
+  it("detects the marker after a single preamble line", () => {
     expect(
       detectBlockedQuestion(
         "I reviewed the ticket.\nBLOCKED: Should retries be configurable?"
+      )
+    ).toBe("Should retries be configurable?");
+  });
+
+  it("detects the marker preceded by a blank first line", () => {
+    expect(detectBlockedQuestion("\nBLOCKED: Should retries be configurable?")).toBe(
+      "Should retries be configurable?"
+    );
+  });
+
+  it("detects the marker after a preceding fenced code block", () => {
+    expect(
+      detectBlockedQuestion(
+        "Here is the diff:\n```\nsome code\n```\nBLOCKED: Should retries be configurable?"
+      )
+    ).toBe("Should retries be configurable?");
+  });
+});
+
+describe("detectBlockedQuestion — negative cases (false-positive guards)", () => {
+  it("ignores the marker mid-line inside prose", () => {
+    expect(
+      detectBlockedQuestion(
+        'The spec says to emit "BLOCKED: <question>" when stuck, which I did not need.'
       )
     ).toBeNull();
   });
@@ -24,22 +63,10 @@ describe("detectBlockedQuestion — negative cases (biased toward false negative
     ).toBeNull();
   });
 
-  it("ignores a marker mentioned inside first-line prose", () => {
-    expect(
-      detectBlockedQuestion(
-        'The spec says to emit "BLOCKED: <question>" when stuck, which I did not need.'
-      )
-    ).toBeNull();
-  });
-
   it("ignores a marker inside a code fence", () => {
     expect(
       detectBlockedQuestion("```\nBLOCKED: Should retries be configurable?\n```")
     ).toBeNull();
-  });
-
-  it("ignores a marker preceded by a blank first line", () => {
-    expect(detectBlockedQuestion("\nBLOCKED: Should retries be configurable?")).toBeNull();
   });
 
   it("ignores an indented marker", () => {
@@ -57,6 +84,9 @@ describe("detectBlockedQuestion — negative cases (biased toward false negative
   it("ignores a marker with no question — there is nothing to ask", () => {
     expect(detectBlockedQuestion("BLOCKED:")).toBeNull();
     expect(detectBlockedQuestion("BLOCKED:   ")).toBeNull();
+    expect(
+      detectBlockedQuestion("I reviewed the ticket.\nBLOCKED:   ")
+    ).toBeNull();
   });
 
   it("returns null for an empty or missing final message", () => {
@@ -66,7 +96,7 @@ describe("detectBlockedQuestion — negative cases (biased toward false negative
 });
 
 describe("detectBlockedQuestion — question extraction", () => {
-  it("returns only the first line — context below stays in the task chat", () => {
+  it("returns only the marker's line — context below stays in the task chat", () => {
     expect(
       detectBlockedQuestion(
         "BLOCKED: Postgres or SQLite for the cache?\n\nThe ticket names neither and both fit."

--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -1704,13 +1704,39 @@ describe("decideNext — blocked escalation", () => {
     expect(actions).toEqual([]);
   });
 
-  it("does not park a run for a mid-message marker", () => {
+  it("escalates a pass whose marker follows a preamble (issue #107)", () => {
     const actions = decideNext(
       makeSnapshot({
         candidates: [],
         completedPasses: [
           makePass({
-            finalMessage: "All done.\nBLOCKED: this is a summary, not a question.",
+            finalMessage:
+              "I'm stopping rather than guessing.\n\n" +
+              "BLOCKED: The ticket names neither Postgres nor SQLite — which one?",
+          }),
+        ],
+      })
+    );
+
+    expect(escalations(actions)).toEqual([
+      {
+        type: "escalate",
+        reason: "blocked",
+        runId: "run-1",
+        taskId: "task-1",
+        issueRef: "acme/widgets#7",
+        question: "The ticket names neither Postgres nor SQLite — which one?",
+      },
+    ]);
+  });
+
+  it("does not park a run for a marker mid-line inside prose", () => {
+    const actions = decideNext(
+      makeSnapshot({
+        candidates: [],
+        completedPasses: [
+          makePass({
+            finalMessage: "All done — no BLOCKED: markers were needed here.",
           }),
         ],
       })

--- a/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
@@ -46,11 +46,11 @@ describe("buildImplementPrompt", () => {
     expect(prompt).toContain("agent/issue-7");
   });
 
-  it("carries the blocked-marker contract: stop and lead the final message with it", () => {
+  it("carries the blocked-marker contract: stop and put the marker on its own line", () => {
     const prompt = buildImplementPrompt({ ...TICKET, workflow: { source: "default" } });
 
     expect(prompt).toContain("BLOCKED: <your question>");
-    expect(prompt).toContain("first line");
+    expect(prompt).toContain("on its own line");
     expect(prompt).toMatch(/stop/i);
   });
 

--- a/src/lib/orchestrator/autonomy/blocked.ts
+++ b/src/lib/orchestrator/autonomy/blocked.ts
@@ -3,20 +3,43 @@
  * question the agent is stuck on, or null. Pure — the deciding and executing
  * around it live in decide.ts and the turn manager.
  *
- * Detection is deliberately biased toward false negatives: the marker counts
- * only as the very first line of the message. A missed marker merely idles
- * the run where the dashboard shows it; a false positive parks healthy work.
+ * The marker counts at the **start of any line**, not just line 0 (issue #107).
+ * "Narrate, then BLOCKED:" is extremely common LLM behaviour, and the earlier
+ * first-line-only bias meant a leading preamble silently defeated the park: the
+ * run was never blocked, the pass completed empty, and the owner never got the
+ * Discord question — leaving a permanent non-terminal ghost (issue #106). A
+ * false negative is therefore far more costly than the header once assumed, so
+ * detection tolerates a preamble.
+ *
+ * The false-positive guards remain: the marker must begin a line (so mid-line
+ * prose like "we were BLOCKED: by X" never matches) and lines inside a fenced
+ * code block are skipped (so an agent quoting the protocol as an example does
+ * not park itself). Only the rest of the marker's line is taken as the
+ * question; further context stays in the task chat.
  */
 
 const BLOCKED_MARKER = /^BLOCKED:\s*(.*)$/;
+const CODE_FENCE = /^\s*(```|~~~)/;
 
 export function detectBlockedQuestion(finalMessage: string | null): string | null {
   if (!finalMessage) return null;
 
-  const firstLine = finalMessage.split("\n", 1)[0].replace(/\r$/, "");
-  const match = firstLine.match(BLOCKED_MARKER);
-  if (!match) return null;
+  let insideFence = false;
+  for (const rawLine of finalMessage.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
 
-  const question = match[1].trim();
-  return question.length > 0 ? question : null;
+    if (CODE_FENCE.test(line)) {
+      insideFence = !insideFence;
+      continue;
+    }
+    if (insideFence) continue;
+
+    const match = line.match(BLOCKED_MARKER);
+    if (!match) continue;
+
+    const question = match[1].trim();
+    return question.length > 0 ? question : null;
+  }
+
+  return null;
 }

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -352,10 +352,11 @@ export function buildImplementPrompt(ticket: ImplementTicket): string {
     `- Make small, atomic commits as you work. Run the repo's tests and lint before ` +
       `you finish, and do not finish with either failing.`,
     `- If you hit a decision the ticket does not resolve, do not guess: stop and ` +
-      `end your turn with a final message whose first line is exactly ` +
-      "`BLOCKED: <your question>` — the marker must start the first line, with " +
-      `nothing before it, or it will not be seen. The question goes to the owner ` +
-      `and the answer arrives as your next turn, with your context intact.`,
+      `end your turn with a final message that puts, on its own line, exactly ` +
+      "`BLOCKED: <your question>` — the marker must start the line, with nothing " +
+      `before it. A short lead-in above it is fine, but keep the marker on its ` +
+      `own line so it is seen. The question goes to the owner and the answer ` +
+      `arrives as your next turn, with your context intact.`,
     `- End with a short summary of what you built and anything a reviewer should know.`,
     ``,
     workflowBlock(ticket),

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -381,9 +381,10 @@ export async function startTask(taskId: string): Promise<void> {
           return;
         }
       }
-      // The pass's turn is over: park it blocked if its final message leads
-      // with the BLOCKED marker — container kept alive, question escalated
-      // to the owner (issue #19). Otherwise the initial turn is the whole
+      // The pass's turn is over: park it blocked if its final message carries
+      // the BLOCKED marker on any line (issue #107) — container kept alive,
+      // question escalated to the owner (issue #19). Otherwise the initial turn
+      // is the whole
       // pass: mark the PR ready and park the container awaiting review — it
       // stays alive (holding no slot) so a request-changes verdict can
       // deliver a fix-up turn into the same attempt. The run stays


### PR DESCRIPTION
Closes #107

## What changed

`detectBlockedQuestion` (`src/lib/orchestrator/autonomy/blocked.ts`) now matches the `BLOCKED:` marker at the **start of any line** in the turn's final message, not only line 0. "Narrate, then `BLOCKED:`" is common LLM behaviour, so the old first-line-only bias let a leading preamble silently defeat the HITL park — the run was never blocked, the pass completed empty, the owner never got the Discord question, and the run dangled non-terminal forever (the #106 ghost card). The concrete instance was moontide #32.

The false-positive guards are kept: the marker must **begin a line** (mid-line prose like "we were BLOCKED: by X" never matches), it stays case-sensitive/unindented (`^BLOCKED:`), and lines inside a fenced code block are skipped. Only the rest of the marker's line becomes the question; further context stays in the task chat.

- `blocked.ts` — line-scanning detector with fence tracking; header comment rewritten to explain the new false-negative cost (#106) and the remaining guards.
- `workflow.ts` — belt-and-braces prompt reinforcement: ask the agent to keep the marker on its own line (a short lead-in is fine), instead of the now-false claim that a preamble hides it. Detection no longer depends on the model complying.
- `turn-manager.ts` — corrected the park-path comment ("leads with" → "on any line").
- Tests — `blocked.test.ts` updated to the new contract (incl. the real moontide #32 message, blank-first-line, and after-a-fence cases) and `decide.test.ts` re-pointed from "mid-message marker doesn't park" to "preamble-then-marker parks" + a genuine mid-line-prose negative.

## Acceptance criteria

- [x] Table-test: a `BLOCKED:` line **after** a preamble paragraph returns the question — the moontide #32 message parks (`blocked.test.ts`, `decide.test.ts`).
- [x] A `BLOCKED:` token mid-line inside prose does **not** trigger.
- [x] Empty/whitespace question still returns `null` (including after a preamble).
- [x] E2E park path unchanged and wired: `detectBlockedQuestion` → `decideNext` → `evaluatePassOutcome` → `parkBlockedRun` (status `blocked` + Discord question; a reply restarts the container and un-parks). The deterministic pieces are covered by tests; the live container leg can only be exercised on the VPS.

## Reviewer note (scope decision)

The issue named only the mid-line-prose false positive; I **additionally kept** the existing code-fence guard (skip lines inside ``` / ~~~ fences) rather than drop it. It preserves an existing test and prevents a real false positive — an agent quoting the `BLOCKED: <question>` protocol as a fenced example would otherwise park itself with a nonsense question. The trade-off is a narrow residual false-negative if an agent emits a genuine marker right after an *unterminated* fence; I judged the quoted-example false positive the more likely of the two. Happy to drop the fence guard if you'd rather track the issue's wording literally.

## Validation

- `pnpm test` — 500 passed (25 files).
- `pnpm exec eslint` on all changed files — clean.
- `tsc --noEmit` — no new errors in touched files (two pre-existing errors remain in the unrelated `container-manager.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)