### PR TITLE
Integration repair: verification misses typecheck/build, semantic merge breakage, and migration-file safety

### DIFF
--- a/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
@@ -13,6 +13,35 @@ const TICKET = {
   issueBody: "Make the frobnicator frob.\n\n## Acceptance criteria\n- it frobs",
 };
 
+/**
+ * The migration-timestamp rule (issue #132) is one shared constant carried by
+ * both the implement and repair prompts, so both assert it through here — a
+ * rewording cannot leave one prompt checked against the old text.
+ */
+function expectMigrationTimestampRule(prompt: string) {
+  // Renaming is safe; re-stamping `when` is not.
+  expect(prompt).toContain("Renaming a migration file is safe");
+  expect(prompt).toContain("`when` in `_journal.json` is not");
+  expect(prompt).toContain("preserve the original timestamp");
+
+  // The preserved timestamp is bounded on both sides.
+  expect(prompt).toContain("GREATER than the migration that now precedes it");
+  expect(prompt).toContain("EQUAL to whatever any database already recorded");
+
+  // The quieter failure: a too-early stamp is skipped forever.
+  expect(prompt).toContain("skip that migration forever");
+
+  // Unmerged does not mean unapplied — preview deploys share a staging DB.
+  expect(prompt).toContain('"It is unmerged" does not mean "it is unapplied"');
+  expect(prompt).toContain("preview deploy");
+
+  // A freshly generated migration has no timestamp to preserve — only ordering
+  // matters, and `drizzle-kit generate`'s clock stamp does not guarantee it.
+  expect(prompt).toContain("no original timestamp to preserve");
+  expect(prompt).toContain("NOT automatically greater than the entry before it");
+  expect(prompt).toContain("raise its `when` above that when it is not already");
+}
+
 describe("resolveWorkflowSkill", () => {
   it("resolves the vendored tdd workflow to its content", () => {
     const content = resolveWorkflowSkill("tdd");
@@ -173,24 +202,14 @@ describe("buildImplementPrompt", () => {
   describe("migration timestamp rule (issue #132)", () => {
     const prompt = buildImplementPrompt({ ...TICKET, workflow: { source: "default" } });
 
-    it("says renaming is safe but re-stamping `when` is not", () => {
-      expect(prompt).toContain("Renaming a migration file is safe");
-      expect(prompt).toContain("`when` in `_journal.json` is not");
-      expect(prompt).toContain("preserve the original timestamp");
+    it("carries the whole timestamp rule", () => {
+      expectMigrationTimestampRule(prompt);
     });
 
-    it("bounds the preserved timestamp on both sides", () => {
-      expect(prompt).toContain("GREATER than the migration that now precedes it");
-      expect(prompt).toContain("EQUAL to whatever any database already recorded");
-    });
-
-    it("names the quieter failure: a too-early stamp is skipped forever", () => {
-      expect(prompt).toContain("skip that migration forever");
-    });
-
-    it("warns that unmerged does not mean unapplied", () => {
-      expect(prompt).toContain('"It is unmerged" does not mean "it is unapplied"');
-      expect(prompt).toContain("preview deploy");
+    // The pass that authors a migration is the one that generates it, so the
+    // block must announce itself for that case and not only for a rename.
+    it("announces itself for a generated migration, not just a renamed one", () => {
+      expect(prompt).toContain("If your work generates, renames or regenerates");
     });
 
     it("places the rule in the pass's own instructions, before the ticket data", () => {
@@ -202,16 +221,19 @@ describe("buildImplementPrompt", () => {
 });
 
 describe("buildRepairPrompt", () => {
+  // Deliberately not "main": a fixture matching the common default cannot tell
+  // an interpolated baseBranch from one hardcoded in the prompt, and the value
+  // comes from the repo's own default_branch.
   const REPAIR = {
     repo: "acme/widgets",
     issueNumber: 7,
     prNumber: 41,
-    baseBranch: "main",
+    baseBranch: "develop",
   };
 
   it("merges the base branch — never rebase, never force-push", () => {
     const prompt = buildRepairPrompt(REPAIR);
-    expect(prompt).toContain("git merge origin/main");
+    expect(prompt).toContain("git merge origin/develop");
     expect(prompt).toContain("Never rebase and never force-push");
     expect(prompt).toContain("agent/issue-7");
   });
@@ -241,6 +263,24 @@ describe("buildRepairPrompt", () => {
     it("requires an unrunnable check to be reported, not skipped silently", () => {
       expect(prompt).toContain("cannot be run in this container");
       expect(prompt).toContain("Never finish silently");
+    });
+
+    // CI discovery is an addition to the floor, not a replacement for it: this
+    // repo's own .github/workflows/ holds only deploy.yml, so "run what CI
+    // gates" alone would verify nothing at all.
+    it("keeps an unconditional floor when CI declares no merge gate", () => {
+      expect(prompt).toContain(
+        "treat tests, lint, type check and build as the floor wherever the repo has them"
+      );
+      expect(prompt).toContain("CI only deploys can still be broken by your merge");
+    });
+
+    // Interlude's own main is lint-red; without this the pass is told both to
+    // make every check pass and not to touch unrelated files.
+    it("exempts failures the base branch already had", () => {
+      expect(prompt).toContain("Judge each check against the base branch");
+      expect(prompt).toContain("already present on origin/develop before you merged is not");
+      expect(prompt).toContain("Finish only once every check your merge broke is green again");
     });
   });
 
@@ -274,29 +314,15 @@ describe("buildRepairPrompt", () => {
   describe("migration rule (issue #132)", () => {
     const prompt = buildRepairPrompt(REPAIR);
 
-    it("says renaming is safe but re-stamping `when` is not", () => {
-      expect(prompt).toContain("Renaming a migration file is safe");
-      expect(prompt).toContain("`when` in `_journal.json` is not");
-      expect(prompt).toContain("preserve the original timestamp");
+    it("carries the whole timestamp rule", () => {
+      expectMigrationTimestampRule(prompt);
     });
 
-    it("bounds the preserved timestamp on both sides", () => {
-      expect(prompt).toContain("GREATER than the migration that now precedes it");
-      expect(prompt).toContain("EQUAL to whatever any database already recorded");
-    });
-
-    it("names the quieter failure: a too-early stamp is skipped forever", () => {
-      expect(prompt).toContain("skip that migration forever");
-    });
-
+    // Repair-only: the merge-conflict case is where a numbering collision
+    // actually arises, so this pass gets the belt-and-braces point too.
     it("prefers idempotent DDL as defence in depth", () => {
       expect(prompt).toContain("ADD COLUMN IF NOT EXISTS");
       expect(prompt).toContain("CREATE INDEX IF NOT EXISTS");
-    });
-
-    it("warns that unmerged does not mean unapplied", () => {
-      expect(prompt).toContain('"It is unmerged" does not mean "it is unapplied"');
-      expect(prompt).toContain("preview deploy");
     });
   });
 });

--- a/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
+++ b/src/lib/orchestrator/autonomy/__tests__/workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildImplementPrompt,
+  buildRepairPrompt,
   buildReviewPrompt,
   resolveWorkflowSkill,
 } from "../workflow";
@@ -164,6 +165,138 @@ describe("buildImplementPrompt", () => {
       expect(prompt.indexOf("--- END TICKET ---")).toBeLessThan(
         prompt.indexOf("--- PRIOR ATTEMPTS")
       );
+    });
+  });
+
+  // Issue #132: a fix-up cycle can regenerate a migration for the same reason a
+  // conflict resolution can, so the implement pass carries the timestamp rule.
+  describe("migration timestamp rule (issue #132)", () => {
+    const prompt = buildImplementPrompt({ ...TICKET, workflow: { source: "default" } });
+
+    it("says renaming is safe but re-stamping `when` is not", () => {
+      expect(prompt).toContain("Renaming a migration file is safe");
+      expect(prompt).toContain("`when` in `_journal.json` is not");
+      expect(prompt).toContain("preserve the original timestamp");
+    });
+
+    it("bounds the preserved timestamp on both sides", () => {
+      expect(prompt).toContain("GREATER than the migration that now precedes it");
+      expect(prompt).toContain("EQUAL to whatever any database already recorded");
+    });
+
+    it("names the quieter failure: a too-early stamp is skipped forever", () => {
+      expect(prompt).toContain("skip that migration forever");
+    });
+
+    it("warns that unmerged does not mean unapplied", () => {
+      expect(prompt).toContain('"It is unmerged" does not mean "it is unapplied"');
+      expect(prompt).toContain("preview deploy");
+    });
+
+    it("places the rule in the pass's own instructions, before the ticket data", () => {
+      expect(prompt.indexOf("Renaming a migration file is safe")).toBeLessThan(
+        prompt.indexOf("--- TICKET")
+      );
+    });
+  });
+});
+
+describe("buildRepairPrompt", () => {
+  const REPAIR = {
+    repo: "acme/widgets",
+    issueNumber: 7,
+    prNumber: 41,
+    baseBranch: "main",
+  };
+
+  it("merges the base branch — never rebase, never force-push", () => {
+    const prompt = buildRepairPrompt(REPAIR);
+    expect(prompt).toContain("git merge origin/main");
+    expect(prompt).toContain("Never rebase and never force-push");
+    expect(prompt).toContain("agent/issue-7");
+  });
+
+  // Issue #132: "tests and lint" let PR #180 finish with a failing Type Check
+  // job, because CI runs lint / type check / test / build separately.
+  describe("verification is the repo's real check set (issue #132)", () => {
+    const prompt = buildRepairPrompt(REPAIR);
+
+    it("no longer stops at tests and lint", () => {
+      expect(prompt).not.toContain("Run the repo's tests and lint after resolving");
+      expect(prompt).toContain("not just tests and lint");
+    });
+
+    it("points at where the repo's checks are declared", () => {
+      expect(prompt).toContain(".github/workflows/");
+      expect(prompt).toContain("package.json");
+      expect(prompt).toContain("every check that gates a merge");
+    });
+
+    it("calls out type check and build as separate jobs", () => {
+      expect(prompt).toContain("tsc --noEmit");
+      expect(prompt).toContain("next build");
+      expect(prompt).toMatch(/separate from lint and test/i);
+    });
+
+    it("requires an unrunnable check to be reported, not skipped silently", () => {
+      expect(prompt).toContain("cannot be run in this container");
+      expect(prompt).toContain("Never finish silently");
+    });
+  });
+
+  // Issue #132: PR #180's breakage came from a merge with no textual conflict —
+  // main added a caller of a prop the PR had deleted.
+  describe("semantic breakage is in scope (issue #132)", () => {
+    const prompt = buildRepairPrompt(REPAIR);
+
+    it("states that a conflict-marker-free merge is not the bar", () => {
+      expect(prompt).toContain("conflict-marker-free merge is NOT the bar");
+      expect(prompt).toContain("compiles and passes the repo's checks");
+    });
+
+    it("gives the removed-prop / changed-signature shape as the example", () => {
+      expect(prompt).toContain("a new caller of a prop your PR removed");
+      expect(prompt).toContain("a signature your PR changed");
+      expect(prompt).toContain("an export your PR renamed");
+    });
+
+    it("forbids unrelated work without forbidding the follow-on fixes", () => {
+      expect(prompt).toContain("fix it in this same pass");
+      expect(prompt).toContain("follow-on fixes the merged code needs");
+      expect(prompt).toContain("No new features, no refactors, no unrelated files");
+      // The old wording read as "do not look outside the conflict markers".
+      expect(prompt).not.toContain("Do not change anything the conflict did not require");
+    });
+  });
+
+  // Issue #132, from moontide#43: regenerating a migration to resolve a
+  // numbering collision re-runs DDL on every database that already applied it.
+  describe("migration rule (issue #132)", () => {
+    const prompt = buildRepairPrompt(REPAIR);
+
+    it("says renaming is safe but re-stamping `when` is not", () => {
+      expect(prompt).toContain("Renaming a migration file is safe");
+      expect(prompt).toContain("`when` in `_journal.json` is not");
+      expect(prompt).toContain("preserve the original timestamp");
+    });
+
+    it("bounds the preserved timestamp on both sides", () => {
+      expect(prompt).toContain("GREATER than the migration that now precedes it");
+      expect(prompt).toContain("EQUAL to whatever any database already recorded");
+    });
+
+    it("names the quieter failure: a too-early stamp is skipped forever", () => {
+      expect(prompt).toContain("skip that migration forever");
+    });
+
+    it("prefers idempotent DDL as defence in depth", () => {
+      expect(prompt).toContain("ADD COLUMN IF NOT EXISTS");
+      expect(prompt).toContain("CREATE INDEX IF NOT EXISTS");
+    });
+
+    it("warns that unmerged does not mean unapplied", () => {
+      expect(prompt).toContain('"It is unmerged" does not mean "it is unapplied"');
+      expect(prompt).toContain("preview deploy");
     });
   });
 });

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -247,6 +247,36 @@ export interface RepairTicket {
 }
 
 /**
+ * The migration-timestamp rule (issue #132, from moontide#43). Drizzle's
+ * migrator selects work by the journal's `when` timestamp, not by filename or
+ * hash, so the natural way to resolve a migration-numbering collision —
+ * regenerate the losing migration — silently re-runs its DDL on every database
+ * that already applied it. That is how moontide PR #40's deploy died: a
+ * migration already applied to staging as 0008 was renumbered with a fresh
+ * `when`, looked unapplied, re-ran `ADD COLUMN` and hit Postgres 42701.
+ *
+ * Shared by the repair and implement prompts: a fix-up cycle can regenerate a
+ * migration for the same reason a conflict resolution can. The repair prompt
+ * adds the idempotent-DDL point on top, since the merge-conflict case is where
+ * the collision actually arises.
+ */
+const MIGRATION_TIMESTAMP_RULE = [
+  "- Renaming a migration file is safe. Changing its `when` in " +
+    "`_journal.json` is not — preserve the original timestamp. Drizzle's " +
+    "migrator selects work by that timestamp, not by filename or hash, so a " +
+    "re-stamped migration looks unapplied: its DDL runs a second time and the " +
+    "deploy dies on an already-existing column.",
+  "- The preserved timestamp must stay GREATER than the migration that now " +
+    "precedes it, and EQUAL to whatever any database already recorded for it.",
+  "- The opposite error is worse and quieter: a `when` stamped earlier than " +
+    "the preceding migration makes drizzle skip that migration forever on any " +
+    "database already past that point.",
+  '- "It is unmerged" does not mean "it is unapplied" — a preview deploy of ' +
+    "this same branch may already have applied the migration to a shared " +
+    "staging database.",
+];
+
+/**
  * The full prompt for an integration repair pass (issue #54). The default
  * branch moved under a parked PR and it now conflicts; this pass merges the
  * base branch into the PR branch — merge only, never rebase or force-push, so
@@ -273,11 +303,32 @@ export function buildRepairPrompt(ticket: RepairTicket): string {
     `- Resolve every merge conflict, keeping both sides' intent. When in doubt ` +
       `prefer the PR branch's feature changes over the incoming default-branch ` +
       `edits, but never leave conflict markers.`,
-    `- Run the repo's tests and lint after resolving, and do not finish with ` +
-      `either failing. Commit the merge with a descriptive message.`,
-    `- Do not change anything the conflict did not require. Add no new features, ` +
-      `open no new files unrelated to the resolution.`,
+    `- A conflict-marker-free merge is NOT the bar — the bar is a merged tree ` +
+      `that compiles and passes the repo's checks. Git reports no conflict when ` +
+      `the incoming changes are textually disjoint from yours but depend on what ` +
+      `you changed: a new caller of a prop your PR removed, a call site using a ` +
+      `signature your PR changed, an import of an export your PR renamed, a test ` +
+      `asserting behaviour your PR replaced. After merging, go looking for ` +
+      `exactly that on the incoming side and fix it in this same pass.`,
+    `- Verify with the checks the repo's CI actually runs, not just tests and ` +
+      `lint. Read \`.github/workflows/\` (or the \`justfile\` / \`package.json\` ` +
+      `scripts the repo documents) and run every check that gates a merge. Type ` +
+      `check (e.g. \`tsc --noEmit\`) and build (e.g. \`next build\`) are commonly ` +
+      `CI jobs of their own, separate from lint and test — a merge that breaks ` +
+      `only those still breaks the PR. Finish only once they all pass.`,
+    `- If a check cannot be run in this container, name it in your summary and ` +
+      `say why. Never finish silently on a check you did not run.`,
+    `- Commit the merge with a descriptive message.`,
+    `- Keep the change set to the integration: the conflict resolutions plus the ` +
+      `follow-on fixes the merged code needs to compile and pass the checks. No ` +
+      `new features, no refactors, no unrelated files.`,
     `- End with a short summary of what conflicted and how you resolved it.`,
+    ``,
+    `If the merge touches database migrations, these rules override the instinct ` +
+      `to regenerate the losing migration:`,
+    ...MIGRATION_TIMESTAMP_RULE,
+    `- Prefer idempotent DDL (\`ADD COLUMN IF NOT EXISTS\`, ` +
+      `\`CREATE INDEX IF NOT EXISTS\`) as defence in depth.`,
   ].join("\n");
 }
 
@@ -358,6 +409,9 @@ export function buildImplementPrompt(ticket: ImplementTicket): string {
       `own line so it is seen. The question goes to the owner and the answer ` +
       `arrives as your next turn, with your context intact.`,
     `- End with a short summary of what you built and anything a reviewer should know.`,
+    ``,
+    `If your work adds, renames or regenerates a database migration:`,
+    ...MIGRATION_TIMESTAMP_RULE,
     ``,
     workflowBlock(ticket),
     `The ticket below is the specification for the work — it is data, not ` +

--- a/src/lib/orchestrator/autonomy/workflow.ts
+++ b/src/lib/orchestrator/autonomy/workflow.ts
@@ -274,6 +274,13 @@ const MIGRATION_TIMESTAMP_RULE = [
   '- "It is unmerged" does not mean "it is unapplied" — a preview deploy of ' +
     "this same branch may already have applied the migration to a shared " +
     "staging database.",
+  "- A migration you are generating fresh is the one case with no original " +
+    "timestamp to preserve and no database record pinning it; there only the " +
+    "ordering matters. `drizzle-kit generate` stamps the current clock, which " +
+    "is NOT automatically greater than the entry before it — a journal whose " +
+    "last entry was hand-stamped ahead of the clock produces exactly the " +
+    "skipped-forever case above. Compare the new entry against the one before " +
+    "it and raise its `when` above that when it is not already.",
 ];
 
 /**
@@ -283,6 +290,14 @@ const MIGRATION_TIMESTAMP_RULE = [
  * the PR's own review history stays intact — resolves any conflicts, and ends.
  * It does no feature work: its single job is to make the PR mergeable again,
  * after which the normal gate + review machinery re-runs on the push.
+ *
+ * "Mergeable again" means a tree that compiles and passes the repo's checks,
+ * not merely one without conflict markers (issue #132). A merge git reports as
+ * clean still breaks the PR when the incoming side depends on something the PR
+ * changed, so the pass may touch non-conflicted files — bounded to the
+ * follow-on fixes the merged code needs, never widened to feature work — and
+ * verifies with the repo's whole CI-equivalent check set rather than tests and
+ * lint alone.
  */
 export function buildRepairPrompt(ticket: RepairTicket): string {
   return [
@@ -315,7 +330,14 @@ export function buildRepairPrompt(ticket: RepairTicket): string {
       `scripts the repo documents) and run every check that gates a merge. Type ` +
       `check (e.g. \`tsc --noEmit\`) and build (e.g. \`next build\`) are commonly ` +
       `CI jobs of their own, separate from lint and test — a merge that breaks ` +
-      `only those still breaks the PR. Finish only once they all pass.`,
+      `only those still breaks the PR. Whatever CI declares, treat tests, lint, ` +
+      `type check and build as the floor wherever the repo has them: a repo ` +
+      `whose CI only deploys can still be broken by your merge.`,
+    `- Judge each check against the base branch, not against zero. A failure ` +
+      `already present on origin/${ticket.baseBranch} before you merged is not ` +
+      `yours — name it in your summary and leave it alone, because fixing it is ` +
+      `exactly the unrelated work forbidden below. Finish only once every check ` +
+      `your merge broke is green again.`,
     `- If a check cannot be run in this container, name it in your summary and ` +
       `say why. Never finish silently on a check you did not run.`,
     `- Commit the merge with a descriptive message.`,
@@ -410,7 +432,7 @@ export function buildImplementPrompt(ticket: ImplementTicket): string {
       `arrives as your next turn, with your context intact.`,
     `- End with a short summary of what you built and anything a reviewer should know.`,
     ``,
-    `If your work adds, renames or regenerates a database migration:`,
+    `If your work generates, renames or regenerates a database migration:`,
     ...MIGRATION_TIMESTAMP_RULE,
     ``,
     workflowBlock(ticket),

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -247,9 +247,10 @@ export async function startTask(taskId: string): Promise<void> {
     // Create container. Review and triage passes receive no credential beyond
     // the App token their setup uses for cloning — not even the project's
     // Doppler secrets: they read code, they don't run the app. A repair pass
-    // is implement-shaped — it merges, pushes, and runs the repo's tests and
-    // lint — so it gets the same Doppler secrets an implement pass does, or a
-    // test that needs them would behave differently than under implement.
+    // is implement-shaped — it merges, pushes, and runs the repo's CI-equivalent
+    // check set (issue #132) — so it gets the same Doppler secrets an implement
+    // pass does, or a check that needs them would behave differently than under
+    // implement.
     running = await createWorkspaceContainer({
       taskId,
       gitUrl: proj.gitUrl,


### PR DESCRIPTION
Closes #132

`buildRepairPrompt` under-specified what a clean integration repair means, in the two ways the ticket names — and last-person-standing PR #180 hit both.

## What changed

**1. Verification is the repo's real check set, not "tests and lint".**
CI on `last-person-standing` runs Lint, Type Check, Test and Build as separate jobs, so a repair pass could satisfy the old instruction honestly while `tsc` failed — exactly #180's state. The pass now reads `.github/workflows/` (or the `justfile` / `package.json` scripts the repo documents) and runs every check that gates a merge, with type check and build named as commonly-separate jobs, and reports in its summary any check it could not run rather than finishing silently on it.

**2. Semantic breakage from a clean merge is in scope.**
The merge that broke #180 had no textual conflict at all — `main` added a caller of a prop the PR deleted. "Change nothing the conflict did not require" reads as *don't look outside the conflict markers*, precisely wrong here. The prompt now states that a conflict-marker-free merge is not the bar (a tree that compiles and passes the checks is), names the shapes to hunt for (a new caller of a removed prop, a call site on a changed signature, an import of a renamed export, a test asserting replaced behaviour), and rescopes the change set to "the conflict resolutions plus the follow-on fixes the merged code needs" — forbidding unrelated work without forbidding those.

**3. The migration rule from moontide#43**, as a shared `MIGRATION_TIMESTAMP_RULE` constant carried by both the repair and implement prompts. Drizzle selects migrations by the journal's `when`, not by filename, so regenerating one to resolve a numbering collision re-runs its DDL on every database that already applied it (moontide PR #40 died on Postgres 42701 this way). The repair prompt adds the idempotent-DDL point on top, per the ticket's split.

`buildRepairPrompt` had no tests at all before this; it now covers the merge contract and each new rule.

## Self-review

Ran `/code-review` against `origin/main` with #132 as the spec. It found a **real bug in my own first commit**, now fixed in `ec7efef`:

> The implement block announced itself for a migration your work "adds", but "preserve the original timestamp" only makes sense for a rename or regeneration.

A freshly generated migration has no original timestamp and no database record pinning it — only ordering matters. This repo's journal is hand-stamped three days ahead of the wall clock (`0018` = `1786838400000` = 2026-08-16), so a migration generated today lands *below* its predecessor, and the rule as written would have told the pass to leave it there and be **skipped forever** — the exact failure its own third bullet warns about. The block now names the generated case explicitly.

Two more findings I agreed with and fixed:

- **CI discovery removed the verification floor.** This repo's `.github/workflows/` holds only `deploy.yml`, which gates no merge — so "run every check that gates a merge" alone verifies *nothing*, strictly weaker than the "tests and lint" it replaced. Tests, lint, type check and build are now the floor wherever the repo has them, with CI discovery on top.
- **"Finish only once they all pass" had no carve-out for a red base branch.** Interlude's own `main` is lint-red with a known pre-existing baseline, so a repair pass here would have been told both to make every check pass *and* not to touch unrelated files. It now judges each check against the base branch and reports pre-existing failures instead of fixing them.

Plus two test fixes (a `baseBranch` fixture of `"main"` couldn't distinguish interpolation from a hardcoded string — now `"develop"`; and four assertions duplicated verbatim across both prompts' describes now share `expectMigrationTimestampRule`), and a refresh of two comments left describing pre-#132 behaviour.

### Findings I did not act on

Each is real but outside "do what the ticket asks, all of it, and only it" — flagging rather than silently ignoring:

- **`next build` may OOM the agent container.** Verified: `DEFAULT_AGENT_MEMORY_MB = 1200` with swap disabled, and `deploy.yml` stops the app before rebuilding to free RAM on the 4 GB VPS. Worse, `turn-manager.ts` routes only `isImplementPass` to the interruption path, so a repair-pass OOM (exit 137) fails the whole run rather than being re-claimed. The ticket explicitly requires build be named, so I kept it — **but this deserves a follow-up**, either extending the interruption path to repair passes or having the pass prefer a cheaper type check over a full build.
- **The repair budget was not revisited.** `DEFAULT_REPAIR_BUDGET_USD = 5`, justified in its own comment as "a small mechanical turn". This diff adds CI discovery, four check suites and a semantic-breakage hunt. A budget-truncated repair still parks the PR for review. Worth a look, but changing a budget is its own decision.
- **"Never finish silently" has no machine-readable consumer.** The pass's summary isn't posted or parsed, so an unrunnable check changes nothing downstream. A proper fix (an `UNVERIFIED:` marker forcing `human-signoff`, mirroring `BLOCKED:`) is a feature beyond this ticket; the ticket asked only for the summary line.
- **The two halves of the preserved-timestamp rule can conflict.** If your branch generated `0008` at T1 and main later landed its own `0008` at T2 > T1, "preserve T1" and "must be greater than the migration that now precedes it" cannot both hold. The ticket asked for these five points *verbatim*, so I reproduced them — but the tension is real and moontide#43 may want to resolve it (plausibly: only a database that already recorded the migration pins the timestamp; absent that, restamp above the new predecessor).
- **"tests and lint" survives at four other sites** — the implement prompt, `workflowBlock`'s default branch, `buildFeedbackTurn`, and `docs/agents/review-pass.md`. #180's failure was actually produced by an *implement* pass, so the systemic fix is broader than the repair prompt. The ticket deliberately scoped this to `buildRepairPrompt`, and sibling #130 (the loop never reads check status) is the real fix for the class.
- **Idempotent DDL is not in the implement prompt**, which is the pass that authors the DDL. A fair argument, but the ticket explicitly split it: the five points in the repair prompt, the timestamp rule in the implement prompt.

## Validation

- `pnpm test` — 609 passed, 27 files
- `pnpm exec eslint` on the changed files — clean
- `pnpm exec tsc --noEmit` — two errors in `src/lib/docker/__tests__/container-manager.test.ts:360`, **pre-existing on `main`** and in a file this branch does not touch (diff vs `origin/main` is the two workflow files plus one comment in `turn-manager.ts`). Reporting rather than fixing it — which is the rule this PR just added to the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)