### PR TITLE
Fleet dashboard: clear an exhausted needs-you card once the tracker shows a human dealt with it

### DIFF
--- a/src/lib/fleet/__tests__/digest.test.ts
+++ b/src/lib/fleet/__tests__/digest.test.ts
@@ -34,6 +34,7 @@ function baseRows(overrides: Partial<FleetRows> = {}): FleetRows {
     runs: [],
     tasks: [],
     backlogByProject: null,
+    needsHumanByProject: null,
     ...overrides,
   };
 }

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -21,6 +21,7 @@ function baseRows(overrides: Partial<FleetRows> = {}): FleetRows {
     runs: [],
     tasks: [],
     backlogByProject: null,
+    needsHumanByProject: null,
     ...overrides,
   };
 }
@@ -664,6 +665,71 @@ describe("buildFleetView — needs you", () => {
     );
 
     expect(view.needsYou).toEqual([]);
+  });
+
+  it("drops an exhausted ticket the tracker shows a human has dealt with", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            attempt: 3,
+            status: "exhausted",
+            finishedAt: TODAY_9AM, // still well inside the 7-day window
+          }),
+        ],
+        // p1 was observed and #34 is no longer open + ready-for-human: the
+        // human closed it or dropped the label, so it stops needing you even
+        // though no newer run exists and the window hasn't elapsed.
+        needsHumanByProject: { p1: [] },
+      })
+    );
+
+    expect(view.needsYou).toEqual([]);
+  });
+
+  it("keeps an exhausted ticket still open and ready-for-human on the tracker", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            attempt: 3,
+            status: "exhausted",
+            finishedAt: TODAY_9AM,
+          }),
+        ],
+        needsHumanByProject: { p1: ["lennons301/lemons#34"] },
+      })
+    );
+
+    expect(view.needsYou.map((i) => i.cause)).toEqual(["exhausted"]);
+  });
+
+  it("keeps an exhausted ticket when its project was never observed", () => {
+    const view = buildFleetView(
+      baseRows({
+        projects: [makeProject({ id: "p1" })],
+        runs: [
+          makeRun({
+            id: "r1",
+            projectId: "p1",
+            attempt: 3,
+            status: "exhausted",
+            finishedAt: TODAY_9AM,
+          }),
+        ],
+        // Another project was observed, but not p1 — absence here is "unknown",
+        // not "resolved", so the window remains the only release valve for p1.
+        needsHumanByProject: { "other-project": [] },
+      })
+    );
+
+    expect(view.needsYou.map((i) => i.cause)).toEqual(["exhausted"]);
   });
 
   it("raises a cap pause card when today's spend reaches the cap", () => {

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -27,6 +27,13 @@ export interface FleetRows {
   /** Tickets armed `ready-for-agent` and not yet claimed, keyed by project
    * id — the sweep's last tracker observation; null = never observed */
   backlogByProject: Record<string, number> | null;
+  /** Open `ready-for-human` issue refs, keyed by project id — the sweep's last
+   * tracker observation of tickets still awaiting a human. An exhausted run
+   * whose project was observed but whose issue is absent has been dealt with
+   * (closed, or the label dropped) and stops needing you. null = never
+   * observed; a project absent from the map = not yet observed (both fall back
+   * to the 7-day window). See {@link buildFleetView}'s exhausted filter. */
+  needsHumanByProject: Record<string, string[]> | null;
 }
 
 export interface FleetProjectRow {
@@ -459,14 +466,25 @@ export function buildFleetView(rows: FleetRows): FleetView {
     // surfaced under Running, deliberately not a needs-you item.
   }
 
-  // An exhausted ticket needs a human until either they re-arm it (a newer
-  // run exists for the issue) or it ages out of the recent window — the DB
-  // can't see the tracker, so the window is the release valve.
+  // An exhausted ticket needs a human until they re-arm it (a newer run
+  // exists for the issue), until the tracker shows they've dealt with it, or
+  // — the backstop — until it ages out of the recent window. The DB can't see
+  // the tracker on its own, so the sweep records which issues are still open
+  // and `ready-for-human` (needsHumanByProject); an exhausted run whose
+  // project was observed but whose issue has left that set was resolved
+  // outside a fresh loop (a human merged the fix or dropped the label) and no
+  // longer names an outstanding action. Only the window applies to a project
+  // the sweep hasn't observed — clearing on absence there would be guessing.
   const windowStart = rows.now.getTime() - RECENT_WINDOW_DAYS * DAY_MS;
+  const resolvedOnTracker = (r: FleetRunRow): boolean => {
+    const observed = rows.needsHumanByProject?.[r.projectId];
+    return observed !== undefined && !observed.includes(r.githubIssue);
+  };
   const exhausted = rows.runs.filter(
     (r) =>
       r.status === "exhausted" &&
       (r.finishedAt?.getTime() ?? 0) >= windowStart &&
+      !resolvedOnTracker(r) &&
       !rows.runs.some(
         (newer) =>
           newer.githubIssue === r.githubIssue &&

--- a/src/lib/fleet/needs-human.ts
+++ b/src/lib/fleet/needs-human.ts
@@ -1,0 +1,44 @@
+/**
+ * Last tracker observation of the open `ready-for-human` issues, per project.
+ * The autonomy sweep already lists a repo's issues every 30s — it records the
+ * refs still open and labelled `ready-for-human` here, and the read model
+ * (dashboard + digest) uses them to retire an exhausted needs-you card the
+ * moment a human has dealt with the ticket, rather than waiting out the 7-day
+ * recent window.
+ *
+ * At exhaustion the loop applies `ready-for-human` (issue #33's ledger); a
+ * human then closes the issue (a merged fix does this) or drops the label to
+ * re-route it. Either way the ref leaves this open+labelled set, which is the
+ * signal that the "attempts exhausted" card no longer names an outstanding
+ * action. The DB can't see the tracker on its own, so — exactly as with the
+ * backlog observation — the sweep is the only thing that ever writes here.
+ *
+ * Null until the first observation: "unknown" must stay distinguishable from a
+ * genuinely empty set, so an exhausted card is never cleared on a project the
+ * sweep hasn't actually looked at (the 7-day window remains the safe fallback).
+ *
+ * Backed by globalThis for the same reason as the backlog store and the bot
+ * client (see fleet/backlog.ts, discord/notifications.ts): route handlers may
+ * load a separate module instance from the orchestrator context that writes
+ * the observations.
+ */
+
+const globalForNeedsHuman = globalThis as unknown as {
+  __interludeNeedsHuman?: Map<string, string[]>;
+};
+
+/** Record one project's open `ready-for-human` issue refs from a sweep. A
+ * project whose listing failed simply isn't recorded — its last good
+ * observation stands, so a transient API error can't wrongly clear its
+ * exhausted cards. */
+export function recordNeedsHuman(projectId: string, issueRefs: string[]): void {
+  const store = (globalForNeedsHuman.__interludeNeedsHuman ??= new Map());
+  store.set(projectId, issueRefs);
+}
+
+/** Open `ready-for-human` issue refs keyed by project id, or null if the
+ * tracker was never observed. */
+export function getNeedsHumanByProject(): Record<string, string[]> | null {
+  const store = globalForNeedsHuman.__interludeNeedsHuman;
+  return store ? Object.fromEntries(store) : null;
+}

--- a/src/lib/fleet/rows.ts
+++ b/src/lib/fleet/rows.ts
@@ -10,6 +10,7 @@ import { and, eq, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { getConfig } from "../config";
 import { getCapacity } from "../orchestrator/capacity";
 import { getBacklogByProject } from "./backlog";
+import { getNeedsHumanByProject } from "./needs-human";
 import { DAILY_AUTONOMOUS_CAP_USD } from "../orchestrator/autonomy/budgets";
 import {
   buildFleetView,
@@ -114,6 +115,9 @@ export async function loadFleetRows(now: Date): Promise<FleetRows> {
     // The sweep's last tracker observation; null (never observed) renders
     // as "queue unknown" rather than a wrong zero.
     backlogByProject: getBacklogByProject(),
+    // Open `ready-for-human` refs from the same sweep; null (never observed)
+    // leaves the exhausted needs-you cards on the 7-day window alone.
+    needsHumanByProject: getNeedsHumanByProject(),
   };
 }
 

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -39,6 +39,7 @@ import {
 } from "../../discord/notifications";
 import { recordBacklog } from "../../fleet/backlog";
 import { isContainerRunning, removeContainerByName } from "../../docker/container-manager";
+import { recordNeedsHuman } from "../../fleet/needs-human";
 import { getCapacity } from "../capacity";
 import { occupiedSlots } from "../queue";
 import { startOfLocalDay, todayAutonomousSpendUsd } from "../spend";
@@ -353,6 +354,29 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     } catch (err) {
       // One repo's API failure must not stall the whole fleet's sweep
       console.error(`[autonomy] Failed to list candidates for ${repoFullName}:`, err);
+    }
+
+    // The open `ready-for-human` set — the read model retires an exhausted
+    // needs-you card once its issue leaves this set (a human closed it or
+    // dropped the label). Recorded only on success, so a transient API error
+    // can't wrongly clear a card; the 7-day window remains the safe backstop.
+    try {
+      const { data: waiting } = await octokit.rest.issues.listForRepo({
+        owner,
+        repo,
+        labels: READY_FOR_HUMAN_LABEL,
+        state: "open",
+        per_page: 100,
+      });
+      const refs = waiting
+        .filter((issue) => !issue.pull_request)
+        .map((issue) => `${repoFullName}#${issue.number}`);
+      recordNeedsHuman(project.id, refs);
+    } catch (err) {
+      console.error(
+        `[autonomy] Failed to list ready-for-human issues for ${repoFullName}:`,
+        err
+      );
     }
   }
 


### PR DESCRIPTION
## What happened

A stale card sat under **needs you** on the production dashboard: *"LPS #138 — attempts exhausted, ready-for-human."* The ticket had since been fixed and merged, but the card never cleared.

The recent ghost-removal PR (#66) didn't cover this — that fixed stale `container_status` resurrecting *running sessions*. This is a separate surface: a genuine **exhausted run** in the needs-you bucket.

## Root cause

In `buildFleetView`, an exhausted run cleared via only **two** release valves:

1. a **newer run** exists for the same issue (a re-arm), or
2. it **ages out of the 7-day** recent window.

`#138` was resolved *outside* a fresh interlude loop — a human merged the fix and closed the issue — so neither valve fired, and the card lingered up to 7 days still claiming attempts were exhausted. The code even called this out: *"the DB can't see the tracker, so the window is the release valve."*

## Fix — a third release valve, backed by a tracker observation

Mirrors the existing `backlogByProject` observation pattern exactly:

- **`src/lib/fleet/needs-human.ts`** (new) — a `globalThis`-backed store of the open `ready-for-human` issue refs the sweep last saw, per project. `null` = never observed.
- **`sweep.ts`** — per registered project, one extra `listForRepo({ labels: ready-for-human, state: "open" })`, recorded **on success only** so a transient API error keeps the last good observation and can never *wrongly* clear a card.
- **`fleet-view.ts`** — `buildFleetView` suppresses an exhausted run when its project **was** observed but its issue has left the open+`ready-for-human` set. A project the sweep hasn't observed still falls back to the 7-day window — absence is **unknown**, never **resolved**.
- **`rows.ts`** — threads `getNeedsHumanByProject()` into the read model (covers both the dashboard SSE stream and the daily digest, which share `buildFleetView`).

**Why `open + ready-for-human` is the right signal:** the loop *applies* that label at exhaustion to mean "a human owes this ticket an action." A human closing it (a merged `Closes #n` does exactly this) or dropping the label is them discharging that action.

## Effect on the stuck card

No manual DB edit needed. Once deployed, the next sweep (~30s) observes LPS's open `ready-for-human` issues; `#138` is closed/merged so it's absent from the set and the card **clears itself**.

## Validation

- 3 new `fleet-view` tests: clears when observed-and-gone; keeps when still open+labelled; keeps when the project was never observed (plus the existing `null`-observation case).
- `pnpm test` — **378 passed**.
- Lint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)