### PR TITLE
Seed composition + follow-on slash routing

### DIFF
--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -37,6 +37,7 @@ import { parseRepoFromGitUrl } from "../github/repo";
 import { createDraftPr, markPrReady } from "../github/pull-requests";
 import { notifyTaskQueued, notifyTaskCompleted, notifyTaskFailed, notifyTaskIdle, notifyRunBlocked } from "../discord/notifications";
 import { decideNext, passOutcomeSnapshot } from "./autonomy/decide";
+import { composeSeed, composeSessionTurn } from "../sessions/seed";
 
 /** Track all active task containers for cancellation and idle polling */
 const activeTasks = new Map<
@@ -163,9 +164,20 @@ export async function startTask(taskId: string): Promise<void> {
   const userPrompt = task.description
     ? `${task.title}\n\n${task.description}`
     : task.title;
-  const prompt = isAutonomousPass
-    ? task.description
-    : `${userPrompt}\n\nWhen you are done with each request, commit all your changes with a descriptive commit message. Stay ready for follow-up instructions.`;
+  // A generation session's first turn is the composed seed (issue #63): the
+  // deterministic slash-passthrough prompt for its session skill, with the
+  // user's title/description as the skill's agenda and any issue anchor passed
+  // as a reference the agent fetches itself. Sessions are always interactive
+  // (no run row), so this never collides with the autonomous-pass branch.
+  const prompt = task.sessionSkill
+    ? composeSeed({
+        sessionSkill: task.sessionSkill,
+        sessionIssue: task.sessionIssue,
+        agenda: userPrompt,
+      })
+    : isAutonomousPass
+      ? task.description
+      : `${userPrompt}\n\nWhen you are done with each request, commit all your changes with a descriptive commit message. Stay ready for follow-up instructions.`;
 
   const run = task.runId
     ? db.select().from(runs).where(eq(runs.id, task.runId)).get()
@@ -632,6 +644,16 @@ export async function processQueuedMessages(
       if (parsed.text) promptText = parsed.text;
     } catch {
       // Plain text content — use as-is
+    }
+
+    // Follow-on slash routing (issue #63): in a generation session, a follow-up
+    // message that leads with a known skill slash (the /to-spec → /to-tickets →
+    // arm progression) is re-framed through the same seed-composition path, so
+    // a typed slash carries the same framing (arming convention included) as the
+    // seed turn and never degrades into the agent improvising the skill. A
+    // non-slash message, or any message on a plain chat task, is untouched.
+    if (task.sessionSkill) {
+      promptText = composeSessionTurn(promptText);
     }
 
     // A follow-up turn on a run-owned task is capped at what remains of the

--- a/src/lib/sessions/__tests__/seed.test.ts
+++ b/src/lib/sessions/__tests__/seed.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeSeed,
+  composeSessionTurn,
+  ISSUE_ANCHOR_HINT,
+  ARMING_CONVENTION,
+  PUBLISHING_SESSION_SKILLS,
+} from "../seed";
+import { SESSION_SKILLS } from "@/db/schema";
+
+describe("composeSeed — slash passthrough (spike #59)", () => {
+  it("emits the bare skill slash for a freeform session with no agenda", () => {
+    // Per the #59 spike: the first-turn prompt is the bare slash-command
+    // string so the CLI expands the user-invocable skill — no SKILL.md inlining.
+    expect(composeSeed({ sessionSkill: "wayfinder" })).toBe("/wayfinder");
+  });
+
+  it("rides the agenda as the skill's argument text on the slash line", () => {
+    expect(
+      composeSeed({ sessionSkill: "to-spec", agenda: "focus on the auth flow" })
+    ).toBe("/to-spec focus on the auth flow");
+  });
+
+  it("treats a blank/whitespace agenda as no agenda", () => {
+    expect(composeSeed({ sessionSkill: "to-spec", agenda: "   " })).toBe("/to-spec");
+  });
+});
+
+describe("composeSeed — issue anchor (reference, not body)", () => {
+  it("appends a gh-fetch instruction naming the anchored issue", () => {
+    const seed = composeSeed({
+      sessionSkill: "triage",
+      sessionIssue: "lennons301/interlude#42",
+    });
+    expect(seed).toBe(`/triage\n\n${ISSUE_ANCHOR_HINT("lennons301/interlude#42")}`);
+  });
+
+  it("omits the anchor block for a freeform session", () => {
+    const seed = composeSeed({ sessionSkill: "triage" });
+    expect(seed).toBe("/triage");
+    expect(seed).not.toContain("gh");
+  });
+
+  it("passes only the reference, never a fetched body, and tells the agent to fetch", () => {
+    const hint = ISSUE_ANCHOR_HINT("owner/repo#7");
+    expect(hint).toContain("owner/repo#7");
+    expect(hint).toContain("gh");
+    expect(hint.toLowerCase()).toContain("fetch");
+  });
+});
+
+describe("composeSeed — arming convention (publishing skills)", () => {
+  it("names grill and to-tickets as the publishing skills", () => {
+    // The ticket pins the arming convention to grill/to-tickets sessions: the
+    // grilling family and the ticket-publishing skill share one pipeline that
+    // ends in armed issues.
+    expect([...PUBLISHING_SESSION_SKILLS].sort()).toEqual(
+      ["grill-me", "grill-with-docs", "to-tickets"].sort()
+    );
+  });
+
+  it("appends the arm-on-confirmation + audit-comment convention for a publishing skill", () => {
+    const seed = composeSeed({ sessionSkill: "to-tickets" });
+    expect(seed).toBe(`/to-tickets\n\n${ARMING_CONVENTION}`);
+  });
+
+  it("carries the three arming rules verbatim", () => {
+    expect(ARMING_CONVENTION).toContain("unlabelled");
+    expect(ARMING_CONVENTION).toContain("only after I confirm");
+    expect(ARMING_CONVENTION).toContain("audit comment");
+    expect(ARMING_CONVENTION).toContain("ready-for-agent");
+  });
+
+  it("omits the arming convention for a non-publishing skill", () => {
+    expect(composeSeed({ sessionSkill: "to-spec" })).not.toContain("Arming convention");
+    expect(composeSeed({ sessionSkill: "triage" })).not.toContain("Arming convention");
+    expect(composeSeed({ sessionSkill: "wayfinder" })).not.toContain("Arming convention");
+  });
+
+  it("orders the parts head → anchor → arming for a publishing, anchored session", () => {
+    const seed = composeSeed({
+      sessionSkill: "grill-me",
+      sessionIssue: "owner/repo#9",
+      agenda: "the new billing model",
+    });
+    expect(seed).toBe(
+      [
+        "/grill-me the new billing model",
+        ISSUE_ANCHOR_HINT("owner/repo#9"),
+        ARMING_CONVENTION,
+      ].join("\n\n")
+    );
+  });
+});
+
+describe("seed building blocks — exact literal content (spec #50/#63)", () => {
+  it("pins the arming convention verbatim", () => {
+    expect(ARMING_CONVENTION).toBe(
+      [
+        "Arming convention for this session:",
+        "- Publish any tickets unlabelled — never apply `ready-for-agent` at creation.",
+        "- Apply `ready-for-agent` only after I confirm the batch in this chat.",
+        "- On each issue you arm, post an audit comment recording this Interlude session and the confirmation route (owner-confirmed in chat).",
+      ].join("\n")
+    );
+  });
+
+  it("pins the issue-anchor hint verbatim", () => {
+    expect(ISSUE_ANCHOR_HINT("owner/repo#1")).toBe(
+      "This session is anchored to GitHub issue owner/repo#1. Fetch it yourself " +
+        "with the `gh` CLI before you begin — you have a GitHub App token in this " +
+        "container, and the orchestrator passed only this reference, not the issue body."
+    );
+  });
+});
+
+describe("composeSeed — fixture matrix: skill × anchored/freeform × agenda/none", () => {
+  // The arming convention is pinned to grill/to-tickets by the ticket — this
+  // list is transcribed from the spec, independent of the implementation, so a
+  // drift in either direction fails the matrix.
+  const PUBLISHING = ["grill-me", "grill-with-docs", "to-tickets"];
+  const REF = "lennons301/interlude#42";
+  const AGENDA = "the new billing model";
+
+  function expected(skill: string, anchored: boolean, withAgenda: boolean): string {
+    const parts = [withAgenda ? `/${skill} ${AGENDA}` : `/${skill}`];
+    if (anchored) parts.push(ISSUE_ANCHOR_HINT(REF));
+    if (PUBLISHING.includes(skill)) parts.push(ARMING_CONVENTION);
+    return parts.join("\n\n");
+  }
+
+  for (const skill of SESSION_SKILLS) {
+    for (const anchored of [false, true]) {
+      for (const withAgenda of [false, true]) {
+        const label = `${skill} · ${anchored ? "anchored" : "freeform"} · ${
+          withAgenda ? "agenda" : "none"
+        }`;
+        it(label, () => {
+          const seed = composeSeed({
+            sessionSkill: skill,
+            sessionIssue: anchored ? REF : null,
+            agenda: withAgenda ? AGENDA : null,
+          });
+          expect(seed).toBe(expected(skill, anchored, withAgenda));
+          // Invariants the exact string also guarantees, stated for intent:
+          expect(seed.startsWith(`/${skill}`)).toBe(true); // slash-first → CLI expands it
+          expect(seed.includes("gh")).toBe(anchored); // anchor block iff anchored
+          expect(seed.includes("Arming convention")).toBe(PUBLISHING.includes(skill));
+        });
+      }
+    }
+  }
+});
+
+describe("composeSessionTurn — follow-on slash routing (#63)", () => {
+  it("routes a typed skill slash through the same composition as the seed", () => {
+    // A mid-session /to-tickets must invoke the skill exactly as a to-tickets
+    // seed would — arming convention included — never improvised from memory.
+    expect(composeSessionTurn("/to-tickets")).toBe(
+      composeSeed({ sessionSkill: "to-tickets" })
+    );
+  });
+
+  it("carries the follow-up's trailing text through as the skill's agenda", () => {
+    expect(composeSessionTurn("/to-spec the decisions we just settled")).toBe(
+      composeSeed({ sessionSkill: "to-spec", agenda: "the decisions we just settled" })
+    );
+  });
+
+  it("passes an ordinary (non-slash) follow-up message through unchanged", () => {
+    const msg = "Yes, arm all four — they look right.";
+    expect(composeSessionTurn(msg)).toBe(msg);
+  });
+
+  it("passes an unknown slash command through unchanged (not a session skill)", () => {
+    expect(composeSessionTurn("/tdd write the test first")).toBe(
+      "/tdd write the test first"
+    );
+    expect(composeSessionTurn("/clear")).toBe("/clear");
+  });
+
+  it("recognises every session skill as a routable follow-on slash", () => {
+    for (const skill of SESSION_SKILLS) {
+      expect(composeSessionTurn(`/${skill}`)).toBe(composeSeed({ sessionSkill: skill }));
+    }
+  });
+});

--- a/src/lib/sessions/seed.ts
+++ b/src/lib/sessions/seed.ts
@@ -1,0 +1,94 @@
+import { SESSION_SKILLS, type SessionSkill } from "@/db/schema";
+
+export interface SeedInput {
+  sessionSkill: SessionSkill;
+  sessionIssue?: string | null;
+  agenda?: string | null;
+}
+
+/**
+ * Session skills whose pipeline publishes and arms tickets, so their seed
+ * carries the arming convention. The ticket (#63) pins this to grill/to-tickets:
+ * the grilling family and the ticket-publishing skill are the one conversation
+ * (grill → /to-spec → /to-tickets → arm) that ends in armed issues. `to-spec`
+ * publishes a spec but arms nothing; `triage` and `wayfinder` never publish
+ * tickets — so none of them carry the convention.
+ */
+export const PUBLISHING_SESSION_SKILLS = [
+  "grill-me",
+  "grill-with-docs",
+  "to-tickets",
+] as const satisfies readonly SessionSkill[];
+
+/**
+ * The arming convention the workflow contract sanctions for an
+ * interactive-session-armed ticket (#63, spec #50): publish unlabelled, arm
+ * only on the owner's in-chat confirmation, and leave an audit trail on each
+ * armed issue. Carried in the seed of every publishing session so the agent
+ * knows it before it reaches the publish/arm step.
+ */
+export const ARMING_CONVENTION = [
+  "Arming convention for this session:",
+  "- Publish any tickets unlabelled — never apply `ready-for-agent` at creation.",
+  "- Apply `ready-for-agent` only after I confirm the batch in this chat.",
+  "- On each issue you arm, post an audit comment recording this Interlude " +
+    "session and the confirmation route (owner-confirmed in chat).",
+].join("\n");
+
+function isPublishingSkill(skill: SessionSkill): boolean {
+  return (PUBLISHING_SESSION_SKILLS as readonly SessionSkill[]).includes(skill);
+}
+
+/**
+ * The anchor block appended when a session is anchored to an issue. The
+ * orchestrator passes only the reference (`owner/repo#n`), never the body — the
+ * agent fetches it itself with the per-exec GitHub App token, so upstream skills
+ * run unmodified against a real `gh`.
+ */
+export function ISSUE_ANCHOR_HINT(ref: string): string {
+  return (
+    `This session is anchored to GitHub issue ${ref}. Fetch it yourself with ` +
+    `the \`gh\` CLI before you begin — you have a GitHub App token in this ` +
+    `container, and the orchestrator passed only this reference, not the issue body.`
+  );
+}
+
+export function composeSeed({ sessionSkill, sessionIssue, agenda }: SeedInput): string {
+  const trimmedAgenda = agenda?.trim();
+  const head = trimmedAgenda
+    ? `/${sessionSkill} ${trimmedAgenda}`
+    : `/${sessionSkill}`;
+
+  const parts = [head];
+  const ref = sessionIssue?.trim();
+  if (ref) parts.push(ISSUE_ANCHOR_HINT(ref));
+  if (isPublishingSkill(sessionSkill)) parts.push(ARMING_CONVENTION);
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Route a generation-session follow-up turn. If the message leads with a known
+ * session-skill slash (the common `/to-spec` → `/to-tickets` → arm progression),
+ * re-frame it through {@link composeSeed} — the same path the seed turn takes —
+ * so a typed slash carries the same framing (notably the arming convention for
+ * publishing skills) and never silently degrades into the agent improvising the
+ * skill from memory. Any other message (plain prose, or a non-session slash the
+ * CLI handles itself) passes through unchanged.
+ *
+ * The #59 spike found the leading slash already expands natively at every turn
+ * position, so this adds framing rather than rescuing expansion. A follow-on
+ * turn has no separate issue anchor — the session's anchor was set at the seed.
+ */
+export function composeSessionTurn(rawText: string): string {
+  const match = /^\s*\/(\S+)([\s\S]*)$/.exec(rawText);
+  if (!match) return rawText;
+
+  const skill = match[1];
+  if (!(SESSION_SKILLS as readonly string[]).includes(skill)) return rawText;
+
+  return composeSeed({
+    sessionSkill: skill as SessionSkill,
+    agenda: match[2].trim() || null,
+  });
+}


### PR DESCRIPTION
Closes #63

## What this does

Adds the seed-composition seam for Mobile generation sessions (batch #50), plus follow-on slash routing.

- **`src/lib/sessions/seed.ts`** — one pure function `composeSeed({ sessionSkill, sessionIssue?, agenda? }) → first-turn prompt`. Per the **#59 spike** (slash passthrough at every turn position), it emits the **bare skill slash** so the CLI expands the user-invocable skill — **no SKILL.md inlining**. The optional agenda rides as the skill's argument text; an anchored session gets a `gh`-fetch hint carrying **only the reference, never the body**; publishing skills carry the arm-on-confirmation + audit-comment convention.
- **`composeSessionTurn(rawText)`** — a session follow-up that leads with a known skill slash is re-framed through the **same** `composeSeed` path, so a typed `/to-tickets` carries the same framing (arming convention included) as the seed turn and never degrades into the agent improvising the skill from memory. Any other message passes through unchanged.
- **Wiring** (`turn-manager.ts`) — a session's first turn is the composed seed (`startTask`); a slash-prefixed follow-up in a session is routed through `composeSessionTurn` (`processQueuedMessages`). Plain chat tasks and autonomous passes are untouched.

## Acceptance criteria

- [x] Fixture tests cover each session skill (incl. `wayfinder`) × anchored/freeform × agenda/none, asserting the **exact** composed prompt (24-combo matrix + building-block literal pins + slice tests; 42 tests, no Docker/GitHub/DB)
- [x] A created session's first turn is the composed seed (`startTask`)
- [x] A slash-prefixed follow-up invokes its skill by the same mechanism as the seed (`composeSessionTurn`), per the spike's passthrough finding
- [x] Seed content for publishing skills includes the arm-on-confirmation + audit-comment convention

## Design notes / decisions

- **Publishing skills = `grill-me`, `grill-with-docs`, `to-tickets`.** The ticket pins the arming convention to "grill/to-tickets sessions" — the grilling family and the ticket-publishing skill are the one conversation (grill → `/to-spec` → `/to-tickets` → arm) that ends in armed issues. `to-spec` publishes a spec but arms nothing; `triage`/`wayfinder` never publish tickets.
- **Slash + trailing text is the only single-turn shape** consistent with both (a) slash-first (required for CLI expansion) and (b) AC#4 (arming convention *in the seed*). This is exactly what #59 recommended ("bare slash, optionally followed by argument text; no inlining").

## Self-review (`/code-review` vs `origin/main`, spec #63)

Ran the review; all four findings sit at the integration boundary that #63's pre-agreed seam explicitly excludes ("the seed-composition pure function … no Docker, GitHub, or database"). None changed within scope:

1. **`gh` unauthenticated in the turn exec** — `Dockerfile.agent` already ships `gh` and its comment declares the per-exec App token is "exposed per exec exactly like git's", but `buildTurnEnv` doesn't yet set `GH_TOKEN`. That plumbing is a **sibling #50 ticket** (Docker surface, out of this seam). The seed's `gh`-fetch hint is correct **target-state** content.
2. **Empty-diff draft PR for no-repo-change sessions** (`/to-tickets`, `triage`) — pre-existing interactive-task PR machinery; this PR changes only the prompt string, not commit/push/PR. Session docs-PR handling is a #50 sibling concern.
3. **Anchor/arming folded into `$ARGUMENTS`** — inherent to the mandated single-turn passthrough (see Design notes). Mitigated: both blocks lead with imperative headers so they read as rules, and the follow-on router re-injects the arming convention when `/to-tickets` actually fires.
4. **`sessionIssue` not validated as `owner/repo#n`** — `route.ts` is #61's surface (untouched here); worth a small follow-up on the API/validation ticket.

## Testing

`vitest run` — 539 passed (42 new). Lint clean on changed files. (Two pre-existing `tsc` errors in `container-manager.test.ts` are unrelated and untouched.)
