### PR TITLE
Per-exec GH_TOKEN for generation sessions

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,6 +15,22 @@ export const SESSION_SKILLS = [
 
 export type SessionSkill = (typeof SESSION_SKILLS)[number];
 
+/**
+ * A generation session is an interactive task running one of the estate's
+ * generation skills (issue #61): kind stays `interactive`, and the non-null
+ * sessionSkill is what distinguishes it from an ordinary chat task and from the
+ * autonomous `kind=triage` pass. This predicate is the single definition of the
+ * concept — issue #62 keys the per-exec `gh` token off it, so that a token able
+ * to create issues (and therefore apply the launch-button label) only ever
+ * reaches an attended session, never an unattended implement/review/triage exec.
+ */
+export function isGenerationSession(task: {
+  kind: string;
+  sessionSkill: SessionSkill | null;
+}): boolean {
+  return task.kind === "interactive" && task.sessionSkill !== null;
+}
+
 export const projects = sqliteTable("projects", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -10,6 +10,11 @@ import {
   SKILLS_PLUGIN_ID,
   SKILLS_VERSION_MARKER,
 } from "../container-manager";
+import {
+  isGenerationSession,
+  SESSION_SKILLS,
+  type SessionSkill,
+} from "@/db/schema";
 
 // Capture the options passed to docker.createContainer so we can assert on the
 // HostConfig the orchestrator asks Docker for.
@@ -177,6 +182,7 @@ describe("buildTurnEnv", () => {
       prompt: "do the thing",
       gitAuthToken: "ghs_abc",
       claudeCodeOauthToken: null,
+      ghToken: null,
     });
     expect(env).toContain("CLAUDE_PROMPT=do the thing");
     expect(env).toContain("GIT_AUTH_TOKEN=ghs_abc");
@@ -187,6 +193,7 @@ describe("buildTurnEnv", () => {
       prompt: "p",
       gitAuthToken: "t",
       claudeCodeOauthToken: "sk-ant-oat01-xyz",
+      ghToken: null,
     });
     expect(env).toContain("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xyz");
   });
@@ -196,8 +203,69 @@ describe("buildTurnEnv", () => {
       prompt: "p",
       gitAuthToken: "t",
       claudeCodeOauthToken: null,
+      ghToken: null,
     });
     expect(env.some((e) => e.startsWith("CLAUDE_CODE_OAUTH_TOKEN"))).toBe(false);
+  });
+
+  // Issue #62: `gh` inside a generation-session container authenticates from
+  // GH_TOKEN. It is exposed only when the caller passes a token — for autonomous
+  // execs the caller passes null, so the negative case is that GH_TOKEN is simply
+  // never in the env.
+  it("exposes GH_TOKEN to gh when a generation-session token is supplied", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "ghs_git",
+      claudeCodeOauthToken: null,
+      ghToken: "ghs_gh",
+    });
+    expect(env).toContain("GH_TOKEN=ghs_gh");
+  });
+
+  it("omits GH_TOKEN entirely when no generation-session token is supplied", () => {
+    const env = buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: "ghs_git",
+      claudeCodeOauthToken: null,
+      ghToken: null,
+    });
+    expect(env.some((e) => e.startsWith("GH_TOKEN"))).toBe(false);
+  });
+});
+
+// Issue #62: the exec-config wiring — a generation session (interactive task
+// with a sessionSkill) receives the App token as GH_TOKEN; every autonomous kind
+// receives none. This mirrors execClaudeTurn's `isGenerationSession(task) ? token
+// : null`, testing the predicate and the env builder as one path. The negative
+// assertions for implement/review/triage are the isolation boundary from #62.
+describe("GH_TOKEN injection is gated on generation sessions (issue #62)", () => {
+  const APP_TOKEN = "ghs_installation";
+
+  const envFor = (task: { kind: string; sessionSkill: SessionSkill | null }) =>
+    buildTurnEnv({
+      prompt: "p",
+      gitAuthToken: APP_TOKEN,
+      claudeCodeOauthToken: null,
+      ghToken: isGenerationSession(task) ? APP_TOKEN : null,
+    });
+
+  it("injects GH_TOKEN for a generation-session exec", () => {
+    for (const sessionSkill of SESSION_SKILLS) {
+      const env = envFor({ kind: "interactive", sessionSkill });
+      expect(env).toContain(`GH_TOKEN=${APP_TOKEN}`);
+    }
+  });
+
+  it("withholds GH_TOKEN from implement, review, and triage execs", () => {
+    for (const kind of ["implement", "review", "triage"] as const) {
+      const env = envFor({ kind, sessionSkill: null });
+      expect(env.some((e) => e.startsWith("GH_TOKEN"))).toBe(false);
+    }
+  });
+
+  it("withholds GH_TOKEN from an ordinary chat task (no session skill)", () => {
+    const env = envFor({ kind: "interactive", sessionSkill: null });
+    expect(env.some((e) => e.startsWith("GH_TOKEN"))).toBe(false);
   });
 });
 

--- a/src/lib/docker/__tests__/container-manager.test.ts
+++ b/src/lib/docker/__tests__/container-manager.test.ts
@@ -256,8 +256,11 @@ describe("GH_TOKEN injection is gated on generation sessions (issue #62)", () =>
     }
   });
 
-  it("withholds GH_TOKEN from implement, review, and triage execs", () => {
-    for (const kind of ["implement", "review", "triage"] as const) {
+  it("withholds GH_TOKEN from every autonomous kind", () => {
+    // The isolation boundary is per-kind: no unattended exec may hold an
+    // issue-writing token, so `repair` is asserted alongside implement/review/
+    // triage even though #62 names only the latter three.
+    for (const kind of ["implement", "review", "triage", "repair"] as const) {
       const env = envFor({ kind, sessionSkill: null });
       expect(env.some((e) => e.startsWith("GH_TOKEN"))).toBe(false);
     }

--- a/src/lib/docker/container-manager.ts
+++ b/src/lib/docker/container-manager.ts
@@ -133,11 +133,20 @@ export function buildSetupScript(
  * CLAUDE_CODE_OAUTH_TOKEN is the sole subscription-auth path — the mounted
  * host credentials file it once fell back to was removed with the host
  * `~/.claude` mount (#28); ANTHROPIC_API_KEY remains an alternative.
+ *
+ * `ghToken` is exposed to `gh` as GH_TOKEN for generation-session execs only
+ * (issue #62): it is the same short-lived App installation token as
+ * GIT_AUTH_TOKEN, so there is one minting path to audit, not two, and like
+ * GIT_AUTH_TOKEN it is exec-scoped and never persisted in the container. It is
+ * `null` for every autonomous kind (implement/review/triage) — a token that can
+ * create issues can also apply the launch-button label, so no unattended kind
+ * may ever hold it; the caller decides via TurnOptions.isGenerationSession.
  */
 export function buildTurnEnv(options: {
   prompt: string;
   gitAuthToken: string;
   claudeCodeOauthToken: string | null;
+  ghToken: string | null;
 }): string[] {
   const env = [
     `CLAUDE_PROMPT=${options.prompt}`,
@@ -145,6 +154,9 @@ export function buildTurnEnv(options: {
   ];
   if (options.claudeCodeOauthToken) {
     env.push(`CLAUDE_CODE_OAUTH_TOKEN=${options.claudeCodeOauthToken}`);
+  }
+  if (options.ghToken) {
+    env.push(`GH_TOKEN=${options.ghToken}`);
   }
   return env;
 }
@@ -186,6 +198,15 @@ export interface TurnOptions {
    * own default.
    */
   effort?: string | null;
+  /**
+   * True only for a generation-session exec — an interactive task carrying a
+   * sessionSkill (issue #62). When set, the exec receives the App installation
+   * token as GH_TOKEN so the generation skills can read and write issues via
+   * `gh`. Never set for an autonomous implement/review/triage pass: a token
+   * that can create issues can also apply the launch-button label, so no
+   * unattended kind may hold it.
+   */
+  isGenerationSession?: boolean;
 }
 
 export interface RunningContainer {
@@ -397,6 +418,9 @@ export async function execClaudeTurn(
       prompt: options.prompt,
       gitAuthToken: token,
       claudeCodeOauthToken: config.claudeCodeOauthToken,
+      // Only a generation session's exec gets an issue-writing token (#62); the
+      // same App token as GIT_AUTH_TOKEN, so one minting path, exec-scoped.
+      ghToken: options.isGenerationSession ? token : null,
     }),
     AttachStdout: true,
     AttachStderr: true,

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -66,3 +66,32 @@ export async function getOctokit(): Promise<Octokit> {
   const token = await getInstallationToken();
   return new Octokit({ auth: token });
 }
+
+/**
+ * The repository permissions the App installation was granted, as an
+ * `{ issues: "write", contents: "write", ... }` map (issue #62). Read via the
+ * App JWT off the installation itself, so it reflects exactly what was granted
+ * at install time and is independent of any one repo. Preflight uses it to
+ * confirm generation sessions have the "Issues: write" they need — every
+ * generation operation (issue creation, comments, labels, dependency edges,
+ * sub-issues) lives under that one permission.
+ */
+export async function getInstallationPermissions(): Promise<
+  Record<string, string>
+> {
+  const config = getConfig();
+  if (
+    !config.githubAppId ||
+    !config.githubAppPrivateKey ||
+    !config.githubAppInstallationId
+  ) {
+    throw new Error(
+      "GitHub App required to read installation permissions (set GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY / GITHUB_APP_INSTALLATION_ID)"
+    );
+  }
+  const appOctokit = new Octokit({ auth: createAppJwt() });
+  const { data } = await appOctokit.rest.apps.getInstallation({
+    installation_id: parseInt(config.githubAppInstallationId, 10),
+  });
+  return (data.permissions ?? {}) as Record<string, string>;
+}

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -4,6 +4,11 @@ import { getConfig } from "../config";
 
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;
+// The installation's granted repository permissions, captured from the same
+// mint as the token (issue #62) — an unnarrowed installation token carries the
+// installation's full grant, so there is nothing extra to fetch. Set alongside
+// cachedToken and read via getInstallationPermissions.
+let cachedPermissions: Record<string, string> = {};
 
 function createAppJwt(): string {
   const config = getConfig();
@@ -58,6 +63,7 @@ export async function getInstallationToken(): Promise<string> {
 
   cachedToken = installation.token;
   tokenExpiresAt = new Date(installation.expires_at).getTime();
+  cachedPermissions = (installation.permissions ?? {}) as Record<string, string>;
 
   return cachedToken;
 }
@@ -69,29 +75,17 @@ export async function getOctokit(): Promise<Octokit> {
 
 /**
  * The repository permissions the App installation was granted, as an
- * `{ issues: "write", contents: "write", ... }` map (issue #62). Read via the
- * App JWT off the installation itself, so it reflects exactly what was granted
- * at install time and is independent of any one repo. Preflight uses it to
- * confirm generation sessions have the "Issues: write" they need — every
- * generation operation (issue creation, comments, labels, dependency edges,
- * sub-issues) lives under that one permission.
+ * `{ issues: "write", contents: "write", ... }` map (issue #62). Reuses the
+ * cached mint from getInstallationToken — the installation token carries the
+ * installation's full grant, so there is one round-trip and one minting path to
+ * audit, not a second `apps.getInstallation` call per project. Preflight uses it
+ * to confirm the App has the "Issues: write" every generation operation needs
+ * (issue creation, comments, labels, dependency edges, sub-issues all live under
+ * that one permission).
  */
 export async function getInstallationPermissions(): Promise<
   Record<string, string>
 > {
-  const config = getConfig();
-  if (
-    !config.githubAppId ||
-    !config.githubAppPrivateKey ||
-    !config.githubAppInstallationId
-  ) {
-    throw new Error(
-      "GitHub App required to read installation permissions (set GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY / GITHUB_APP_INSTALLATION_ID)"
-    );
-  }
-  const appOctokit = new Octokit({ auth: createAppJwt() });
-  const { data } = await appOctokit.rest.apps.getInstallation({
-    installation_id: parseInt(config.githubAppInstallationId, 10),
-  });
-  return (data.permissions ?? {}) as Record<string, string>;
+  await getInstallationToken();
+  return cachedPermissions;
 }

--- a/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
@@ -106,7 +106,7 @@ describe("evaluatePreflight", () => {
     const result = evaluatePreflight({ ...ALL_PASS, issuesWritable: false });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe(
-      'the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)'
+      'the GitHub App lacks the "Issues: write" permission needed for issue creation, comments, labels, dependency edges, and sub-issues'
     );
   });
 
@@ -122,7 +122,7 @@ describe("evaluatePreflight", () => {
     });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe(
-      `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing; the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)`
+      `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing; the GitHub App lacks the "Issues: write" permission needed for issue creation, comments, labels, dependency edges, and sub-issues`
     );
   });
 

--- a/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/preflight.test.ts
@@ -16,6 +16,7 @@ const ALL_PASS: PreflightChecks = {
   branchProtection: "protected",
   reviewerIsCollaborator: true,
   signoffLabelExists: true,
+  issuesWritable: true,
 };
 
 describe("evaluatePreflight", () => {
@@ -33,6 +34,7 @@ describe("evaluatePreflight", () => {
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
+      issuesWritable: false,
     });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe("no GitHub repo configured (needs gitUrl and githubRepo)");
@@ -97,6 +99,17 @@ describe("evaluatePreflight", () => {
     expect(result.reason).toBe(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
   });
 
+  it("names a missing Issues:write permission for generation sessions", () => {
+    // The one grant every generation skill needs — issue creation, comments,
+    // labels, dependency edges, and sub-issues all live under Issues:write, so a
+    // single failure names them all (issue #62).
+    const result = evaluatePreflight({ ...ALL_PASS, issuesWritable: false });
+    expect(result.status).toBe("failing");
+    expect(result.reason).toBe(
+      'the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)'
+    );
+  });
+
   it("accumulates every independent failure into one reason", () => {
     const result = evaluatePreflight({
       repoConfigured: true,
@@ -105,10 +118,11 @@ describe("evaluatePreflight", () => {
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
+      issuesWritable: false,
     });
     expect(result.status).toBe("failing");
     expect(result.reason).toBe(
-      `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing`
+      `no branch protection on the default branch; the reviewer account is not a collaborator; the "${HUMAN_SIGNOFF_LABEL}" label is missing; the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)`
     );
   });
 

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -24,7 +24,7 @@ import { projects } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { Octokit } from "octokit";
 import { getConfig } from "../../config";
-import { getOctokit, isGitHubConfigured } from "../../github/client";
+import { getInstallationPermissions, getOctokit, isGitHubConfigured } from "../../github/client";
 import { HUMAN_SIGNOFF_LABEL } from "./gates";
 
 /**
@@ -60,6 +60,13 @@ export interface PreflightChecks {
   reviewerIsCollaborator: boolean;
   /** The `human-signoff` label exists so gated PRs can be labelled */
   signoffLabelExists: boolean;
+  /**
+   * The App installation grants "Issues: write" (issue #62). It is the one
+   * permission every generation skill relies on — issue creation, comments,
+   * labels, native dependency edges, and sub-issue creation all require it — so
+   * a single check covers everything a generation session does via `gh`.
+   */
+  issuesWritable: boolean;
 }
 
 export interface PreflightResult {
@@ -107,6 +114,10 @@ export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
   }
   if (!checks.reviewerIsCollaborator) missing.push("the reviewer account is not a collaborator");
   if (!checks.signoffLabelExists) missing.push(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
+  if (!checks.issuesWritable)
+    missing.push(
+      'the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)'
+    );
 
   return missing.length === 0
     ? { status: "passing", reason: null }
@@ -201,6 +212,23 @@ async function isReviewerCollaborator(
 }
 
 /**
+ * Does the App installation grant "Issues: write"? Read off the installation's
+ * declared permissions (issue #62) rather than probed by mutating an issue —
+ * the declared grant is the deterministic, side-effect-free source of truth.
+ * Any failure to read it fails closed as `false`, so an under-permissioned or
+ * unreachable App never reads as ready for a generation session.
+ */
+async function hasIssuesWrite(): Promise<boolean> {
+  try {
+    const permissions = await getInstallationPermissions();
+    return permissions.issues === "write";
+  } catch (err) {
+    console.error("[preflight] Could not read App installation permissions:", err);
+    return false;
+  }
+}
+
+/**
  * Gather the autonomy checks for a project via the GitHub API. Every network
  * failure resolves to the fail-closed value so an unreachable or
  * under-permissioned repo never reads as ready. Downstream checks are only
@@ -218,6 +246,7 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
+      issuesWritable: false,
     });
   }
 
@@ -256,16 +285,19 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
       branchProtection: "unprotected",
       reviewerIsCollaborator: false,
       signoffLabelExists: false,
+      issuesWritable: false,
     });
   }
 
-  const [branchProtection, reviewerIsCollaborator, signoffLabelExists] = await Promise.all([
-    probeBranchProtection(octokit, owner, repo, defaultBranch),
-    isReviewerCollaborator(octokit, owner, repo),
-    apiCheck(`getLabel ${repoLabel}`, () =>
-      octokit.rest.issues.getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
-    ),
-  ]);
+  const [branchProtection, reviewerIsCollaborator, signoffLabelExists, issuesWritable] =
+    await Promise.all([
+      probeBranchProtection(octokit, owner, repo, defaultBranch),
+      isReviewerCollaborator(octokit, owner, repo),
+      apiCheck(`getLabel ${repoLabel}`, () =>
+        octokit.rest.issues.getLabel({ owner, repo, name: HUMAN_SIGNOFF_LABEL })
+      ),
+      hasIssuesWrite(),
+    ]);
 
   return evaluatePreflight({
     repoConfigured: true,
@@ -274,6 +306,7 @@ export async function computePreflight(project: ProjectRow): Promise<PreflightRe
     branchProtection,
     reviewerIsCollaborator,
     signoffLabelExists,
+    issuesWritable,
   });
 }
 

--- a/src/lib/orchestrator/autonomy/preflight.ts
+++ b/src/lib/orchestrator/autonomy/preflight.ts
@@ -62,9 +62,11 @@ export interface PreflightChecks {
   signoffLabelExists: boolean;
   /**
    * The App installation grants "Issues: write" (issue #62). It is the one
-   * permission every generation skill relies on — issue creation, comments,
-   * labels, native dependency edges, and sub-issue creation all require it — so
-   * a single check covers everything a generation session does via `gh`.
+   * permission a generation session's every operation relies on — issue
+   * creation, comments, labels, native dependency edges, and sub-issue creation
+   * all require it, so a single check covers everything a session does via `gh`.
+   * The autonomous loop needs it too (its own issue comments and label moves),
+   * which is why the check belongs in this shared preflight.
    */
   issuesWritable: boolean;
 }
@@ -116,7 +118,7 @@ export function evaluatePreflight(checks: PreflightChecks): PreflightResult {
   if (!checks.signoffLabelExists) missing.push(`the "${HUMAN_SIGNOFF_LABEL}" label is missing`);
   if (!checks.issuesWritable)
     missing.push(
-      'the GitHub App lacks the "Issues: write" permission generation sessions need (issue creation, comments, labels, dependency edges, sub-issues)'
+      'the GitHub App lacks the "Issues: write" permission needed for issue creation, comments, labels, dependency edges, and sub-issues'
     );
 
   return missing.length === 0

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -1,5 +1,5 @@
 import { db } from "@/db";
-import { tasks, messages, projects, runs } from "@/db/schema";
+import { tasks, messages, projects, runs, isGenerationSession } from "@/db/schema";
 import { eq, and, isNull, asc, desc } from "drizzle-orm";
 import { newId } from "../ulid";
 import {
@@ -321,6 +321,8 @@ export async function startTask(taskId: string): Promise<void> {
       captureRaw: isReviewPass || isTriagePass,
       model: passModel,
       effort: passEffort,
+      // A generation session's exec gets a `gh` token; no autonomous pass does (#62).
+      isGenerationSession: isGenerationSession(task),
     });
 
     // A terminal `result` event arrived — the turn ran to completion, so any
@@ -503,6 +505,7 @@ async function runTurn(
     captureRaw?: boolean;
     model?: string | null;
     effort?: string | null;
+    isGenerationSession?: boolean;
   }
 ): Promise<TurnResult & { raw?: string }> {
   const handler = createOutputHandler(taskId);
@@ -516,6 +519,7 @@ async function runTurn(
     maxTurns: opts?.maxTurns,
     model: opts?.model,
     effort: opts?.effort,
+    isGenerationSession: opts?.isGenerationSession,
   });
 
   // Race: wait for the exec stream to close OR the "result" event from Claude.
@@ -647,6 +651,8 @@ export async function processQueuedMessages(
         maxTurns: run?.maxTurns ?? undefined,
         model: resolveAgentModel(task.kind, config, run?.model ?? null),
         effort: resolveAgentEffort(task.kind, config, run?.effort ?? null),
+        // A generation session's follow-up exec gets a `gh` token too (#62).
+        isGenerationSession: isGenerationSession(task),
       }
     );
 


### PR DESCRIPTION
Closes #62

Decomposed from #50 (Mobile generation sessions). Blocked-by #61 (merged), which
made a generation session a first-class class: an interactive task carrying a
non-null `sessionSkill`.

## What this does

**Per-exec `GH_TOKEN`, generation sessions only.** A generation session's Claude
turn now receives the same short-lived GitHub App installation token as `GH_TOKEN`
that `GIT_AUTH_TOKEN` already carries — so `gh issue view` / `gh issue create` and
the rest of the generation skills work inside the container. It is minted through
the one existing App path (`getInstallationToken`), exposed to the exec env only,
and never written to git config or anything durable — exactly mirroring the git
credential.

The isolation boundary is the security decision: injection is gated on
`isGenerationSession(task)` (the single definition of the concept, added to the
schema). Autonomous `implement` / `review` / `triage` / `repair` execs — and
ordinary chat tasks — receive no `GH_TOKEN` at all. A token that can create issues
can also apply the launch-button label, so no unattended kind may hold it.

**Preflight covers the permission generation needs.** The preflight now verifies
the App installation grants **Issues: write**. Every generation operation the
ticket lists — issue creation, comments, labels, native dependency edges, and
sub-issue creation — lives under that one permission (confirmed against GitHub's
fine-grained-permission docs), so a single check covers all four and its failure
names them in the stated reason. It is read from the installation's declared grant
(captured from the token mint), not probed by mutating an issue — deterministic and
side-effect-free — and fails closed like every other check.

## Acceptance criteria

- [x] Inside a generation-session container, `gh issue view` / `gh issue create`
  succeed against the project repo — the turn exec now carries `GH_TOKEN`.
- [x] Exec-config tests assert injection for every session skill and its **absence**
  for each autonomous kind (implement/review/triage/repair) and for a plain chat
  task, in the style of the existing no-token assertions.
- [x] No token value persists durably — `GH_TOKEN` is exec-scoped env, never
  written to disk/git config (same lifetime as `GIT_AUTH_TOKEN`).
- [x] Preflight covers issues, labels, dependency edges, and sub-issues, with a
  stated reason on failure.

## Self-review (`/code-review` vs `origin/main`, spec #62)

Acted on all four findings:
- Reused the cached token mint for the permission read (no second
  `apps.getInstallation` per project; removes a duplicated App-config guard).
- Made the token-absence test exhaustive over autonomous kinds (added `repair`).
- Reworded the preflight reason to be capability-framed rather than
  consumer-framed.

**One finding I deliberately scoped out:** the reviewer noted the Issues:write
check lives in the *autonomy* preflight, which only runs for autonomy-enabled
projects and does not itself gate generation-session *launch*. Extending the
existing preflight is what the ticket asks ("Preflight check covers…"); gating an
attended session's launch on autonomy infrastructure is a separate design decision
and out of scope here. A missing permission surfaces to the driver live as a `gh`
error, and Issues:write is a genuine prerequisite for the autonomous loop's own
issue/label operations too — so the check belongs in the shared preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
