### PR TITLE
Reliability: a finalized run's owed review can never wedge pickup

### DIFF
--- a/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/decide.test.ts
@@ -781,6 +781,41 @@ describe("decideNext — pause reasons", () => {
     expect(pauses(decideNext(makeSnapshot()))).toEqual([]);
   });
 
+  it("does not park on 'no-slots' when the only queued review belongs to a finalized run (issue #124)", () => {
+    // The LPS #135 wedge: a gated PR was merged by hand, finalizing its run,
+    // but the run's review task sat `queued`. The snapshot builder now excludes
+    // that dead-run task from the reservation counts (queuedTasksReservingSlots
+    // — unit-tested in review-tasks.test.ts), so the count the reducer sees is
+    // 0. With a slot free and a ready ticket, the frontier claims it rather
+    // than parking on `no-slots` — the ~1.5h stall this fixes.
+    const actions = decideNext(
+      makeSnapshot({
+        slots: { total: 1, occupied: 0, occupants: [] },
+        queuedReviewCount: 0,
+        candidates: [makeCandidate()],
+      })
+    );
+
+    expect(actions.some((a) => a.type === "pausePickup" && a.reason === "no-slots")).toBe(false);
+    expect(claims(actions)).toHaveLength(1);
+  });
+
+  it("still reserves a slot for a live-run queued review (the count is not blanket-zeroed, issue #124)", () => {
+    // The mirror case: a review owed by a *live* reviewing/gated run legitimately
+    // reserves the free slot, so a new claim waits. Only dead-run tasks are
+    // dropped — a genuinely owed review is not.
+    const actions = decideNext(
+      makeSnapshot({
+        slots: { total: 1, occupied: 0, occupants: [] },
+        queuedReviewCount: 1,
+        candidates: [makeCandidate()],
+      })
+    );
+
+    expect(actions).toContainEqual({ type: "pausePickup", reason: "no-slots" });
+    expect(claims(actions)).toHaveLength(0);
+  });
+
   it("pauses with 'daily-cap' and announces it once when today's spend meets the cap", () => {
     const actions = decideNext(
       makeSnapshot({ todayAutonomousSpendUsd: 500, dailyCapUsd: 500 })

--- a/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import * as schema from "@/db/schema";
 import { createTestDb } from "@/test/create-test-db";
-import { inFlightReviewTaskId, reapDeadReviewTasks, type Db } from "../review-tasks";
+import {
+  cancelOrphanedRunTasks,
+  inFlightReviewTaskId,
+  queuedTasksReservingSlots,
+  reapDeadReviewTasks,
+  type Db,
+} from "../review-tasks";
 import { decideNext, passOutcomeSnapshot, type AutonomySnapshot } from "../decide";
 
 const ISSUE_REF = "owner/repo#141";
@@ -169,5 +175,139 @@ describe("review-pass in-flight + ungraceful-death reaping (issue #95)", () => {
       (a) => a.type === "startReview"
     );
     expect(startReviews).toEqual([]);
+  });
+});
+
+describe("cancelOrphanedRunTasks — no task outlives its run (issue #124)", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = createTestDb().db;
+    db.insert(schema.projects).values({ id: "p1", name: "Test", createdAt: new Date() }).run();
+  });
+
+  function seedRun(id: string, status: (typeof schema.runs.$inferInsert)["status"]): void {
+    db.insert(schema.runs)
+      .values({
+        id,
+        projectId: "p1",
+        githubIssue: ISSUE_REF,
+        attempt: 1,
+        mode: "autonomous",
+        status,
+        budgetUsd: 20,
+        pullRequestNumber: 144,
+        claimedAt: new Date(),
+      })
+      .run();
+  }
+
+  function seedTask(opts: {
+    id: string;
+    runId: string;
+    kind: (typeof schema.tasks.$inferInsert)["kind"];
+    status: (typeof schema.tasks.$inferInsert)["status"];
+    containerName?: string | null;
+  }): void {
+    db.insert(schema.tasks)
+      .values({
+        id: opts.id,
+        projectId: "p1",
+        title: opts.id,
+        kind: opts.kind,
+        runId: opts.runId,
+        status: opts.status,
+        containerName: opts.containerName ?? null,
+        containerStatus: opts.status === "running" ? "idle" : null,
+        githubIssue: ISSUE_REF,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .run();
+  }
+
+  const statusOf = (id: string) =>
+    db.select().from(schema.tasks).where(eq(schema.tasks.id, id)).get()!.status;
+
+  it("cancels a review task left queued when its run finalized to merged", () => {
+    seedRun("run-1", "merged");
+    // The parked implement pass was released to `completed` by its own path
+    // before this runs; only the never-started review is the orphan.
+    seedTask({ id: "task-impl", runId: "run-1", kind: "implement", status: "completed" });
+    seedTask({ id: "task-review", runId: "run-1", kind: "review", status: "queued" });
+
+    const cancelled = cancelOrphanedRunTasks(db, "run-1");
+
+    expect(cancelled).toEqual([{ taskId: "task-review", containerName: null }]);
+    expect(statusOf("task-review")).toBe("cancelled");
+    // A terminal task is left exactly as it was.
+    expect(statusOf("task-impl")).toBe("completed");
+  });
+
+  it("returns a still-running pass's container so the caller can remove it, and clears container_status", () => {
+    // A human merged the PR while the review pass was actually running.
+    seedRun("run-1", "merged");
+    seedTask({
+      id: "task-review",
+      runId: "run-1",
+      kind: "review",
+      status: "running",
+      containerName: "interlude-task-review",
+    });
+
+    const cancelled = cancelOrphanedRunTasks(db, "run-1");
+
+    expect(cancelled).toEqual([{ taskId: "task-review", containerName: "interlude-task-review" }]);
+    const row = db.select().from(schema.tasks).where(eq(schema.tasks.id, "task-review")).get()!;
+    expect(row.status).toBe("cancelled");
+    // Cleared alongside the terminal status so the row can never later read as
+    // a live session (cf. issue #46).
+    expect(row.containerStatus).toBeNull();
+  });
+
+  it("touches only the finalized run's tasks — a live run's owed review is untouched (self-heal preserved, AC #4)", () => {
+    seedRun("dead", "failed");
+    seedRun("live", "reviewing");
+    seedTask({ id: "dead-review", runId: "dead", kind: "review", status: "queued" });
+    seedTask({ id: "live-review", runId: "live", kind: "review", status: "queued" });
+
+    cancelOrphanedRunTasks(db, "dead");
+
+    expect(statusOf("dead-review")).toBe("cancelled");
+    expect(statusOf("live-review")).toBe("queued");
+    // The existing self-heal still sees the live run's owed review in flight.
+    expect(inFlightReviewTaskId(db, "live")).toBe("live-review");
+  });
+
+  it("is a no-op when the run owns no non-terminal task", () => {
+    seedRun("run-1", "exhausted");
+    seedTask({ id: "task-impl", runId: "run-1", kind: "implement", status: "failed" });
+
+    expect(cancelOrphanedRunTasks(db, "run-1")).toEqual([]);
+    expect(statusOf("task-impl")).toBe("failed");
+  });
+});
+
+describe("queuedTasksReservingSlots — dead-run tasks never reserve a slot (issue #124)", () => {
+  it("keeps live-run and run-less tasks, drops tasks under a terminal run", () => {
+    const liveRunIds = new Set(["r-live"]);
+    const queued = [
+      { kind: "review", runId: "r-dead" }, // orphan under a finalized run
+      { kind: "review", runId: "r-live" }, // a genuinely owed review
+      { kind: "implement", runId: "r-live" },
+      { kind: "interactive", runId: null }, // no run — always real intent
+      { kind: "triage", runId: null },
+    ];
+
+    expect(queuedTasksReservingSlots(queued, liveRunIds)).toEqual([
+      { kind: "review", runId: "r-live" },
+      { kind: "implement", runId: "r-live" },
+      { kind: "interactive", runId: null },
+      { kind: "triage", runId: null },
+    ]);
+  });
+
+  it("drops every task when no run is live (the wedge: one dead-run review must not count)", () => {
+    const queued = [{ kind: "review", runId: "r-dead" }];
+    expect(queuedTasksReservingSlots(queued, new Set())).toEqual([]);
   });
 });

--- a/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
@@ -278,12 +278,58 @@ describe("cancelOrphanedRunTasks — no task outlives its run (issue #124)", () 
     expect(inFlightReviewTaskId(db, "live")).toBe("live-review");
   });
 
+  it("cancels a blocked pass too — the invariant covers every non-terminal status", () => {
+    // A blocked pass holds a parked (stopped-but-preserved) container; if its
+    // run is finalized, the pass must not be left waiting on an answer forever.
+    seedRun("run-1", "cancelled");
+    seedTask({
+      id: "task-impl",
+      runId: "run-1",
+      kind: "implement",
+      status: "blocked",
+      containerName: "interlude-task-impl",
+    });
+
+    const cancelled = cancelOrphanedRunTasks(db, "run-1");
+
+    expect(cancelled).toEqual([{ taskId: "task-impl", containerName: "interlude-task-impl" }]);
+    expect(statusOf("task-impl")).toBe("cancelled");
+  });
+
   it("is a no-op when the run owns no non-terminal task", () => {
     seedRun("run-1", "exhausted");
     seedTask({ id: "task-impl", runId: "run-1", kind: "implement", status: "failed" });
 
     expect(cancelOrphanedRunTasks(db, "run-1")).toEqual([]);
     expect(statusOf("task-impl")).toBe("failed");
+  });
+
+  it("regression: a hand-merged gated PR neither strands its review nor lets it reserve a slot (issue #124)", () => {
+    // The LPS #135 shape at the DB seam the sweep drives: a gated run's PR was
+    // merged by hand while its review pass sat queued (the single slot busy),
+    // and a separate live run holds the slot with its own owed review.
+    seedRun("merged", "merged");
+    seedRun("live", "reviewing");
+    seedTask({ id: "orphan-review", runId: "merged", kind: "review", status: "queued" });
+    seedTask({ id: "live-review", runId: "live", kind: "review", status: "queued" });
+
+    // executeFinalizeRun's cleanup terminalizes the orphan and leaves the live
+    // run's owed review in flight (self-heal preserved).
+    cancelOrphanedRunTasks(db, "merged");
+    expect(statusOf("orphan-review")).toBe("cancelled");
+    expect(statusOf("live-review")).toBe("queued");
+
+    // gatherSnapshot's reservation accounting then counts only the live run's
+    // review, so the dead-run orphan can never force claimableSlots to 0 — the
+    // ~1.5h wedge this fixes.
+    const stillQueued = db
+      .select({ kind: schema.tasks.kind, runId: schema.tasks.runId })
+      .from(schema.tasks)
+      .where(eq(schema.tasks.status, "queued"))
+      .all();
+    expect(queuedTasksReservingSlots(stillQueued, new Set(["live"]))).toEqual([
+      { kind: "review", runId: "live" },
+    ]);
   });
 });
 

--- a/src/lib/orchestrator/autonomy/review-tasks.ts
+++ b/src/lib/orchestrator/autonomy/review-tasks.ts
@@ -65,12 +65,16 @@ export function inFlightReviewTaskId(db: Db, runId: string): string | null {
   return task?.id ?? null;
 }
 
-/** A review task the reaper terminalized — returned so the caller can drop its
- * in-memory session entry and remove the dead container. */
-export interface ReapedReviewTask {
+/** A task some path terminalized — returned so the caller can drop its
+ * in-memory session entry and remove any container it held. */
+export interface TerminalizedTask {
   taskId: string;
   containerName: string | null;
 }
+
+/** @deprecated alias kept for the reaper's existing name — see
+ * {@link TerminalizedTask}. */
+export type ReapedReviewTask = TerminalizedTask;
 
 /**
  * Mark review tasks stuck `running` whose container is gone as `failed`, the
@@ -146,21 +150,24 @@ export async function reapDeadReviewTasks(
  * restart-interrupted run's queued pass are handled (init.ts). A parked
  * implement/repair container is released to `completed` by its own path
  * *before* this runs, so this only sweeps up the genuinely-orphaned tasks;
- * anything already terminal is skipped by the status filter.
+ * anything already terminal is skipped by the status filter. `blocked` is
+ * swept too (not just `queued`/`running`) so the invariant is total — no task
+ * in any non-terminal status outlives its run.
  *
  * DB-only: returns the cancelled tasks with their container names so the
  * caller removes any container that was still live, exactly like
- * `reapDeadReviewTasks`. (A `queued` orphan has no container; only a `running`
- * one — a review pass a hand-merge raced — carries a name to clean up.)
+ * `reapDeadReviewTasks`. (A `queued` orphan has no container; a `running` one —
+ * a review pass a hand-merge raced — or a `blocked` one's parked container
+ * carries a name to clean up.)
  */
-export function cancelOrphanedRunTasks(db: Db, runId: string): ReapedReviewTask[] {
+export function cancelOrphanedRunTasks(db: Db, runId: string): TerminalizedTask[] {
   const orphaned = db
     .select({ id: tasks.id, containerName: tasks.containerName, kind: tasks.kind })
     .from(tasks)
-    .where(and(eq(tasks.runId, runId), inArray(tasks.status, ["queued", "running"])))
+    .where(and(eq(tasks.runId, runId), inArray(tasks.status, ["queued", "running", "blocked"])))
     .all();
 
-  const cancelled: ReapedReviewTask[] = [];
+  const cancelled: TerminalizedTask[] = [];
   const now = new Date();
   for (const task of orphaned) {
     db.update(tasks)
@@ -175,7 +182,7 @@ export function cancelOrphanedRunTasks(db: Db, runId: string): ReapedReviewTask[
         type: "system",
         content: JSON.stringify({
           text:
-            `Run finalized while this ${task.kind} pass was still pending — ` +
+            `Run finalized while this ${task.kind} pass had not terminalized — ` +
             "cancelling it so no task outlives its run (issue #124).",
         }),
         createdAt: now,

--- a/src/lib/orchestrator/autonomy/review-tasks.ts
+++ b/src/lib/orchestrator/autonomy/review-tasks.ts
@@ -1,8 +1,9 @@
 /**
- * Review-pass task bookkeeping shared by the sweep (issue #95).
+ * Task bookkeeping shared by the sweep, DB-only and side-effect-light so it is
+ * unit-testable against an in-memory database (issues #95, #124).
  *
- * Two mechanisms that must work together so a run has *exactly one* review
- * pass in flight — never zero when one is owed, never two racing the same PR:
+ * The exactly-one-review invariant — a run has *exactly one* review pass in
+ * flight, never zero when one is owed, never two racing the same PR:
  *
  *  1. `inFlightReviewTaskId` — the idempotency rule. Before queueing a review
  *     pass, any review task for the same run that is still `queued` or
@@ -17,8 +18,18 @@
  *     container is confirmed gone, so the next sweep's rule-1 check queues one
  *     deliberate replacement rather than stalling or racing.
  *
+ * The finalized-run cleanup (issue #124):
+ *
+ *  3. `cancelOrphanedRunTasks` — when a run reaches a terminal status, cancel
+ *     any pass it still owns so nothing outlives its run.
+ *  4. `queuedTasksReservingSlots` — the mirror on the read side: only a queued
+ *     task whose run is still live reserves a slot for pickup accounting, so a
+ *     task orphaned under a dead run can never wedge new claims.
+ *
  * DB-only by design (no Docker/GitHub imports): the container-liveness probe
- * is injected so the sweep passes the real daemon check and tests pass a fake.
+ * is injected so the sweep passes the real daemon check and tests pass a fake,
+ * and cancelled tasks are returned so the caller — not this module — removes
+ * their containers.
  */
 
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
@@ -117,4 +128,78 @@ export async function reapDeadReviewTasks(
     reaped.push({ taskId: task.id, containerName: task.containerName });
   }
   return reaped;
+}
+
+/**
+ * Terminalize every task a run still owns that is `queued` or `running`,
+ * setting it `cancelled` — the shared cleanup called from every run-
+ * finalization point (issue #124). When a run reaches a terminal status — its
+ * PR merged or closed, or the run failed/exhausted — any pass it still owns
+ * must not outlive it. The classic orphan is a review task left `queued`
+ * because the single slot was busy when a human merged the gated PR by hand:
+ * the run finalized to `merged`, but its queued review sat non-terminal
+ * forever, read as a reserved slot by the claim accounting, and wedged all
+ * new pickup (the LPS #135 incident).
+ *
+ * `cancelled` (not `failed`) by design: an orphaned pass is abandoned, not bad
+ * work, so it consumes no attempt — matching how a user-cancelled task and a
+ * restart-interrupted run's queued pass are handled (init.ts). A parked
+ * implement/repair container is released to `completed` by its own path
+ * *before* this runs, so this only sweeps up the genuinely-orphaned tasks;
+ * anything already terminal is skipped by the status filter.
+ *
+ * DB-only: returns the cancelled tasks with their container names so the
+ * caller removes any container that was still live, exactly like
+ * `reapDeadReviewTasks`. (A `queued` orphan has no container; only a `running`
+ * one — a review pass a hand-merge raced — carries a name to clean up.)
+ */
+export function cancelOrphanedRunTasks(db: Db, runId: string): ReapedReviewTask[] {
+  const orphaned = db
+    .select({ id: tasks.id, containerName: tasks.containerName, kind: tasks.kind })
+    .from(tasks)
+    .where(and(eq(tasks.runId, runId), inArray(tasks.status, ["queued", "running"])))
+    .all();
+
+  const cancelled: ReapedReviewTask[] = [];
+  const now = new Date();
+  for (const task of orphaned) {
+    db.update(tasks)
+      .set({ status: "cancelled", containerId: null, containerStatus: null, updatedAt: now })
+      .where(eq(tasks.id, task.id))
+      .run();
+    db.insert(messages)
+      .values({
+        id: newId(),
+        taskId: task.id,
+        role: "system",
+        type: "system",
+        content: JSON.stringify({
+          text:
+            `Run finalized while this ${task.kind} pass was still pending — ` +
+            "cancelling it so no task outlives its run (issue #124).",
+        }),
+        createdAt: now,
+      })
+      .run();
+    cancelled.push({ taskId: task.id, containerName: task.containerName });
+  }
+  return cancelled;
+}
+
+/**
+ * The queued tasks that reserve a slot for new-pickup accounting (issue #124):
+ * a task counts only if its run is still live, or it has no run at all
+ * (interactive and triage passes, which are real queued intent, never a dead
+ * run's ghost). `liveRunIds` is the set of run IDs in a non-terminal status
+ * (`ACTIVE_RUN_STATUSES`). A task orphaned under a finalized run — the queued
+ * review left behind by a hand-merged PR — is excluded, so it can never force
+ * `claimableSlots` to 0 and halt the frontier while a slot sits free. This is
+ * the read-side mirror of `cancelOrphanedRunTasks`: even if a finalization
+ * point were ever missed, a dead-run task still cannot suppress a claim.
+ */
+export function queuedTasksReservingSlots<T extends { runId: string | null }>(
+  queuedTasks: readonly T[],
+  liveRunIds: ReadonlySet<string>
+): T[] {
+  return queuedTasks.filter((t) => t.runId == null || liveRunIds.has(t.runId));
 }

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -81,7 +81,12 @@ import {
   buildTriagePrompt,
   type PriorAttempt,
 } from "./workflow";
-import { inFlightReviewTaskId, reapDeadReviewTasks } from "./review-tasks";
+import {
+  cancelOrphanedRunTasks,
+  inFlightReviewTaskId,
+  queuedTasksReservingSlots,
+  reapDeadReviewTasks,
+} from "./review-tasks";
 import {
   DAILY_AUTONOMOUS_CAP_USD,
   MAX_ATTEMPTS,
@@ -225,13 +230,25 @@ async function gatherSnapshot(now: Date): Promise<AutonomySnapshot> {
     .where(isNotNull(projects.githubRepo))
     .all();
 
-  const queuedTasks = db
-    .select({ kind: tasks.kind })
-    .from(tasks)
-    .where(eq(tasks.status, "queued"))
-    .all();
-
   const allRuns = db.select().from(runs).all();
+
+  // The queued tasks that reserve a slot for pickup accounting (issue #124):
+  // only those whose run is still live, plus run-less passes (interactive,
+  // triage). A task left `queued` under a now-terminal run — the review a
+  // hand-merged PR orphaned — is dropped here so it can never suppress a new
+  // claim while a slot sits free (the LPS #135 wedge). `runId` is carried
+  // solely for this filter.
+  const liveRunIds = new Set(
+    allRuns.filter((r) => ACTIVE_RUN_STATUS_SET.has(r.status)).map((r) => r.id)
+  );
+  const queuedTasks = queuedTasksReservingSlots(
+    db
+      .select({ kind: tasks.kind, runId: tasks.runId })
+      .from(tasks)
+      .where(eq(tasks.status, "queued"))
+      .all(),
+    liveRunIds
+  );
 
   // Occupant labels for the saturation announcement. Parked containers
   // (implement passes idling while their PR is reviewed) hold no slot.
@@ -1526,6 +1543,9 @@ async function executeFinalizeRun(
       ? `PR #${action.prNumber} merged — releasing container.`
       : `PR #${action.prNumber} closed without merging — releasing container.`
   );
+  // The PR is settled, so an owed review is moot: cancel any pass still queued
+  // (or running) under this now-terminal run so it cannot wedge pickup (#124).
+  await terminalizeFinalizedRunTasks(action.runId);
 
   console.log(`[autonomy] Run ${action.runId} settled: ${action.issueRef} ${action.outcome}`);
 }
@@ -1728,6 +1748,10 @@ async function executeExhaust(action: Extract<Action, { type: "exhaust" }>): Pro
   ].filter((r) => r != null);
   for (const marker of markers) {
     db.update(runs).set({ status: "exhausted" }).where(eq(runs.id, marker.id)).run();
+    // Defence-in-depth: a marked run was already failed/interrupted, so its
+    // tasks are terminal — but keep the "no task outlives its run" invariant
+    // total even here (issue #124).
+    await terminalizeFinalizedRunTasks(marker.id);
   }
 
   // The strikes are the failed (or interrupted) runs, but the ticket's bill
@@ -1824,6 +1848,9 @@ async function executeFailAttempt(
     action.runId,
     "Review cycles exhausted — attempt failed, releasing container."
   );
+  // Defence-in-depth: the failing verdict's review already completed, but if
+  // any pass is still non-terminal under this now-failed run, cancel it (#124).
+  await terminalizeFinalizedRunTasks(action.runId);
 
   console.log(
     `[autonomy] Run ${action.runId} failed: review cycles exhausted (${action.issueRef})`
@@ -1892,6 +1919,33 @@ async function releaseImplementContainer(runId: string, note: string): Promise<v
   const workingTask = workingTaskOf(runId);
   if (workingTask?.status === "running") {
     await releaseParkedImplementTask(workingTask.id, note);
+  }
+}
+
+/**
+ * The run-finalization cleanup (issue #124): once a run reaches a terminal
+ * status, cancel any task it still owns that never terminalized and let go of
+ * any container such a task held. The orphan this exists to catch is a review
+ * pass left `queued` because the single slot was busy when its gated PR was
+ * merged by hand — the run finalized to `merged`, but its queued review sat
+ * non-terminal, read as a reserved slot, and halted all new pickup (the
+ * LPS #135 incident).
+ *
+ * Call this *after* `releaseImplementContainer` at each finalization point:
+ * that releases the parked implement/repair task to `completed`, so what
+ * remains here is the genuine orphan. A queued orphan has no container; a
+ * running one (a review a hand-merge raced) is removed by name, mirroring
+ * `reapOrphanedReviewPasses`.
+ */
+async function terminalizeFinalizedRunTasks(runId: string): Promise<void> {
+  const cancelled = cancelOrphanedRunTasks(db, runId);
+  for (const task of cancelled) {
+    getActiveTasks().delete(task.taskId);
+    if (task.containerName) await removeContainerByName(task.containerName);
+    console.log(
+      `[autonomy] Cancelled orphaned task ${task.taskId} under finalized run ${runId} ` +
+        `— a pass must not outlive its run (issue #124)`
+    );
   }
 }
 

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -17,6 +17,7 @@ import { createOutputHandler, type TurnResult } from "./output-parser";
 import { parseReviewVerdict } from "./autonomy/verdict";
 import { parseTriageExit } from "./autonomy/triage";
 import { passProducedResult } from "./autonomy/pass-output";
+import { cancelOrphanedRunTasks } from "./autonomy/review-tasks";
 import {
   DEFAULT_REPAIR_BUDGET_USD,
   DEFAULT_REVIEW_BUDGET_USD,
@@ -1514,12 +1515,23 @@ function taskStatus(taskId: string): string | null {
   );
 }
 
-/** Terminalize a run: failed consumes an attempt, cancelled does not. */
+/**
+ * Terminalize a run: failed consumes an attempt, cancelled does not. Any pass
+ * the run still owns is cancelled alongside it, so no task outlives its run
+ * (issue #124) — the same invariant the sweep's finalization points enforce,
+ * centralized here for the turn-manager terminal transitions (a container
+ * error, or a user cancelling a task whose run had a review already queued).
+ * DB-only and idempotent: the caller has already terminalized the task in hand,
+ * so this reaches only *other* non-terminal siblings; a queued orphan holds no
+ * container, and the rare parked/running one becomes reaper-eligible the moment
+ * its run turns terminal here.
+ */
 function finishRun(runId: string, status: "failed" | "cancelled", reason?: string): void {
   db.update(runs)
     .set({ status, finishedAt: new Date(), ...(reason ? { failureReason: reason } : {}) })
     .where(eq(runs.id, runId))
     .run();
+  cancelOrphanedRunTasks(db, runId);
 }
 
 /**


### PR DESCRIPTION
Closes #124

## What this fixes

The LPS #135 incident: a human merged a gated PR whose review pass was still `queued` (the single slot was busy). The run finalized to `merged`, but its queued review task was **orphaned** — left non-terminal forever. That one dead task was counted by the slot-reservation accounting (`claimableSlots`), forcing `no-slots` on every sweep and **halting all new pickup for ~1.5h** while the dashboard showed a free slot and ready tickets.

## The fix — two defences

Both live in the DB-only, unit-testable `review-tasks` module.

1. **Write side — `cancelOrphanedRunTasks(db, runId)`** (`review-tasks.ts`). When a run reaches a terminal status, any pass it still owns that is non-terminal is set `cancelled` (an abandoned pass consumes no attempt — like a user-cancel or a restart-interrupted queued pass). It returns the cancelled tasks so the caller removes any container they held. Called from **every finalization point**:
   - sweep: `executeFinalizeRun` (merged/closed), `executeFailAttempt` (failed), `executeExhaust` (exhausted), via the `terminalizeFinalizedRunTasks` wrapper that also tears down containers;
   - turn-manager: `finishRun` (container error / user-cancel), so the invariant holds at the non-sweep terminal transitions too.

   A parked implement/repair task is released to `completed` by its own path first, so this only sweeps up genuine orphans. Runs still `reviewing`/`gated` (legitimately owed a review) are never touched.

2. **Read side — `queuedTasksReservingSlots(queued, liveRunIds)`** (`review-tasks.ts`). `gatherSnapshot` now filters the reservation counts through it: only a queued task whose run is still live (or a run-less interactive/triage pass) reserves a slot. So a dead-run task can never suppress a claim even if a finalization point were ever missed.

The existing gated→review self-heal is preserved — live runs are untouched, and `inFlightReviewTaskId` is unchanged.

## Acceptance criteria

- [x] A finalized run (merged/closed/failed/exhausted) leaves no owned task non-terminal — covered across the three sweep finalizers **and** turn-manager's `finishRun`, for every non-terminal status (`queued`/`running`/`blocked`).
- [x] Pickup is not suppressed by a queued task whose run is terminal — `queuedTasksReservingSlots` drops dead-run tasks from `claimableSlots`.
- [x] Regression test reproducing the incident shape — see below.
- [x] Existing self-heal preserved and still fires (asserted in tests).

## Tests

- `review-tasks.test.ts`: cancels queued/running/blocked owned tasks; leaves terminal, other-run, and live-run tasks alone (self-heal preserved); returns containers for cleanup; reserving-count drops dead-run tasks; an integrated DB-seam regression chaining finalize → orphan cancelled → reservation counts only the live run's review.
- `decide.test.ts`: with the orphan excluded (count 0), a free slot + ready ticket claims rather than parking on `no-slots`; a live-run queued review still reserves its slot (the count is not blanket-zeroed).

`pnpm test` green (564), lint clean on changed files, no new `tsc` errors (2 pre-existing `container-manager.test.ts` errors exist on `main`, unrelated).

## Self-review notes (code-review skill, fixed point `origin/main`, spec #124)

Acted on the findings I agreed with:
- **Turn-manager finalizers were uncovered** (AC-1 gap) → wired the helper into `finishRun`.
- **`blocked` was excluded** from the cancel filter → now swept too, so the invariant is total.
- **Return type name** `ReapedReviewTask` mis-described cancelled tasks of any kind → renamed to `TerminalizedTask` (deprecated alias retained for the reaper).

Where I made a judgement call rather than change code:
- **Duplication** with `reapDeadReviewTasks` is deliberate: the two share a shape but differ in the parts that matter (WHERE filter, terminal status `cancelled` vs `failed`, message) and encode distinct concepts (finalize-cleanup vs infra-death reaping); extracting a micro-helper would couple them and obscure intent.
- **AC-3 as one end-to-end test**: `gatherSnapshot` does live Octokit/Docker I/O, so a single merge→finalize→claim test isn't practical without mocking the world. Coverage is split across the DB-seam integrated test (write+read) and the `decideNext` claim test — the incident is reproduced across the seam.