### PR TITLE
Observability: fleet surfaces & Discord-alerts stalled review + wedged pickup (#126)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,10 @@ GITHUB_APP_INSTALLATION_ID=12345678
 # it NEVER enters an agent container. Canonical home is Doppler platform/prd,
 # mirrored into interlude/prd (rotation must update both).
 # REVIEWER_GH_TOKEN=github_pat_...
+
+# Fleet-health watchdog thresholds (issue #126), in MINUTES. Each surfaces a
+# needs-you card + one Discord fleet ping when a stall lasts past the threshold.
+# Defaults shown; a blank/invalid value keeps the default.
+# OWED_REVIEW_STALL_MINUTES=30      # a reviewing/gated run whose review never started
+# PICKUP_WEDGED_MINUTES=3           # a free slot but claimable work not dispatching
+# QUEUE_HEARTBEAT_STALE_MINUTES=2   # the 2s queue poll loop stopped making progress

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -120,16 +120,20 @@ The **dashboard is the home page** (`/`). It streams live over SSE and shows:
 
 - **slots** — total vs used, and what occupies each (autonomous / interactive).
 - **needs you** — blocked questions, `human-signoff` PRs, exhausted tickets, a
-  daily-cap pause, and failing preflights, each with a link.
+  daily-cap pause, failing preflights, and the fleet-health watchdog's stall
+  signals (issue #126: an owed review that never started, a wedged pickup, a
+  stale queue heartbeat), each with a link where one applies.
 - **running** — each active run's ticket, attempt (n/3), turn, spend vs budget,
   and phase (implement ▸ review ▸ merge).
 - **recent** — the last 7 days of completions.
 - **spend** — today's autonomous spend vs the $500/day cap.
 
 Discord is **push-only**: it tells you *when to look* (claimed, blocked question,
-sign-off needed, attempts exhausted, cap pause, slots saturated, daily digest).
-Autonomous success is deliberately silent — it shows on the dashboard. There is
-no `!status` command; the dashboard answers "what's happening".
+sign-off needed, attempts exhausted, cap pause, slots saturated, a fleet-health
+stall — owed review / wedged pickup / stale queue, issue #126 — daily digest).
+Each stall pings once per occurrence, not every sweep. Autonomous success is
+deliberately silent — it shows on the dashboard. There is no `!status` command;
+the dashboard answers "what's happening".
 
 ### 3. Pause pickup
 
@@ -263,6 +267,7 @@ Override with `CAPACITY_SLOTS`; per-agent memory with `AGENT_MEMORY_MB` (default
 | `DISCORD_FLEET_CHANNEL_ID` | Channel for fleet events + fallback for blocked questions when a project has no linked channel. |
 | `MAX_BUDGET_USD` | Per-attempt default budget ($20). |
 | `CAPACITY_SLOTS`, `AGENT_MEMORY_MB` | Override derived capacity — only when the derivation is wrong. |
+| `OWED_REVIEW_STALL_MINUTES`, `PICKUP_WEDGED_MINUTES`, `QUEUE_HEARTBEAT_STALE_MINUTES` | Fleet-health watchdog thresholds in minutes (issue #126). Defaults 30 / 3 / 2. |
 
 ### Labels
 

--- a/src/components/fleet/needs-you.tsx
+++ b/src/components/fleet/needs-you.tsx
@@ -10,6 +10,9 @@ const CAUSE_LABEL: Record<NeedsYouItem["cause"], string> = {
   exhausted: "exhausted",
   cap: "cap pause",
   preflight: "preflight",
+  "review-stalled": "review stalled",
+  "pickup-wedged": "pickup wedged",
+  "queue-stale": "queue stalled",
 };
 
 const CAUSE_TONE: Record<NeedsYouItem["cause"], "amber" | "red"> = {
@@ -20,6 +23,9 @@ const CAUSE_TONE: Record<NeedsYouItem["cause"], "amber" | "red"> = {
   exhausted: "red",
   cap: "red",
   preflight: "amber",
+  "review-stalled": "red",
+  "pickup-wedged": "red",
+  "queue-stale": "red",
 };
 
 /** Quiet confirmation sub-line: "No active runs · queue empty · autonomy on" */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,20 @@
 import {
   ALLOWED_TICKET_EFFORTS,
   DEFAULT_ATTEMPT_BUDGET_USD,
+  DEFAULT_OWED_REVIEW_STALL_MS,
+  DEFAULT_PICKUP_WEDGED_MS,
+  DEFAULT_QUEUE_HEARTBEAT_STALE_MS,
 } from "./orchestrator/autonomy/budgets";
+import type { FleetHealthThresholds } from "./fleet/health";
+
+/** Parse an env value expressed in minutes into ms, falling back to a default.
+ * A blank, non-numeric or non-positive value keeps the default (a mistyped
+ * threshold must never silently become 0 and alarm every sweep). */
+function minutesEnvMs(raw: string | undefined, defaultMs: number): number {
+  if (raw == null || raw === "") return defaultMs;
+  const mins = parseFloat(raw);
+  return Number.isFinite(mins) && mins > 0 ? mins * 60_000 : defaultMs;
+}
 
 /**
  * Validate an `AGENT_EFFORT*` env value against the CLI's level set. Effort,
@@ -100,6 +113,10 @@ export interface AppConfig {
   autonomyAllowedAuthors: string[];
   /** Discord channel for fleet-level events (e.g. slot saturation). Null = log only */
   discordFleetChannelId: string | null;
+  /** Thresholds for the fleet-health watchdog (issue #126), in ms. Overridable
+   * in minutes via OWED_REVIEW_STALL_MINUTES / PICKUP_WEDGED_MINUTES /
+   * QUEUE_HEARTBEAT_STALE_MINUTES. */
+  fleetHealthThresholds: FleetHealthThresholds;
 }
 
 let _config: AppConfig | null = null;
@@ -158,6 +175,20 @@ export function getConfig(): AppConfig {
       .map((a) => a.trim())
       .filter(Boolean),
     discordFleetChannelId: process.env.DISCORD_FLEET_CHANNEL_ID ?? null,
+    fleetHealthThresholds: {
+      owedReviewStallMs: minutesEnvMs(
+        process.env.OWED_REVIEW_STALL_MINUTES,
+        DEFAULT_OWED_REVIEW_STALL_MS
+      ),
+      pickupWedgedMs: minutesEnvMs(
+        process.env.PICKUP_WEDGED_MINUTES,
+        DEFAULT_PICKUP_WEDGED_MS
+      ),
+      heartbeatStaleMs: minutesEnvMs(
+        process.env.QUEUE_HEARTBEAT_STALE_MINUTES,
+        DEFAULT_QUEUE_HEARTBEAT_STALE_MS
+      ),
+    },
   };
 
   return _config;

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -1,5 +1,6 @@
 import { Client, EmbedBuilder, TextChannel, type Message } from "discord.js";
 import { DIGEST_TITLE_PREFIX, type DigestContent } from "../fleet/digest";
+import type { OwedReviewStall, PickupWedge, QueueStale } from "../fleet/health";
 
 // The bot client is set once, in the instrumentation/orchestrator context where
 // the Discord bot connects (client.ts -> setBotClient). But notification helpers
@@ -228,6 +229,106 @@ export async function notifySlotsSaturated(
     await sendWithRetry(channel as TextChannel, embed);
   } catch (err) {
     console.error(`[discord] Failed to send saturation notification:`, err);
+  }
+}
+
+/** Whole minutes for a fleet-health ping body — durations are minutes-to-hours
+ * and shown at sweep granularity, so seconds would be noise. */
+function minutesOf(ms: number): number {
+  return Math.max(1, Math.round(ms / 60_000));
+}
+
+/**
+ * Fleet-health watchdog (issue #126): a run's review pass has not started for
+ * too long — the PR sits owed a review while the slot is busy. Sent once per
+ * stall (the sweep tracks the announcement; this just delivers). No-op when no
+ * fleet channel is configured: the sweep already logged it.
+ */
+export async function notifyOwedReviewStalled(
+  channelId: string | null,
+  payload: OwedReviewStall
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Owed review stalled — PR #${payload.prNumber}`)
+      .setDescription(
+        `${payload.issueRef} (PR #${payload.prNumber}) has been owed a review for ` +
+          `~${minutesOf(payload.stalledForMs)}m without it starting: ${payload.reason}.\n\n` +
+          `Nothing merges until the review lands — free a slot or check the queue.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send owed-review-stalled notification:`, err);
+  }
+}
+
+/**
+ * Fleet-health watchdog (issue #126): pickup is wedged — a slot is free but
+ * claimable work is not dispatching. Sent once per wedge. No-op when no fleet
+ * channel is configured: the sweep already logged it.
+ */
+export async function notifyPickupWedged(
+  channelId: string | null,
+  payload: PickupWedge
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Pickup wedged — a slot is free but nothing dispatches`)
+      .setDescription(
+        `${payload.detail} for ~${minutesOf(payload.wedgedForMs)}m. The queue is not ` +
+          `picking up claimable work — check the orchestrator (a hung Docker daemon ` +
+          `or a stuck poll loop).`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send pickup-wedged notification:`, err);
+  }
+}
+
+/**
+ * Fleet-health watchdog (issue #126): the queue poll loop, which should tick
+ * every 2s, has stopped making progress. Sent once per stall. No-op when no
+ * fleet channel is configured: the sweep already logged it.
+ */
+export async function notifyQueueStale(
+  channelId: string | null,
+  payload: QueueStale
+): Promise<void> {
+  const botClient = getBotClient();
+  if (!botClient || !channelId) return;
+
+  try {
+    const channel = await botClient.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Queue loop stalled`)
+      .setDescription(
+        `The queue poll loop hasn't made progress for ~${minutesOf(payload.staleForMs)}m ` +
+          `(it should tick every 2s). Dispatch is likely wedged — check the ` +
+          `orchestrator process.`
+      )
+      .setColor(0xef4444);
+
+    await sendWithRetry(channel as TextChannel, embed);
+  } catch (err) {
+    console.error(`[discord] Failed to send queue-stale notification:`, err);
   }
 }
 

--- a/src/lib/discord/notifications.ts
+++ b/src/lib/discord/notifications.ts
@@ -1,6 +1,11 @@
 import { Client, EmbedBuilder, TextChannel, type Message } from "discord.js";
 import { DIGEST_TITLE_PREFIX, type DigestContent } from "../fleet/digest";
-import type { OwedReviewStall, PickupWedge, QueueStale } from "../fleet/health";
+import {
+  formatDuration,
+  type OwedReviewStall,
+  type PickupWedge,
+  type QueueStale,
+} from "../fleet/health";
 
 // The bot client is set once, in the instrumentation/orchestrator context where
 // the Discord bot connects (client.ts -> setBotClient). But notification helpers
@@ -232,12 +237,6 @@ export async function notifySlotsSaturated(
   }
 }
 
-/** Whole minutes for a fleet-health ping body — durations are minutes-to-hours
- * and shown at sweep granularity, so seconds would be noise. */
-function minutesOf(ms: number): number {
-  return Math.max(1, Math.round(ms / 60_000));
-}
-
 /**
  * Fleet-health watchdog (issue #126): a run's review pass has not started for
  * too long — the PR sits owed a review while the slot is busy. Sent once per
@@ -259,7 +258,7 @@ export async function notifyOwedReviewStalled(
       .setTitle(`Owed review stalled — PR #${payload.prNumber}`)
       .setDescription(
         `${payload.issueRef} (PR #${payload.prNumber}) has been owed a review for ` +
-          `~${minutesOf(payload.stalledForMs)}m without it starting: ${payload.reason}.\n\n` +
+          `~${formatDuration(payload.stalledForMs)} without it starting: ${payload.reason}.\n\n` +
           `Nothing merges until the review lands — free a slot or check the queue.`
       )
       .setColor(0xef4444);
@@ -289,7 +288,7 @@ export async function notifyPickupWedged(
     const embed = new EmbedBuilder()
       .setTitle(`Pickup wedged — a slot is free but nothing dispatches`)
       .setDescription(
-        `${payload.detail} for ~${minutesOf(payload.wedgedForMs)}m. The queue is not ` +
+        `${payload.detail} for ~${formatDuration(payload.wedgedForMs)}. The queue is not ` +
           `picking up claimable work — check the orchestrator (a hung Docker daemon ` +
           `or a stuck poll loop).`
       )
@@ -320,7 +319,7 @@ export async function notifyQueueStale(
     const embed = new EmbedBuilder()
       .setTitle(`Queue loop stalled`)
       .setDescription(
-        `The queue poll loop hasn't made progress for ~${minutesOf(payload.staleForMs)}m ` +
+        `The queue poll loop hasn't made progress for ~${formatDuration(payload.staleForMs)} ` +
           `(it should tick every 2s). Dispatch is likely wedged — check the ` +
           `orchestrator process.`
       )

--- a/src/lib/fleet/__tests__/digest.test.ts
+++ b/src/lib/fleet/__tests__/digest.test.ts
@@ -35,6 +35,7 @@ function baseRows(overrides: Partial<FleetRows> = {}): FleetRows {
     tasks: [],
     backlogByProject: null,
     needsHumanByProject: null,
+    fleetHealth: null,
     ...overrides,
   };
 }

--- a/src/lib/fleet/__tests__/fleet-view.test.ts
+++ b/src/lib/fleet/__tests__/fleet-view.test.ts
@@ -22,6 +22,7 @@ function baseRows(overrides: Partial<FleetRows> = {}): FleetRows {
     tasks: [],
     backlogByProject: null,
     needsHumanByProject: null,
+    fleetHealth: null,
     ...overrides,
   };
 }
@@ -784,10 +785,24 @@ describe("buildFleetView — needs you", () => {
     ]);
   });
 
-  it("orders causes: cap, blocked, sign-off, exhausted, preflight", () => {
+  it("orders causes: cap, machinery health, blocked, sign-off, exhausted, preflight", () => {
     const view = buildFleetView(
       baseRows({
         dailyCapUsd: 10,
+        fleetHealth: {
+          owedReviewStalls: [
+            {
+              runId: "run-x",
+              issueRef: "o/r#5",
+              prNumber: 12,
+              prUrl: "https://github.com/o/r/pull/12",
+              reason: "a slot is held by an interactive session (1/1 busy)",
+              stalledForMs: 31 * 60_000,
+            },
+          ],
+          pickupWedged: { detail: "1 slot free but pickup is paused (no-slots)", wedgedForMs: 4 * 60_000 },
+          queueStale: { staleForMs: 3 * 60_000 },
+        },
         projects: [
           makeProject({
             id: "p1",
@@ -828,11 +843,141 @@ describe("buildFleetView — needs you", () => {
 
     expect(view.needsYou.map((item) => item.cause)).toEqual([
       "cap",
+      "queue-stale",
+      "pickup-wedged",
+      "review-stalled",
       "blocked",
       "signoff",
       "exhausted",
       "preflight",
     ]);
+  });
+});
+
+describe("buildFleetView — fleet health (#126)", () => {
+  it("renders no health cards when the sweep has not evaluated (null)", () => {
+    const view = buildFleetView(baseRows({ fleetHealth: null }));
+    expect(view.needsYou).toEqual([]);
+  });
+
+  it("raises a stale-queue card, red, no action", () => {
+    const view = buildFleetView(
+      baseRows({
+        fleetHealth: {
+          owedReviewStalls: [],
+          pickupWedged: null,
+          queueStale: { staleForMs: 3 * 60_000 },
+        },
+      })
+    );
+    expect(view.needsYou).toEqual([
+      {
+        cause: "queue-stale",
+        severity: "red",
+        context: "queue loop",
+        body: "Queue poll loop hasn't made progress for 3m — dispatch is likely wedged",
+        action: null,
+      },
+    ]);
+  });
+
+  it("raises a pickup-wedged card carrying the sweep's detail", () => {
+    const view = buildFleetView(
+      baseRows({
+        fleetHealth: {
+          owedReviewStalls: [],
+          pickupWedged: {
+            detail: '1 slot free but "review: o/r#5" has not dispatched',
+            wedgedForMs: 5 * 60_000,
+          },
+          queueStale: null,
+        },
+      })
+    );
+    expect(view.needsYou).toEqual([
+      {
+        cause: "pickup-wedged",
+        severity: "red",
+        context: "pickup",
+        body: '1 slot free but "review: o/r#5" has not dispatched for 5m',
+        action: null,
+      },
+    ]);
+  });
+
+  it("raises an owed-review-stalled card naming the PR, with a link when known", () => {
+    const view = buildFleetView(
+      baseRows({
+        fleetHealth: {
+          owedReviewStalls: [
+            {
+              runId: "run-1",
+              issueRef: "lennons301/last-person-standing#135",
+              prNumber: 159,
+              prUrl: "https://github.com/lennons301/last-person-standing/pull/159",
+              reason: "a slot is held by an interactive session (1/1 busy)",
+              stalledForMs: 34 * 60_000,
+            },
+          ],
+          pickupWedged: null,
+          queueStale: null,
+        },
+      })
+    );
+    expect(view.needsYou).toEqual([
+      {
+        cause: "review-stalled",
+        severity: "red",
+        context: "last-person-standing #135 · PR #159",
+        body: "Review hasn't started for 34m — a slot is held by an interactive session (1/1 busy)",
+        action: {
+          label: "Open PR #159",
+          href: "https://github.com/lennons301/last-person-standing/pull/159",
+        },
+      },
+    ]);
+  });
+
+  it("omits the link on a stalled review whose PR URL is unknown", () => {
+    const view = buildFleetView(
+      baseRows({
+        fleetHealth: {
+          owedReviewStalls: [
+            {
+              runId: "run-1",
+              issueRef: "o/r#7",
+              prNumber: 7,
+              prUrl: null,
+              reason: "all 2 slots busy",
+              stalledForMs: 90 * 60_000,
+            },
+          ],
+          pickupWedged: null,
+          queueStale: null,
+        },
+      })
+    );
+    expect(view.needsYou[0]).toMatchObject({
+      cause: "review-stalled",
+      body: "Review hasn't started for 1h 30m — all 2 slots busy",
+      action: null,
+    });
+  });
+
+  it("raises one card per stalled review", () => {
+    const view = buildFleetView(
+      baseRows({
+        fleetHealth: {
+          owedReviewStalls: [
+            { runId: "a", issueRef: "o/r#1", prNumber: 1, prUrl: null, reason: "x", stalledForMs: 31 * 60_000 },
+            { runId: "b", issueRef: "o/r#2", prNumber: 2, prUrl: null, reason: "x", stalledForMs: 31 * 60_000 },
+          ],
+          pickupWedged: null,
+          queueStale: null,
+        },
+      })
+    );
+    expect(view.needsYou.filter((i) => i.cause === "review-stalled")).toHaveLength(2);
   });
 });
 

--- a/src/lib/fleet/__tests__/health.test.ts
+++ b/src/lib/fleet/__tests__/health.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateFleetHealth,
+  EMPTY_FLEET_HEALTH_STATE,
+  type FleetHealthInput,
+  type FleetHealthState,
+  type FleetHealthThresholds,
+  type OwedReviewObservation,
+} from "../health";
+
+const THRESHOLDS: FleetHealthThresholds = {
+  owedReviewStallMs: 30 * 60_000,
+  pickupWedgedMs: 3 * 60_000,
+  heartbeatStaleMs: 2 * 60_000,
+};
+
+const T0 = new Date(2026, 7, 1, 12, 0, 0).getTime();
+const min = (n: number) => n * 60_000;
+
+function baseInput(overrides: Partial<FleetHealthInput> = {}): FleetHealthInput {
+  return {
+    nowMs: T0,
+    owedReviews: [],
+    slots: { total: 2, occupied: 0 },
+    pickupPausedWithFreeSlot: false,
+    queuedWhileSlotFree: [],
+    queueRunning: true,
+    queueLastProgressMs: T0,
+    ...overrides,
+  };
+}
+
+function owed(overrides: Partial<OwedReviewObservation> = {}): OwedReviewObservation {
+  return {
+    runId: "run-1",
+    issueRef: "lennons301/lemons#34",
+    prNumber: 55,
+    prUrl: "https://github.com/lennons301/lemons/pull/55",
+    reason: "a slot is held by an interactive session (1/1 busy)",
+    ...overrides,
+  };
+}
+
+function evaluate(input: FleetHealthInput, prev: FleetHealthState = EMPTY_FLEET_HEALTH_STATE) {
+  return evaluateFleetHealth(input, prev, THRESHOLDS);
+}
+
+describe("evaluateFleetHealth — owed-review stalled", () => {
+  it("does not fire before the threshold, but seeds the since-timer", () => {
+    const { signals, announce, state } = evaluate(
+      baseInput({ owedReviews: [owed()], slots: { total: 1, occupied: 1 } })
+    );
+    expect(signals.owedReviewStalls).toEqual([]);
+    expect(announce.owedReviewStalls).toEqual([]);
+    expect(state.owedReviewSinceMs["run-1"]).toBe(T0);
+  });
+
+  it("fires — card + one-time ping — once the review has been owed past the threshold", () => {
+    const first = evaluate(
+      baseInput({ owedReviews: [owed()], slots: { total: 1, occupied: 1 } })
+    );
+    // 31 minutes later, still owed, slot still held.
+    const { signals, announce } = evaluate(
+      baseInput({
+        nowMs: T0 + min(31),
+        owedReviews: [owed()],
+        slots: { total: 1, occupied: 1 },
+      }),
+      first.state
+    );
+    expect(signals.owedReviewStalls).toHaveLength(1);
+    expect(signals.owedReviewStalls[0]).toMatchObject({
+      runId: "run-1",
+      prNumber: 55,
+      prUrl: "https://github.com/lennons301/lemons/pull/55",
+    });
+    expect(signals.owedReviewStalls[0].stalledForMs).toBe(min(31));
+    // First crossing announces exactly once.
+    expect(announce.owedReviewStalls).toHaveLength(1);
+  });
+
+  it("keeps the card but does not re-ping on the next stalled sweep", () => {
+    const s1 = evaluate(baseInput({ owedReviews: [owed()], slots: { total: 1, occupied: 1 } }));
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(31), owedReviews: [owed()], slots: { total: 1, occupied: 1 } }),
+      s1.state
+    );
+    const s3 = evaluate(
+      baseInput({ nowMs: T0 + min(32), owedReviews: [owed()], slots: { total: 1, occupied: 1 } }),
+      s2.state
+    );
+    expect(s3.signals.owedReviewStalls).toHaveLength(1); // card persists
+    expect(s3.announce.owedReviewStalls).toEqual([]); // ping is one-shot
+  });
+
+  it("clears the card and re-arms once the run is no longer owed (review landed/finalized)", () => {
+    const s1 = evaluate(baseInput({ owedReviews: [owed()], slots: { total: 1, occupied: 1 } }));
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(31), owedReviews: [owed()], slots: { total: 1, occupied: 1 } }),
+      s1.state
+    );
+    // Review lands: the run drops out of the owed set.
+    const cleared = evaluate(baseInput({ nowMs: T0 + min(40), owedReviews: [] }), s2.state);
+    expect(cleared.signals.owedReviewStalls).toEqual([]);
+    expect(cleared.state.owedReviewSinceMs).toEqual({});
+    expect(cleared.state.owedReviewAnnounced).toEqual([]);
+    // If it becomes owed again later, its timer restarts (fresh 30-min clock).
+    const reArmed = evaluate(
+      baseInput({ nowMs: T0 + min(41), owedReviews: [owed()], slots: { total: 1, occupied: 1 } }),
+      cleared.state
+    );
+    expect(reArmed.signals.owedReviewStalls).toEqual([]);
+    expect(reArmed.state.owedReviewSinceMs["run-1"]).toBe(T0 + min(41));
+  });
+
+  it("times each owed run independently", () => {
+    const a = owed({ runId: "run-a", prNumber: 1 });
+    const b = owed({ runId: "run-b", prNumber: 2 });
+    const s1 = evaluate(baseInput({ owedReviews: [a], slots: { total: 1, occupied: 1 } }));
+    // run-b appears 20 min later.
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(20), owedReviews: [a, b], slots: { total: 1, occupied: 1 } }),
+      s1.state
+    );
+    // At T0+31, run-a is stalled (31m) but run-b is not (11m).
+    const s3 = evaluate(
+      baseInput({ nowMs: T0 + min(31), owedReviews: [a, b], slots: { total: 1, occupied: 1 } }),
+      s2.state
+    );
+    expect(s3.signals.owedReviewStalls.map((s) => s.runId)).toEqual(["run-a"]);
+  });
+});
+
+describe("evaluateFleetHealth — pickup wedged", () => {
+  const queued = [{ taskId: "task-9", label: "review: lennons301/lemons#34" }];
+
+  it("does not fire before the debounce window", () => {
+    const { signals, announce, state } = evaluate(
+      baseInput({ slots: { total: 2, occupied: 1 }, queuedWhileSlotFree: queued })
+    );
+    expect(signals.pickupWedged).toBeNull();
+    expect(announce.pickupWedged).toBeNull();
+    expect(state.pickupWedgedSinceMs).toBe(T0);
+  });
+
+  it("fires once a task has been queued past the threshold while a slot is free", () => {
+    const s1 = evaluate(
+      baseInput({ slots: { total: 2, occupied: 1 }, queuedWhileSlotFree: queued })
+    );
+    const s2 = evaluate(
+      baseInput({
+        nowMs: T0 + min(4),
+        slots: { total: 2, occupied: 1 },
+        queuedWhileSlotFree: queued,
+      }),
+      s1.state
+    );
+    expect(s2.signals.pickupWedged).not.toBeNull();
+    expect(s2.signals.pickupWedged!.wedgedForMs).toBe(min(4));
+    expect(s2.signals.pickupWedged!.detail).toContain("review: lennons301/lemons#34");
+    expect(s2.signals.pickupWedged!.detail).toContain("1 slot free");
+    expect(s2.announce.pickupWedged).not.toBeNull(); // one-time ping
+    // Deduped on the next wedged sweep.
+    const s3 = evaluate(
+      baseInput({
+        nowMs: T0 + min(5),
+        slots: { total: 2, occupied: 1 },
+        queuedWhileSlotFree: queued,
+      }),
+      s2.state
+    );
+    expect(s3.signals.pickupWedged).not.toBeNull();
+    expect(s3.announce.pickupWedged).toBeNull();
+  });
+
+  it("fires for pickup paused (no-slots) while a slot is free — the orphan-wedge shape", () => {
+    const s1 = evaluate(
+      baseInput({ slots: { total: 2, occupied: 1 }, pickupPausedWithFreeSlot: true })
+    );
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(4), slots: { total: 2, occupied: 1 }, pickupPausedWithFreeSlot: true }),
+      s1.state
+    );
+    expect(s2.signals.pickupWedged).not.toBeNull();
+    expect(s2.signals.pickupWedged!.detail).toContain("pickup is paused (no-slots)");
+  });
+
+  it("does not fire when all slots are busy (no free slot to dispatch into)", () => {
+    const { signals } = evaluate(
+      baseInput({ slots: { total: 1, occupied: 1 }, queuedWhileSlotFree: [] })
+    );
+    expect(signals.pickupWedged).toBeNull();
+  });
+
+  it("resets the timer and re-arms once the wedge clears", () => {
+    const s1 = evaluate(
+      baseInput({ slots: { total: 2, occupied: 1 }, queuedWhileSlotFree: queued })
+    );
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(4), slots: { total: 2, occupied: 1 }, queuedWhileSlotFree: queued }),
+      s1.state
+    );
+    // Queue drains — no longer wedged.
+    const cleared = evaluate(
+      baseInput({ nowMs: T0 + min(5), slots: { total: 2, occupied: 2 } }),
+      s2.state
+    );
+    expect(cleared.signals.pickupWedged).toBeNull();
+    expect(cleared.state.pickupWedgedSinceMs).toBeNull();
+    expect(cleared.state.pickupWedgedAnnounced).toBe(false);
+  });
+});
+
+describe("evaluateFleetHealth — stale queue heartbeat", () => {
+  it("does not fire for a healthy idle loop (fresh heartbeat)", () => {
+    const { signals, announce } = evaluate(
+      baseInput({ nowMs: T0 + min(5), queueLastProgressMs: T0 + min(5) - 10_000 })
+    );
+    expect(signals.queueStale).toBeNull();
+    expect(announce.queueStale).toBeNull();
+  });
+
+  it("fires once the heartbeat is stale past the threshold", () => {
+    const { signals, announce } = evaluate(
+      baseInput({ nowMs: T0 + min(5), queueLastProgressMs: T0 + min(2) })
+    );
+    expect(signals.queueStale).not.toBeNull();
+    expect(signals.queueStale!.staleForMs).toBe(min(3));
+    expect(announce.queueStale).not.toBeNull();
+  });
+
+  it("keeps the card but does not re-ping while stale, then re-arms on recovery", () => {
+    const s1 = evaluate(baseInput({ nowMs: T0 + min(5), queueLastProgressMs: T0 + min(2) }));
+    const s2 = evaluate(
+      baseInput({ nowMs: T0 + min(6), queueLastProgressMs: T0 + min(2) }),
+      s1.state
+    );
+    expect(s2.signals.queueStale).not.toBeNull();
+    expect(s2.announce.queueStale).toBeNull(); // deduped
+    // Loop recovers — heartbeat fresh again.
+    const recovered = evaluate(
+      baseInput({ nowMs: T0 + min(7), queueLastProgressMs: T0 + min(7) }),
+      s2.state
+    );
+    expect(recovered.signals.queueStale).toBeNull();
+    expect(recovered.state.queueStaleAnnounced).toBe(false);
+    // A later stall re-pings.
+    const again = evaluate(
+      baseInput({ nowMs: T0 + min(12), queueLastProgressMs: T0 + min(7) }),
+      recovered.state
+    );
+    expect(again.announce.queueStale).not.toBeNull();
+  });
+
+  it("never alarms when the queue loop is not running (boot/shutdown, not a wedge)", () => {
+    const { signals } = evaluate(
+      baseInput({ nowMs: T0 + min(10), queueRunning: false, queueLastProgressMs: T0 })
+    );
+    expect(signals.queueStale).toBeNull();
+  });
+
+  it("never alarms before the loop's first tick (null heartbeat)", () => {
+    const { signals } = evaluate(
+      baseInput({ nowMs: T0 + min(10), queueRunning: true, queueLastProgressMs: null })
+    );
+    expect(signals.queueStale).toBeNull();
+  });
+});

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -11,7 +11,7 @@ import {
   MAX_ATTEMPTS,
   MAX_INTEGRATION_ATTEMPTS,
 } from "../orchestrator/autonomy/budgets";
-import type { FleetHealthSignals } from "./health";
+import { formatDuration, type FleetHealthSignals } from "./health";
 
 export interface FleetRows {
   /** Current time — passed in, never read inside */
@@ -258,16 +258,6 @@ function issueUrl(githubIssue: string): string | null {
 function repoTicket(issueRef: string): string {
   const match = issueRef.match(/^[^/#]+\/([^/#]+)#(\d+)$/);
   return match ? `${match[1]} #${match[2]}` : issueRef;
-}
-
-/** A coarse "34m" / "1h 5m" for a needs-you body. Health durations are only ever
- * minutes-to-hours and shown at sweep granularity, so seconds are noise. */
-function formatDuration(ms: number): string {
-  const mins = Math.floor(ms / 60_000);
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  const rem = mins % 60;
-  return rem ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
 const RECENT_WINDOW_DAYS = 7;

--- a/src/lib/fleet/fleet-view.ts
+++ b/src/lib/fleet/fleet-view.ts
@@ -11,6 +11,7 @@ import {
   MAX_ATTEMPTS,
   MAX_INTEGRATION_ATTEMPTS,
 } from "../orchestrator/autonomy/budgets";
+import type { FleetHealthSignals } from "./health";
 
 export interface FleetRows {
   /** Current time — passed in, never read inside */
@@ -34,6 +35,13 @@ export interface FleetRows {
    * observed; a project absent from the map = not yet observed (both fall back
    * to the 7-day window). See {@link buildFleetView}'s exhausted filter. */
   needsHumanByProject: Record<string, string[]> | null;
+  /** The sweep's last fleet-health evaluation (issue #126) — owed-review
+   * stalls, a wedged pickup, a stale queue heartbeat. null = never evaluated
+   * (no sweep yet), which renders no health cards. Computed by the sweep, not
+   * derivable from DB rows alone (it needs live orchestrator state: the queue
+   * heartbeat and occupied-vs-total slots), so it arrives via a store like the
+   * backlog/needs-human observations. */
+  fleetHealth: FleetHealthSignals | null;
 }
 
 export interface FleetProjectRow {
@@ -133,7 +141,12 @@ export type NeedsYouCause =
   | "conflict"
   | "exhausted"
   | "cap"
-  | "preflight";
+  | "preflight"
+  /** Fleet-health watchdog (issue #126): an owed review that never started, a
+   * wedged pickup, a queue poll loop gone quiet. */
+  | "review-stalled"
+  | "pickup-wedged"
+  | "queue-stale";
 
 export interface NeedsYouItem {
   cause: NeedsYouCause;
@@ -238,6 +251,23 @@ function issueUrl(githubIssue: string): string | null {
   return match
     ? `https://github.com/${match[1]}/${match[2]}/issues/${match[3]}`
     : null;
+}
+
+/** "owner/repo#34" -> "repo #34" — a compact context label for a fleet-health
+ * card, which has no run/project row to hand (the signal carries only a ref). */
+function repoTicket(issueRef: string): string {
+  const match = issueRef.match(/^[^/#]+\/([^/#]+)#(\d+)$/);
+  return match ? `${match[1]} #${match[2]}` : issueRef;
+}
+
+/** A coarse "34m" / "1h 5m" for a needs-you body. Health durations are only ever
+ * minutes-to-hours and shown at sweep granularity, so seconds are noise. */
+function formatDuration(ms: number): string {
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
 const RECENT_WINDOW_DAYS = 7;
@@ -406,6 +436,47 @@ export function buildFleetView(rows: FleetRows): FleetView {
       context: `$${todayUsd.toFixed(2)} / $${rows.dailyCapUsd.toFixed(2)} today`,
       body: "Autonomous pickup paused until midnight — interactive work unaffected",
       action: null,
+    });
+  }
+
+  // Fleet-health watchdog (issue #126): the machinery itself has stalled, so
+  // these outrank any single run's question or sign-off. A dead queue or a
+  // wedged pickup halts the whole frontier (the parent #115 incident hid one for
+  // ~1.5h behind a dashboard that read healthy); an owed review that never
+  // started strands a specific PR. All red — nothing progresses until you look.
+  const health = rows.fleetHealth;
+  if (health?.queueStale) {
+    needsYou.push({
+      cause: "queue-stale",
+      severity: "red",
+      context: "queue loop",
+      body: `Queue poll loop hasn't made progress for ${formatDuration(
+        health.queueStale.staleForMs
+      )} — dispatch is likely wedged`,
+      action: null,
+    });
+  }
+  if (health?.pickupWedged) {
+    needsYou.push({
+      cause: "pickup-wedged",
+      severity: "red",
+      context: "pickup",
+      body: `${health.pickupWedged.detail} for ${formatDuration(
+        health.pickupWedged.wedgedForMs
+      )}`,
+      action: null,
+    });
+  }
+  for (const stall of health?.owedReviewStalls ?? []) {
+    const prTag = `PR #${stall.prNumber}`;
+    needsYou.push({
+      cause: "review-stalled",
+      severity: "red",
+      context: `${repoTicket(stall.issueRef)} · ${prTag}`,
+      body: `Review hasn't started for ${formatDuration(
+        stall.stalledForMs
+      )} — ${stall.reason}`,
+      action: stall.prUrl ? { label: `Open ${prTag}`, href: stall.prUrl } : null,
     });
   }
 

--- a/src/lib/fleet/health-store.ts
+++ b/src/lib/fleet/health-store.ts
@@ -1,0 +1,28 @@
+/**
+ * Last fleet-health evaluation from the sweep (issue #126). The autonomy sweep
+ * evaluates the three health signals every 30s and records them here; the read
+ * model (dashboard + digest) surfaces them as needs-you cards. Backed by
+ * globalThis for the same reason as the backlog / needs-human stores (see
+ * fleet/backlog.ts, fleet/needs-human.ts): a route handler may load a separate
+ * module instance from the orchestrator context that writes the observation.
+ *
+ * Null until the first sweep records — no health cards render before then, and
+ * a redeploy re-arms every signal (acceptable for a watchdog, matching the
+ * in-memory saturation/cap announcement flags in the sweep).
+ */
+
+import type { FleetHealthSignals } from "./health";
+
+const globalForFleetHealth = globalThis as unknown as {
+  __interludeFleetHealth?: FleetHealthSignals | null;
+};
+
+/** Record the current health signals from a sweep. */
+export function recordFleetHealth(signals: FleetHealthSignals): void {
+  globalForFleetHealth.__interludeFleetHealth = signals;
+}
+
+/** The last recorded health signals, or null if no sweep has run yet. */
+export function getFleetHealth(): FleetHealthSignals | null {
+  return globalForFleetHealth.__interludeFleetHealth ?? null;
+}

--- a/src/lib/fleet/health.ts
+++ b/src/lib/fleet/health.ts
@@ -76,12 +76,7 @@ export interface FleetHealthInput {
   queueLastProgressMs: number | null;
 }
 
-export interface OwedReviewStall {
-  runId: string;
-  issueRef: string;
-  prNumber: number;
-  prUrl: string | null;
-  reason: string;
+export interface OwedReviewStall extends OwedReviewObservation {
   stalledForMs: number;
 }
 
@@ -167,14 +162,7 @@ export function evaluateFleetHealth(
     const stalledForMs = now - since;
     if (stalledForMs < thresholds.owedReviewStallMs) continue;
 
-    const stall: OwedReviewStall = {
-      runId: obs.runId,
-      issueRef: obs.issueRef,
-      prNumber: obs.prNumber,
-      prUrl: obs.prUrl,
-      reason: obs.reason,
-      stalledForMs,
-    };
+    const stall: OwedReviewStall = { ...obs, stalledForMs };
     owedReviewStalls.push(stall);
     owedReviewAnnounced.push(obs.runId);
     if (!prev.owedReviewAnnounced.includes(obs.runId)) announcedStalls.push(stall);
@@ -233,6 +221,18 @@ export function evaluateFleetHealth(
       queueStaleAnnounced,
     },
   };
+}
+
+/** A coarse "34m" / "1h 30m" for a health duration. Shared by the dashboard
+ * card and the Discord ping so the same `stalledForMs` never renders a minute
+ * apart between them (both floor). Durations here are minutes-to-hours and shown
+ * at 30s sweep granularity, so seconds are noise. */
+export function formatDuration(ms: number): string {
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem ? `${hrs}h ${rem}m` : `${hrs}h`;
 }
 
 function pickupWedgeDetail(input: FleetHealthInput): string {

--- a/src/lib/fleet/health.ts
+++ b/src/lib/fleet/health.ts
@@ -1,0 +1,250 @@
+/**
+ * Fleet-health watchdog (issue #126). Three signals make a silent pickup or
+ * review stall loud instead of invisible (the parent #115 incident hid a wedged
+ * frontier behind a dashboard that showed a free slot and ready tickets):
+ *
+ *   (a) owed-review stalled — a run awaiting review whose pass never started;
+ *   (b) pickup wedged — a free slot but queued work not dispatching;
+ *   (c) stale queue heartbeat — the 2s poll loop stopped making progress.
+ *
+ * `evaluateFleetHealth` is pure. It takes the current observations, the prior
+ * evaluation's memory (per-signal since-timers plus which signals were already
+ * announced) and the thresholds, and returns:
+ *   - `signals`  — every currently-active problem, one dashboard needs-you card;
+ *   - `announce` — the subset that JUST crossed threshold, one Discord ping each
+ *                  (so a ping fires once per occurrence, not every 30s sweep);
+ *   - `state`    — the memory to carry into the next evaluation.
+ *
+ * The sweep holds `state` in a module variable across sweeps, exactly like the
+ * saturation/daily-cap announcement flags it sits beside. Kept here in the
+ * fleet read-model dir, and pure, so the dashboard, the digest and the Discord
+ * ping can never disagree about the state of the fleet.
+ */
+
+export interface FleetHealthThresholds {
+  /** A run owed a review whose pass hasn't started for longer than this is
+   * stalled (default 30 min). */
+  owedReviewStallMs: number;
+  /** Pickup wedged — a free slot but queued work not dispatching, or pickup
+   * paused no-slots while a slot is free — for longer than this is surfaced
+   * (default 3 min). The debounce also stops a single-sweep race (a slot just
+   * freed, a claim about to dispatch) from flapping the card. */
+  pickupWedgedMs: number;
+  /** The queue poll loop going without progress longer than this is stale
+   * (default 2 min ≈ 60 missed 2s polls). */
+  heartbeatStaleMs: number;
+}
+
+/** A run owed a review whose pass has not started — no review container is
+ * running: either no review task exists yet, or one is queued but starved of a
+ * slot. A review that is actually running is progressing, not stalled, and is
+ * deliberately excluded upstream. */
+export interface OwedReviewObservation {
+  runId: string;
+  /** "owner/repo#n" */
+  issueRef: string;
+  prNumber: number;
+  prUrl: string | null;
+  /** Why the review can't run right now — e.g. "a slot is held by an
+   * interactive session". Surfaced verbatim on the card. */
+  reason: string;
+}
+
+/** A queued task that could take a slot while one sits free. */
+export interface QueuedTaskObservation {
+  taskId: string;
+  /** Human context, e.g. "review: owner/repo#34". */
+  label: string;
+}
+
+export interface FleetHealthInput {
+  /** Evaluation time in ms. */
+  nowMs: number;
+  /** Runs owed a review with no review pass running. */
+  owedReviews: OwedReviewObservation[];
+  slots: { total: number; occupied: number };
+  /** Pickup paused for no-slots (claimableSlots === 0) while a slot is free —
+   * the accounting-orphan wedge shape (#115). */
+  pickupPausedWithFreeSlot: boolean;
+  /** Queued dispatchable tasks observed while a slot is free — the exact
+   * incident shape: a review left queued while a slot sits open. */
+  queuedWhileSlotFree: QueuedTaskObservation[];
+  /** Whether the 2s queue poll loop is running at all. A stopped loop is boot
+   * or shutdown, not a wedge, so it never alarms. */
+  queueRunning: boolean;
+  /** The queue loop's last-progress stamp (ms); null before its first tick. */
+  queueLastProgressMs: number | null;
+}
+
+export interface OwedReviewStall {
+  runId: string;
+  issueRef: string;
+  prNumber: number;
+  prUrl: string | null;
+  reason: string;
+  stalledForMs: number;
+}
+
+export interface PickupWedge {
+  /** Human-readable specifics for the card/ping body. */
+  detail: string;
+  wedgedForMs: number;
+}
+
+export interface QueueStale {
+  staleForMs: number;
+}
+
+/** The currently-active health problems — one dashboard needs-you card each. */
+export interface FleetHealthSignals {
+  owedReviewStalls: OwedReviewStall[];
+  pickupWedged: PickupWedge | null;
+  queueStale: QueueStale | null;
+}
+
+/** The subset that just became active this evaluation — one Discord ping each. */
+export interface FleetHealthAnnounce {
+  owedReviewStalls: OwedReviewStall[];
+  pickupWedged: PickupWedge | null;
+  queueStale: QueueStale | null;
+}
+
+/** Cross-sweep memory: when each condition first became true, and which have
+ * already been announced (so a ping fires once per occurrence, not per sweep). */
+export interface FleetHealthState {
+  /** runId -> first-seen owed-and-not-started (ms). A run absent from the next
+   * evaluation's owed set is not re-seeded, so its timer resets — the card and
+   * the dedup both clear automatically when the review starts, lands, or the run
+   * finalizes. */
+  owedReviewSinceMs: Record<string, number>;
+  /** runIds whose stall was already pinged; kept while still stalled, pruned
+   * when the run is no longer owed. */
+  owedReviewAnnounced: string[];
+  /** First-seen wedged (ms), or null when not wedged. */
+  pickupWedgedSinceMs: number | null;
+  pickupWedgedAnnounced: boolean;
+  queueStaleAnnounced: boolean;
+}
+
+export const EMPTY_FLEET_HEALTH_STATE: FleetHealthState = {
+  owedReviewSinceMs: {},
+  owedReviewAnnounced: [],
+  pickupWedgedSinceMs: null,
+  pickupWedgedAnnounced: false,
+  queueStaleAnnounced: false,
+};
+
+export const DEFAULT_FLEET_HEALTH_THRESHOLDS: FleetHealthThresholds = {
+  owedReviewStallMs: 30 * 60_000,
+  pickupWedgedMs: 3 * 60_000,
+  heartbeatStaleMs: 2 * 60_000,
+};
+
+export interface FleetHealthEvaluation {
+  signals: FleetHealthSignals;
+  announce: FleetHealthAnnounce;
+  state: FleetHealthState;
+}
+
+export function evaluateFleetHealth(
+  input: FleetHealthInput,
+  prev: FleetHealthState,
+  thresholds: FleetHealthThresholds
+): FleetHealthEvaluation {
+  const now = input.nowMs;
+
+  // --- (a) Owed-review stalled -------------------------------------------
+  const owedReviewSinceMs: Record<string, number> = {};
+  const owedReviewStalls: OwedReviewStall[] = [];
+  const announcedStalls: OwedReviewStall[] = [];
+  const owedReviewAnnounced: string[] = [];
+  for (const obs of input.owedReviews) {
+    // Carry the first-seen time forward. A run that dropped out of the owed set
+    // (review started/landed, or the run finalized) is simply not re-seeded, so
+    // its timer and its announced-flag reset and the card clears on its own.
+    const since = prev.owedReviewSinceMs[obs.runId] ?? now;
+    owedReviewSinceMs[obs.runId] = since;
+    const stalledForMs = now - since;
+    if (stalledForMs < thresholds.owedReviewStallMs) continue;
+
+    const stall: OwedReviewStall = {
+      runId: obs.runId,
+      issueRef: obs.issueRef,
+      prNumber: obs.prNumber,
+      prUrl: obs.prUrl,
+      reason: obs.reason,
+      stalledForMs,
+    };
+    owedReviewStalls.push(stall);
+    owedReviewAnnounced.push(obs.runId);
+    if (!prev.owedReviewAnnounced.includes(obs.runId)) announcedStalls.push(stall);
+  }
+
+  // --- (b) Pickup wedged --------------------------------------------------
+  const slotFree = input.slots.occupied < input.slots.total;
+  const wedgedNow =
+    slotFree &&
+    (input.pickupPausedWithFreeSlot || input.queuedWhileSlotFree.length > 0);
+  let pickupWedgedSinceMs: number | null = null;
+  let pickupWedged: PickupWedge | null = null;
+  let pickupWedgedAnnounced = false;
+  let announcePickupWedged: PickupWedge | null = null;
+  if (wedgedNow) {
+    pickupWedgedSinceMs = prev.pickupWedgedSinceMs ?? now;
+    const wedgedForMs = now - pickupWedgedSinceMs;
+    if (wedgedForMs >= thresholds.pickupWedgedMs) {
+      pickupWedged = { detail: pickupWedgeDetail(input), wedgedForMs };
+      pickupWedgedAnnounced = true;
+      if (!prev.pickupWedgedAnnounced) announcePickupWedged = pickupWedged;
+    } else {
+      // Still inside the debounce window: carry the (still-false) announced flag.
+      pickupWedgedAnnounced = prev.pickupWedgedAnnounced;
+    }
+  }
+  // else: not wedged — since-timer and announced flag stay reset, re-arming.
+
+  // --- (c) Stale queue heartbeat -----------------------------------------
+  let queueStale: QueueStale | null = null;
+  let queueStaleAnnounced = false;
+  let announceQueueStale: QueueStale | null = null;
+  if (input.queueRunning && input.queueLastProgressMs != null) {
+    const staleForMs = now - input.queueLastProgressMs;
+    if (staleForMs >= thresholds.heartbeatStaleMs) {
+      queueStale = { staleForMs };
+      queueStaleAnnounced = true;
+      if (!prev.queueStaleAnnounced) announceQueueStale = queueStale;
+    }
+  }
+  // A healthy idle loop still completes a cycle every 2s, keeping the stamp
+  // fresh — only a hung or dead loop goes stale, so an idle fleet never alarms.
+
+  return {
+    signals: { owedReviewStalls, pickupWedged, queueStale },
+    announce: {
+      owedReviewStalls: announcedStalls,
+      pickupWedged: announcePickupWedged,
+      queueStale: announceQueueStale,
+    },
+    state: {
+      owedReviewSinceMs,
+      owedReviewAnnounced,
+      pickupWedgedSinceMs,
+      pickupWedgedAnnounced,
+      queueStaleAnnounced,
+    },
+  };
+}
+
+function pickupWedgeDetail(input: FleetHealthInput): string {
+  const free = input.slots.total - input.slots.occupied;
+  const freeSlots = `${free} slot${free === 1 ? "" : "s"} free`;
+  if (input.queuedWhileSlotFree.length > 0) {
+    const first = input.queuedWhileSlotFree[0];
+    const more =
+      input.queuedWhileSlotFree.length > 1
+        ? ` (+${input.queuedWhileSlotFree.length - 1} more)`
+        : "";
+    return `${freeSlots} but "${first.label}" has not dispatched${more}`;
+  }
+  return `${freeSlots} but pickup is paused (no-slots)`;
+}

--- a/src/lib/fleet/rows.ts
+++ b/src/lib/fleet/rows.ts
@@ -11,6 +11,7 @@ import { getConfig } from "../config";
 import { getCapacity } from "../orchestrator/capacity";
 import { getBacklogByProject } from "./backlog";
 import { getNeedsHumanByProject } from "./needs-human";
+import { getFleetHealth } from "./health-store";
 import { DAILY_AUTONOMOUS_CAP_USD } from "../orchestrator/autonomy/budgets";
 import {
   buildFleetView,
@@ -118,6 +119,9 @@ export async function loadFleetRows(now: Date): Promise<FleetRows> {
     // Open `ready-for-human` refs from the same sweep; null (never observed)
     // leaves the exhausted needs-you cards on the 7-day window alone.
     needsHumanByProject: getNeedsHumanByProject(),
+    // The sweep's last fleet-health evaluation (issue #126); null until the
+    // first sweep, which renders no health cards.
+    fleetHealth: getFleetHealth(),
   };
 }
 

--- a/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/review-tasks.test.ts
@@ -7,6 +7,7 @@ import {
   inFlightReviewTaskId,
   queuedTasksReservingSlots,
   reapDeadReviewTasks,
+  runningReviewTaskId,
   type Db,
 } from "../review-tasks";
 import { decideNext, passOutcomeSnapshot, type AutonomySnapshot } from "../decide";
@@ -175,6 +176,31 @@ describe("review-pass in-flight + ungraceful-death reaping (issue #95)", () => {
       (a) => a.type === "startReview"
     );
     expect(startReviews).toEqual([]);
+  });
+});
+
+describe("runningReviewTaskId — only a running review counts as started (issue #126)", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = createTestDb().db;
+    seedReviewingRun(db);
+  });
+
+  it("returns null when the review is only queued (owed, not started)", () => {
+    const taskId = seedReviewTask(db, { status: "queued", containerName: null });
+    // A queued review still blocks a duplicate...
+    expect(inFlightReviewTaskId(db, "run-1")).toBe(taskId);
+    // ...but has not started, so the owed-review watchdog sees no running pass.
+    expect(runningReviewTaskId(db, "run-1")).toBeNull();
+  });
+
+  it("returns the task id once the review is running", () => {
+    const taskId = seedReviewTask(db, { status: "running" });
+    expect(runningReviewTaskId(db, "run-1")).toBe(taskId);
+  });
+
+  it("returns null when the run has no review task at all", () => {
+    expect(runningReviewTaskId(db, "run-1")).toBeNull();
   });
 });
 

--- a/src/lib/orchestrator/autonomy/budgets.ts
+++ b/src/lib/orchestrator/autonomy/budgets.ts
@@ -104,3 +104,16 @@ export const MAX_UNPARSEABLE_REVIEW_RETRIES = 1;
  * until local midnight; interactive tasks (no run row) are exempt by
  * construction. */
 export const DAILY_AUTONOMOUS_CAP_USD = 500;
+
+/**
+ * Fleet-health watchdog thresholds (issue #126). Defaults chosen in the parent
+ * design (#115): a review owed for over half an hour, a pickup wedged for a few
+ * minutes, and a queue poll loop (which should tick every 2s) gone quiet for a
+ * couple of minutes are each surfaced as a needs-you card + one Discord ping.
+ * Env-overridable in minutes via config.ts (`OWED_REVIEW_STALL_MINUTES`,
+ * `PICKUP_WEDGED_MINUTES`, `QUEUE_HEARTBEAT_STALE_MINUTES`); kept here as ms so
+ * the leaf that holds every tunable also holds these.
+ */
+export const DEFAULT_OWED_REVIEW_STALL_MS = 30 * 60_000;
+export const DEFAULT_PICKUP_WEDGED_MS = 3 * 60_000;
+export const DEFAULT_QUEUE_HEARTBEAT_STALE_MS = 2 * 60_000;

--- a/src/lib/orchestrator/autonomy/review-tasks.ts
+++ b/src/lib/orchestrator/autonomy/review-tasks.ts
@@ -65,6 +65,29 @@ export function inFlightReviewTaskId(db: Db, runId: string): string | null {
   return task?.id ?? null;
 }
 
+/**
+ * The id of a review task for this run whose container is actually *running*,
+ * or null. Distinct from {@link inFlightReviewTaskId}, which also counts a
+ * `queued` task: a review that is merely queued has not started — it may be
+ * starved of a slot — so the owed-review-stalled watchdog (issue #126) treats
+ * it as not-yet-started work, while inFlightReviewTaskId still (correctly)
+ * blocks a duplicate from being queued.
+ */
+export function runningReviewTaskId(db: Db, runId: string): string | null {
+  const task = db
+    .select({ id: tasks.id })
+    .from(tasks)
+    .where(
+      and(
+        eq(tasks.runId, runId),
+        eq(tasks.kind, "review"),
+        eq(tasks.status, "running")
+      )
+    )
+    .get();
+  return task?.id ?? null;
+}
+
 /** A task some path terminalized — returned so the caller can drop its
  * in-memory session entry and remove any container it held. */
 export interface TerminalizedTask {

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -33,6 +33,9 @@ import {
   notifyDailyCapReached,
   notifyGateConfigError,
   notifyIntegrationEscalation,
+  notifyOwedReviewStalled,
+  notifyPickupWedged,
+  notifyQueueStale,
   notifyReviewBlocked,
   notifySlotsSaturated,
   notifyTriageRecommendation,
@@ -40,8 +43,16 @@ import {
 import { recordBacklog } from "../../fleet/backlog";
 import { isContainerRunning, removeContainerByName } from "../../docker/container-manager";
 import { recordNeedsHuman } from "../../fleet/needs-human";
+import {
+  EMPTY_FLEET_HEALTH_STATE,
+  evaluateFleetHealth,
+  type FleetHealthInput,
+  type FleetHealthState,
+  type QueuedTaskObservation,
+} from "../../fleet/health";
+import { recordFleetHealth } from "../../fleet/health-store";
 import { getCapacity } from "../capacity";
-import { occupiedSlots } from "../queue";
+import { getQueueLastProgress, isQueueRunning, occupiedSlots } from "../queue";
 import { startOfLocalDay, todayAutonomousSpendUsd } from "../spend";
 import { getActiveTasks, isParked, releaseParkedImplementTask } from "../turn-manager";
 import {
@@ -87,6 +98,7 @@ import {
   inFlightReviewTaskId,
   queuedTasksReservingSlots,
   reapDeadReviewTasks,
+  runningReviewTaskId,
 } from "./review-tasks";
 import {
   DAILY_AUTONOMOUS_CAP_USD,
@@ -120,6 +132,11 @@ const ACTIVE_RUN_STATUS_SET = new Set<string>(ACTIVE_RUN_STATUSES);
 let sweepInterval: ReturnType<typeof setInterval> | null = null;
 let sweeping = false;
 let saturationAnnounced = false;
+// Fleet-health watchdog memory (issue #126): per-signal since-timers plus which
+// signals were already pinged, carried across sweeps so each stall fires one
+// Discord ping, not one per 30s sweep. In-memory like the saturation/cap flags
+// above — a redeploy re-arms, which is fine for a watchdog.
+let fleetHealthState: FleetHealthState = EMPTY_FLEET_HEALTH_STATE;
 // The local day (startOfLocalDay ms) whose cap pause was announced — keyed by
 // day rather than a boolean so the announcement re-arms itself at midnight.
 let dailyCapAnnouncedDay: number | null = null;
@@ -189,9 +206,150 @@ export async function runAutonomySweep(): Promise<void> {
     } else if (actions.some((a) => a.type === "notify" && a.event === "slots-saturated")) {
       saturationAnnounced = true;
     }
+
+    // Fleet-health watchdog (issue #126): surface silent pickup/review stalls.
+    await evaluateFleetHealthSignals(snapshot, actions);
   } finally {
     sweeping = false;
   }
+}
+
+/**
+ * The fleet-health watchdog (issue #126). After a sweep has decided and acted,
+ * evaluate the three signals that make a silent stall loud — an owed review that
+ * never started, a wedged pickup, a quiet queue loop — record them for the
+ * dashboard's needs-you cards, and fire a one-time Discord ping for any that
+ * just crossed threshold. State is held across sweeps in `fleetHealthState`, the
+ * same in-memory debounce the saturation/cap announcements use.
+ */
+async function evaluateFleetHealthSignals(
+  snapshot: AutonomySnapshot,
+  actions: Action[]
+): Promise<void> {
+  const input = gatherFleetHealthInput(snapshot, actions);
+  const { signals, announce, state } = evaluateFleetHealth(
+    input,
+    fleetHealthState,
+    getConfig().fleetHealthThresholds
+  );
+  fleetHealthState = state;
+  recordFleetHealth(signals);
+
+  const channelId = getConfig().discordFleetChannelId;
+  for (const stall of announce.owedReviewStalls) {
+    console.warn(
+      `[autonomy] Owed review stalled: ${stall.issueRef} (PR #${stall.prNumber}) — ` +
+        `not started for ~${Math.round(stall.stalledForMs / 60_000)}m (${stall.reason})`
+    );
+    await notifyOwedReviewStalled(channelId, stall);
+  }
+  if (announce.pickupWedged) {
+    console.warn(
+      `[autonomy] Pickup wedged: ${announce.pickupWedged.detail} ` +
+        `(~${Math.round(announce.pickupWedged.wedgedForMs / 60_000)}m)`
+    );
+    await notifyPickupWedged(channelId, announce.pickupWedged);
+  }
+  if (announce.queueStale) {
+    console.warn(
+      `[autonomy] Queue heartbeat stale: no progress for ` +
+        `~${Math.round(announce.queueStale.staleForMs / 60_000)}m`
+    );
+    await notifyQueueStale(channelId, announce.queueStale);
+  }
+}
+
+/**
+ * Assemble the fleet-health input from a decided sweep. The reducer snapshot is
+ * left untouched (it carries only the facts the reducer needs); the extra facts
+ * the watchdog wants — a review task's *running* status, a run's PR URL, the
+ * queued tasks' labels, the live queue heartbeat — are read here.
+ */
+function gatherFleetHealthInput(
+  snapshot: AutonomySnapshot,
+  actions: Action[]
+): FleetHealthInput {
+  const slotFree = snapshot.slots.occupied < snapshot.slots.total;
+  const reason = owedReviewReason(snapshot.slots);
+
+  // A run owed a review with no review *container running* — no task at all, or
+  // one queued but starved of a slot. A running review is progressing, not
+  // stalled, and shows under Running instead.
+  const owedReviews = snapshot.awaitingReview
+    .filter((a) => runningReviewTaskId(db, a.runId) == null)
+    .map((a) => {
+      const run = db
+        .select({ prUrl: runs.pullRequestUrl })
+        .from(runs)
+        .where(eq(runs.id, a.runId))
+        .get();
+      return {
+        runId: a.runId,
+        issueRef: a.issueRef,
+        prNumber: a.prNumber,
+        prUrl: run?.prUrl ?? null,
+        reason,
+      };
+    });
+
+  // Queued dispatchable tasks observed while a slot sits free — the exact
+  // incident shape (#115): a review left queued while a slot is open.
+  const queuedWhileSlotFree = slotFree ? gatherQueuedDispatchable() : [];
+
+  const pickupPausedWithFreeSlot =
+    slotFree &&
+    actions.some((a) => a.type === "pausePickup" && a.reason === "no-slots");
+
+  return {
+    nowMs: snapshot.now.getTime(),
+    owedReviews,
+    slots: { total: snapshot.slots.total, occupied: snapshot.slots.occupied },
+    pickupPausedWithFreeSlot,
+    queuedWhileSlotFree,
+    queueRunning: isQueueRunning(),
+    queueLastProgressMs: getQueueLastProgress()?.getTime() ?? null,
+  };
+}
+
+/** Why an owed review can't run right now, for the stalled-review card body. */
+function owedReviewReason(slots: AutonomySnapshot["slots"]): string {
+  if (slots.occupied < slots.total) {
+    return "a slot is free but the review is not dispatching";
+  }
+  if (slots.occupants.some((o) => o.startsWith("interactive:"))) {
+    return `a slot is held by an interactive session (${slots.occupied}/${slots.total} busy)`;
+  }
+  return `all ${slots.total} slot${slots.total === 1 ? "" : "s"} busy`;
+}
+
+/** Queued tasks that reserve a slot (interactive/triage, or a pass under a live
+ * run) with a label for the wedged-pickup card. Mirrors the reservation filter
+ * gatherSnapshot uses for claim accounting (issue #124), so a dead-run orphan is
+ * never counted as dispatchable work. */
+function gatherQueuedDispatchable(): QueuedTaskObservation[] {
+  const liveRunIds = new Set(
+    db
+      .select({ id: runs.id, status: runs.status })
+      .from(runs)
+      .all()
+      .filter((r) => ACTIVE_RUN_STATUS_SET.has(r.status))
+      .map((r) => r.id)
+  );
+  const queued = db
+    .select({
+      id: tasks.id,
+      kind: tasks.kind,
+      runId: tasks.runId,
+      title: tasks.title,
+      githubIssue: tasks.githubIssue,
+    })
+    .from(tasks)
+    .where(eq(tasks.status, "queued"))
+    .all();
+  return queuedTasksReservingSlots(queued, liveRunIds).map((t) => ({
+    taskId: t.id,
+    label: `${t.kind}: ${t.githubIssue ?? t.title}`,
+  }));
 }
 
 /**

--- a/src/lib/orchestrator/autonomy/sweep.ts
+++ b/src/lib/orchestrator/autonomy/sweep.ts
@@ -274,23 +274,32 @@ function gatherFleetHealthInput(
 
   // A run owed a review with no review *container running* — no task at all, or
   // one queued but starved of a slot. A running review is progressing, not
-  // stalled, and shows under Running instead.
-  const owedReviews = snapshot.awaitingReview
-    .filter((a) => runningReviewTaskId(db, a.runId) == null)
-    .map((a) => {
-      const run = db
-        .select({ prUrl: runs.pullRequestUrl })
-        .from(runs)
-        .where(eq(runs.id, a.runId))
-        .get();
-      return {
-        runId: a.runId,
-        issueRef: a.issueRef,
-        prNumber: a.prNumber,
-        prUrl: run?.prUrl ?? null,
-        reason,
-      };
-    });
+  // stalled, and shows under Running instead. Sourced straight from the DB
+  // (not the GitHub-gated `awaitingReview` set) so a transient PR-read failure
+  // that drops a run for one sweep can't reset its 30-min stall timer: any
+  // reviewing/gated run with a PR, no stored/posted verdict, and no running
+  // review is owed. A spent-repairs conflict has its own needs-you card
+  // (classifyGated), so it is excluded here rather than double-surfaced.
+  const owedReviews = db
+    .select()
+    .from(runs)
+    .all()
+    .filter(
+      (r) =>
+        (r.status === "reviewing" || r.status === "gated") &&
+        r.pullRequestNumber != null &&
+        r.reviewResult == null &&
+        r.reviewVerdict == null &&
+        r.integrationCount < MAX_INTEGRATION_ATTEMPTS &&
+        runningReviewTaskId(db, r.id) == null
+    )
+    .map((r) => ({
+      runId: r.id,
+      issueRef: r.githubIssue,
+      prNumber: r.pullRequestNumber!,
+      prUrl: r.pullRequestUrl,
+      reason,
+    }));
 
   // Queued dispatchable tasks observed while a slot sits free — the exact
   // incident shape (#115): a review left queued while a slot is open.

--- a/src/lib/orchestrator/queue.ts
+++ b/src/lib/orchestrator/queue.ts
@@ -12,6 +12,13 @@ import {
 
 let pollInterval: ReturnType<typeof setInterval> | null = null;
 let pollCount = 0;
+/** Last time a poll cycle ran to completion — the queue-loop heartbeat (issue
+ * #126). Stamped at the END of each cycle so that a cycle which hangs on an
+ * un-returned await (the #125 daemon-freeze shape) never advances it, letting
+ * the sweep's watchdog see the loop stop making progress. A healthy idle loop
+ * still finishes its cycle every 2s, so an idle fleet keeps this fresh and never
+ * false-alarms. Null while the loop is stopped (boot/shutdown, not a wedge). */
+let lastProgressAt: Date | null = null;
 
 /** Track which tasks are currently being processed to prevent double-dispatch */
 const processingTasks = new Set<string>();
@@ -42,6 +49,8 @@ export function startQueue(): void {
   if (pollInterval) return;
 
   console.log("[orchestrator] Queue started, polling every 2s");
+  // Seed the heartbeat so a freshly-started loop is not immediately "stale".
+  lastProgressAt = new Date();
 
   pollInterval = setInterval(async () => {
     try {
@@ -167,6 +176,11 @@ export function startQueue(): void {
           scanForDevServer(taskId, entry.container).catch(console.error);
         }
       }
+
+      // Heartbeat: the cycle completed. Reached only on a clean pass, so a hung
+      // await (a wedged dispatch path) or a run of consecutive poll errors leaves
+      // it stale for the watchdog; an idle-but-alive loop stamps it every 2s.
+      lastProgressAt = new Date();
     } catch (err) {
       console.error("[orchestrator] Queue poll error:", err);
     }
@@ -178,8 +192,16 @@ export function stopQueue(): void {
     clearInterval(pollInterval);
     pollInterval = null;
   }
+  lastProgressAt = null;
 }
 
 export function isQueueRunning(): boolean {
   return pollInterval !== null;
+}
+
+/** The queue poll loop's last completed-cycle time, or null when the loop is
+ * stopped or has not finished its first tick — the heartbeat the fleet-health
+ * watchdog reads (issue #126). See {@link lastProgressAt}. */
+export function getQueueLastProgress(): Date | null {
+  return lastProgressAt;
 }


### PR DESCRIPTION
Closes #126

Implements the observability leg (B + C) of the parent #115 design: make silent pickup/review stalls **loud** instead of invisible (the incident hid a wedged frontier for ~1.5h behind a dashboard that showed a free slot and ready tickets). The reliability legs (#124/#125) already shipped as #127/#128.

## What this adds

Three fleet-health signals, each surfaced as a **needs-you card** on the fleet dashboard **and** a **one-time deduped Discord fleet ping** (fires once per occurrence, not every 30s sweep, like the existing saturation/cap announcements):

- **(a) Owed-review stalled** — a `reviewing`/`gated` run whose review pass hasn't started for > threshold (~30 min). The card names the PR and the reason (e.g. "a slot is held by an interactive session"). Clears automatically when the review starts, lands, or the run finalizes.
- **(b) Pickup wedged** — a free slot (`occupied < total`) while either pickup is paused no-slots or a dispatchable task has sat queued, past a ~3 min debounce. Clears when pickup resumes.
- **(c) Stale queue heartbeat** — the 2s poll loop stamps a last-progress time at the end of each cycle; warn if stale > ~2 min. A healthy idle loop still completes a cycle every 2s so it never false-alarms; a hung dispatch path (an un-returned await, the #125 shape) never reaches the stamp.

Thresholds are configurable in minutes via `OWED_REVIEW_STALL_MINUTES` / `PICKUP_WEDGED_MINUTES` / `QUEUE_HEARTBEAT_STALE_MINUTES` (defaults 30 / 3 / 2), documented in `.env.example` and the runbook.

## Design

- The core is a **pure evaluator** (`src/lib/fleet/health.ts`, `evaluateFleetHealth`) over the current observations + prior memory (per-signal since-timers + already-announced flags) + thresholds. It returns the active signals (dashboard cards), the subset that just crossed threshold (Discord pings), and the next memory — so the card and the ping can **never disagree**. Fully unit-tested (`health.test.ts`).
- The sweep is the only caller: after it decides and acts, it gathers the input, runs the evaluator, records signals in a `globalThis` store (like the backlog / needs-human observations — the signals need live orchestrator state the DB alone can't provide), and fires pings for newly-crossed signals. Dedup memory is an in-memory module var beside the saturation/cap flags.
- `buildFleetView` stays pure — it gets `fleetHealth` in its rows and renders red cards, ordered right after the cap pause (a dead queue / wedged pickup halts the whole frontier, so it outranks any single run's question or sign-off).

## Tests

- `health.test.ts` — 15 evaluator cases: each signal's threshold, one-shot ping + dedup, auto-clear/re-arm, per-run independence, idle-loop no-false-alarm, queue-stopped/null-heartbeat guards.
- `fleet-view.test.ts` — health cards (queue-stale / pickup-wedged / review-stalled with & without PR link), and the updated cause-ordering assertion.
- `review-tasks.test.ts` — `runningReviewTaskId` (queued ≠ started, running = started, none).

`pnpm test` (594 pass) and `eslint` on changed files both green.

## Self-review (`/code-review` vs origin/main, #126 as spec)

Acted on:
- **Owed-review timer robustness** — sourced owed reviews from the DB run state rather than the GitHub-read-gated `awaitingReview`, so a transient PR-read failure can't reset the 30-min stall timer. Also a closer match to the spec wording.
- **Formatter drift** — the dashboard floored minutes while Discord rounded; unified on one shared `formatDuration`.

Noted but deliberately not changed:
- **Pickup-wedged uses one 3-min debounce for both sub-conditions** (paused-no-slots and queued-while-free). Intentional: `claimableSlots==0` with a free slot is *normal* for a single sweep when a claim is about to dispatch, so debouncing avoids flapping while still firing "within minutes" per the acceptance criteria.
- **Heartbeat also goes stale on a run of consecutive poll errors** — a genuine no-progress state, within the spirit of "the loop stopped making progress".
- **Health cards flow into the daily digest** via `buildFleetView().needsYou` (the digest renders needs-you generically) — an active stall at digest time is worth surfacing, so this is intended.

A separate `ticket-reviewer` with fresh eyes is still the approval gate.