### PR TITLE
Reliability: bound the memory-admission probe so a hung Docker daemon can't wedge the queue

### DIFF
--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
+  checkMemoryAdmission,
   createLocalCapacityProvider,
   deriveCapacity,
   wouldOvercommitMemory,
@@ -144,6 +145,40 @@ describe("wouldOvercommitMemory", () => {
     expect(
       wouldOvercommitMemory({ memTotalBytes: 4 * GiB, perAgentMemory, liveContainers: 1 })
     ).toBe(true);
+  });
+});
+
+describe("checkMemoryAdmission", () => {
+  // Issue #115: a hung Docker daemon connection must never freeze dispatch.
+  // The probe is raced against a bounded timeout and fails open on both a hang
+  // and an error, matching how it already fails open on a probe error.
+  it("fails open when the probe hangs past the timeout, and logs it", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A probe that never resolves — the signature of a hung daemon connection.
+    const hangingProbe = () => new Promise<{ ok: boolean }>(() => {});
+
+    const result = await checkMemoryAdmission(hangingProbe, 20);
+
+    expect(result.ok).toBe(true);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("timed out")
+    );
+    errSpy.mockRestore();
+  });
+
+  it("returns the probe's verdict when it resolves before the timeout", async () => {
+    const refused = { ok: false, reason: "2 live + one more overcommits" };
+    const result = await checkMemoryAdmission(async () => refused, 1000);
+    expect(result).toEqual(refused);
+  });
+
+  it("fails open when the probe rejects (existing on-error behaviour)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = await checkMemoryAdmission(async () => {
+      throw new Error("daemon unreachable");
+    }, 1000);
+    expect(result.ok).toBe(true);
+    errSpy.mockRestore();
   });
 });
 

--- a/src/lib/orchestrator/__tests__/capacity.test.ts
+++ b/src/lib/orchestrator/__tests__/capacity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   checkMemoryAdmission,
   createLocalCapacityProvider,
@@ -149,6 +149,11 @@ describe("wouldOvercommitMemory", () => {
 });
 
 describe("checkMemoryAdmission", () => {
+  // Restore in a hook, not inline, so a failing assertion can't leave
+  // console.error stubbed for the rest of the suite (vitest config sets no
+  // restoreMocks).
+  afterEach(() => vi.restoreAllMocks());
+
   // Issue #115: a hung Docker daemon connection must never freeze dispatch.
   // The probe is raced against a bounded timeout and fails open on both a hang
   // and an error, matching how it already fails open on a probe error.
@@ -163,7 +168,6 @@ describe("checkMemoryAdmission", () => {
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("timed out")
     );
-    errSpy.mockRestore();
   });
 
   it("returns the probe's verdict when it resolves before the timeout", async () => {
@@ -173,12 +177,11 @@ describe("checkMemoryAdmission", () => {
   });
 
   it("fails open when the probe rejects (existing on-error behaviour)", async () => {
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await checkMemoryAdmission(async () => {
       throw new Error("daemon unreachable");
     }, 1000);
     expect(result.ok).toBe(true);
-    errSpy.mockRestore();
   });
 });
 

--- a/src/lib/orchestrator/capacity.ts
+++ b/src/lib/orchestrator/capacity.ts
@@ -101,6 +101,54 @@ export function wouldOvercommitMemory(input: {
 }
 
 /**
+ * How long the memory-admission probe may wait on the Docker daemon before it
+ * gives up and fails open. A hung daemon connection has no timeout of its own,
+ * so an unbounded probe blocks every queue poll before it can dispatch — during
+ * the 2026-08-11 incident (issue #115) this silently stalled *all* dispatch,
+ * interactive included, for ~1.5h with the slot count reading free. The bound
+ * guarantees a poll can always make progress.
+ */
+export const ADMISSION_PROBE_TIMEOUT_MS = 5000;
+
+/** Sentinel the timeout resolves with, distinct from any value the probe can
+ * return, so the race can tell "timed out" from a genuine `{ ok }` verdict. */
+const PROBE_TIMED_OUT = Symbol("memory-admission-probe-timeout");
+
+/**
+ * Gather the live numbers from the daemon and decide admission. Split out from
+ * `checkMemoryAdmission` so the timeout wrapper stays thin and the Docker calls
+ * — the ones that can hang on an unresponsive connection — are exactly what the
+ * timeout races against.
+ */
+async function probeMemoryAdmission(): Promise<{ ok: boolean; reason?: string }> {
+  const docker = getDocker();
+  const capacity = await getCapacity();
+  const info = await docker.info();
+  // Default listing (no `all`) returns only running containers — the ones
+  // holding memory right now.
+  const running = await docker.listContainers({
+    filters: { name: ["interlude-task-"] },
+  });
+  const liveContainers = running.length;
+
+  if (
+    wouldOvercommitMemory({
+      memTotalBytes: info.MemTotal,
+      perAgentMemory: capacity.perAgentMemory,
+      liveContainers,
+    })
+  ) {
+    const perMb = Math.round(capacity.perAgentMemory / MiB);
+    const usableMb = Math.round(usableMemoryBytes(info.MemTotal) / MiB);
+    return {
+      ok: false,
+      reason: `${liveContainers} agent container(s) live × ${perMb} MiB + one more exceeds ~${usableMb} MiB usable`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
  * Ask the daemon how many agent containers are actually *running* and refuse
  * to start another when the live set plus the newcomer would overcommit host
  * memory (issue #93). Independent of the in-memory slot count, so it also
@@ -108,39 +156,39 @@ export function wouldOvercommitMemory(input: {
  * containers are `docker stop`ped since #93, so they are correctly absent from
  * the running set and weigh nothing here.
  *
- * Fails open: a Docker probe error logs and allows, so a transient daemon
- * hiccup never wedges the queue behind a phantom memory ceiling.
+ * Fails open on both failure modes so an unhealthy daemon can never wedge the
+ * queue behind a phantom memory ceiling: a probe *error* logs and allows (a
+ * transient daemon hiccup), and a probe that *hangs* past
+ * `ADMISSION_PROBE_TIMEOUT_MS` logs and allows too (issue #115) — an
+ * unresponsive connection can never freeze dispatch. `probe`/`timeoutMs` are
+ * injectable for tests; production callers use the defaults.
  */
-export async function checkMemoryAdmission(): Promise<{ ok: boolean; reason?: string }> {
+export async function checkMemoryAdmission(
+  probe: () => Promise<{ ok: boolean; reason?: string }> = probeMemoryAdmission,
+  timeoutMs: number = ADMISSION_PROBE_TIMEOUT_MS
+): Promise<{ ok: boolean; reason?: string }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const docker = getDocker();
-    const capacity = await getCapacity();
-    const info = await docker.info();
-    // Default listing (no `all`) returns only running containers — the ones
-    // holding memory right now.
-    const running = await docker.listContainers({
-      filters: { name: ["interlude-task-"] },
+    const probePromise = probe();
+    // Keep a losing (timed-out) probe's eventual rejection from surfacing as an
+    // unhandled rejection once nothing awaits the race any more.
+    probePromise.catch(() => {});
+    const timeout = new Promise<typeof PROBE_TIMED_OUT>((resolve) => {
+      timer = setTimeout(() => resolve(PROBE_TIMED_OUT), timeoutMs);
     });
-    const liveContainers = running.length;
-
-    if (
-      wouldOvercommitMemory({
-        memTotalBytes: info.MemTotal,
-        perAgentMemory: capacity.perAgentMemory,
-        liveContainers,
-      })
-    ) {
-      const perMb = Math.round(capacity.perAgentMemory / MiB);
-      const usableMb = Math.round(usableMemoryBytes(info.MemTotal) / MiB);
-      return {
-        ok: false,
-        reason: `${liveContainers} agent container(s) live × ${perMb} MiB + one more exceeds ~${usableMb} MiB usable`,
-      };
+    const result = await Promise.race([probePromise, timeout]);
+    if (result === PROBE_TIMED_OUT) {
+      console.error(
+        `[capacity] memory-admission probe timed out after ${timeoutMs}ms, allowing start`
+      );
+      return { ok: true };
     }
-    return { ok: true };
+    return result;
   } catch (err) {
     console.error("[capacity] memory-admission probe failed, allowing start:", err);
     return { ok: true };
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/lib/orchestrator/queue.ts
+++ b/src/lib/orchestrator/queue.ts
@@ -77,25 +77,44 @@ export function startQueue(): void {
         // actually running, catching any drift the slot bookkeeping missed
         // before the host OOMs. Both must clear before a task starts.
         const slotFree = await capacityProvider.isSlotAvailable();
-        const admission = slotFree ? await checkMemoryAdmission() : { ok: false };
-        if (slotFree && admission.ok) {
-          saturationLogged = false;
+        if (!slotFree) {
+          if (!saturationLogged) {
+            saturationLogged = true;
+            console.log(
+              `[orchestrator] All ${capacityProvider.capacity.slots} slot(s) busy — task ${next.id} waits in queue`
+            );
+          }
+        } else {
+          // Reserve the task before probing. The probe can now block for up to
+          // ADMISSION_PROBE_TIMEOUT_MS on a slow or hung daemon (issue #125) —
+          // longer than the 2s poll interval — so without reserving first, an
+          // overlapping poll would still see this task queued, clear its own
+          // slot check, and dispatch it a second time: two containers for one
+          // task, the exact overcommit #93 guards against. Reserving also caps
+          // the probe to one in-flight call per free slot, since a full box
+          // short-circuits above without probing. Released again if the probe
+          // refuses the start.
           processingTasks.add(next.id);
-          console.log(
-            `[orchestrator] Picked up task: ${next.id} — ${next.title}`
-          );
-          startTask(next.id)
-            .catch((err) =>
-              console.error(`[orchestrator] Task ${next.id} failed:`, err)
-            )
-            .finally(() => processingTasks.delete(next.id));
-        } else if (!saturationLogged) {
-          saturationLogged = true;
-          console.log(
-            !slotFree
-              ? `[orchestrator] All ${capacityProvider.capacity.slots} slot(s) busy — task ${next.id} waits in queue`
-              : `[orchestrator] Memory headroom low (${admission.reason}) — task ${next.id} waits in queue`
-          );
+          const admission = await checkMemoryAdmission();
+          if (admission.ok) {
+            saturationLogged = false;
+            console.log(
+              `[orchestrator] Picked up task: ${next.id} — ${next.title}`
+            );
+            startTask(next.id)
+              .catch((err) =>
+                console.error(`[orchestrator] Task ${next.id} failed:`, err)
+              )
+              .finally(() => processingTasks.delete(next.id));
+          } else {
+            processingTasks.delete(next.id);
+            if (!saturationLogged) {
+              saturationLogged = true;
+              console.log(
+                `[orchestrator] Memory headroom low (${admission.reason}) — task ${next.id} waits in queue`
+              );
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Closes #125

## What & why

The queue's per-poll memory-admission check (`checkMemoryAdmission`) calls the Docker daemon (`docker.info()` + `listContainers()`) with **no timeout**. A hung daemon connection therefore blocks every poll before it can dispatch, silently stalling **all** dispatch — interactive included — with the slot count reading free and no error logged. This is the signature of the ~1.5h dispatch stall during the 2026-08-11 incident (parent #115).

## Change

- **Bound the probe** (`src/lib/orchestrator/capacity.ts`): race it against `ADMISSION_PROBE_TIMEOUT_MS` (5s). On timeout, **log and fail open** (allow the start), exactly as it already does on a probe *error*, so an unresponsive daemon connection can never freeze dispatch. The Docker gathering is split into `probeMemoryAdmission`; `checkMemoryAdmission` gained injectable `probe`/`timeoutMs` params (defaulted) so a test can simulate a hanging probe with no real daemon. Both call sites (`queue.ts`, `turn-manager.ts`) keep calling it argument-free and inherit the bound.
- **Reserve the slot before probing** (`src/lib/orchestrator/queue.ts`): the probe can now block up to 5s — longer than the 2s poll interval — so an overlapping poll could otherwise pick the same still-queued task and dispatch it twice (two containers for one task, the exact overcommit #93 guards against). Reserve the task in `processingTasks` before the probe and release it if the probe refuses. This also caps in-flight probes to one per free slot, since a full box short-circuits without probing.

## Acceptance criteria

- [x] The admission probe cannot block a queue poll indefinitely — it resolves within `ADMISSION_PROBE_TIMEOUT_MS`.
- [x] On probe timeout, dispatch proceeds (fail-open), matching the existing on-error behaviour, and the timeout is logged.
- [x] Task dispatch continues to function when the Docker connection is unresponsive — covered by `checkMemoryAdmission` tests that simulate a hanging probe (and a resolving/rejecting probe).

## Validation

- `pnpm test` — 560 passed (3 new).
- `pnpm lint` on changed files — clean.
- (Repo has 2 pre-existing `tsc` errors in `src/lib/docker/__tests__/container-manager.test.ts`, untouched here; and a 16-error lint baseline on `main` — neither in changed files.)

## Self-review notes (`/code-review` vs origin/main, spec #125)

Acted on:
- **Double-dispatch under overlapping polls** — fixed via the slot reservation above; this was the main risk the 5s bound introduced.
- **Abandoned/leaked hung probe per poll** — largely mitigated by the same reservation: after the first fail-open dispatch fills the slot, subsequent polls short-circuit *before* probing, so hung requests don't accumulate every 2s.
- **Test hygiene** — `console.error` spies now restored in an `afterEach`, so a failing assertion can't leave it stubbed for the rest of the suite.

Considered, not changed (rationale):
- **Boot-time `getCapacity()` outside the bound** — `initOrchestrator` derives capacity (`getCapacity`) before `startQueue`, so `_capacity` is cached before any poll. The unbounded first-call path only bites if the daemon is dead *at boot*, when init itself hangs and nothing could dispatch anyway — a different failure from the mid-operation hang this ticket targets.
- **Fail-open bypasses the overcommit guard under legitimate load** — the spec mandates fail-open on timeout; 5s is far above a healthy `info`+`listContainers` (tens of ms even under load), so this is a designed tradeoff, not a routinely-reachable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)