### PR TITLE
Live view: preview pane fleet restyle

### DIFF
--- a/src/components/preview-pane.tsx
+++ b/src/components/preview-pane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { FOCUS_RING } from "@/components/fleet/fleet-bits";
 
 interface PreviewPaneProps {
   taskId: string;
@@ -113,7 +113,7 @@ export function PreviewPane({
 
   if (!devPort) {
     return (
-      <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
+      <div className="flex h-full items-center justify-center bg-fl-ground font-plex-mono text-[11px] text-fl-ink-2">
         {status === "stopped"
           ? "Dev server stopped"
           : "No dev server running"}
@@ -122,48 +122,40 @@ export function PreviewPane({
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex h-full flex-col bg-fl-ground">
       {/* Toolbar */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-zinc-800 shrink-0">
-        <span className="text-xs text-zinc-500 font-mono">:{devPort}</span>
+      <div className="flex shrink-0 items-center gap-2 border-b border-fl-line bg-fl-surface px-3 py-2">
+        <span className="font-plex-mono text-[11px] tabular-nums text-fl-ink-2">
+          :{devPort}
+        </span>
         <div className="flex-1" />
-        <Button
-          onClick={reload}
-          size="sm"
-          variant="ghost"
-          className="h-6 px-2 text-xs text-zinc-400"
-        >
-          Reload
-        </Button>
-        <Button
-          onClick={() => window.open(previewUrl, "_blank")}
-          size="sm"
-          variant="ghost"
-          className="h-6 px-2 text-xs text-zinc-400"
-        >
-          Open
-        </Button>
+        <ToolbarButton onClick={reload}>reload</ToolbarButton>
+        <ToolbarButton onClick={() => window.open(previewUrl, "_blank")}>
+          open
+        </ToolbarButton>
       </div>
 
       {/* iframe */}
       <div className="flex-1 relative">
         {(status === "loading" || status === "provisioning") && (
-          <div className="absolute inset-0 flex items-center justify-center bg-zinc-950/50 z-10">
-            <span className="text-zinc-500 text-sm">
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-fl-ground/80">
+            <StatusNote>
               {status === "provisioning"
                 ? "Provisioning preview certificate..."
                 : "Connecting to dev server..."}
-            </span>
+            </StatusNote>
           </div>
         )}
         {status === "error" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 z-10">
-            <span className="text-zinc-500 text-sm">
-              Could not connect to dev server
-            </span>
-            <Button onClick={reload} size="sm" variant="outline" className="text-xs">
-              Retry
-            </Button>
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2.5 bg-fl-ground">
+            <StatusNote>Could not connect to dev server</StatusNote>
+            <button
+              type="button"
+              onClick={reload}
+              className={`rounded-[4px] border border-fl-line-strong px-2.5 py-1 font-plex-mono text-[11px] lowercase text-fl-ink hover:bg-fl-card ${FOCUS_RING}`}
+            >
+              retry
+            </button>
           </div>
         )}
         <iframe
@@ -180,5 +172,38 @@ export function PreviewPane({
         />
       </div>
     </div>
+  );
+}
+
+/** The pane's chrome controls speak the fleet's quiet lowercase mono voice, the
+ * same one the shell's nav and theme toggle use. They are deliberately not
+ * shadcn `Button`s: those are painted from the greyscale shadcn tokens, which
+ * are a different palette from the fleet's parchment/ink one. */
+function ToolbarButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-[4px] px-1.5 py-px font-plex-mono text-[11px] lowercase text-fl-ink-2 hover:text-fl-ink ${FOCUS_RING}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** A message shown over the iframe carries its own opaque ground: what the dev
+ * server has painted underneath is not a background this palette controls, so
+ * ink-on-scrim alone can't be relied on to stay legible. */
+function StatusNote({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded-[4px] border border-fl-line bg-fl-card px-2.5 py-1 font-plex-mono text-[11px] text-fl-ink-2">
+      {children}
+    </span>
   );
 }

--- a/src/components/preview-pane.tsx
+++ b/src/components/preview-pane.tsx
@@ -130,15 +130,23 @@ export function PreviewPane({
         </span>
         <div className="flex-1" />
         <ToolbarButton onClick={reload}>reload</ToolbarButton>
-        <ToolbarButton onClick={() => window.open(previewUrl, "_blank")}>
+        {/* noopener: the preview is agent-authored code, and a bare
+            window.open leaves it holding window.opener on this tab. */}
+        <ToolbarButton
+          onClick={() => window.open(previewUrl, "_blank", "noopener")}
+        >
           open
         </ToolbarButton>
       </div>
 
       {/* iframe */}
       <div className="flex-1 relative">
+        {/* Held at half opacity: this overlay is not rare. Every agent write
+            reloads the iframe 500ms later, so a heavier scrim would blink the
+            preview out on each save rather than tint it. The note carries its
+            own ground, so legibility does not depend on the scrim. */}
         {(status === "loading" || status === "provisioning") && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-fl-ground/80">
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-fl-ground/50">
             <StatusNote>
               {status === "provisioning"
                 ? "Provisioning preview certificate..."
@@ -152,7 +160,7 @@ export function PreviewPane({
             <button
               type="button"
               onClick={reload}
-              className={`rounded-[4px] border border-fl-line-strong px-2.5 py-1 font-plex-mono text-[11px] lowercase text-fl-ink hover:bg-fl-card ${FOCUS_RING}`}
+              className={`flex h-7 items-center rounded-[4px] border border-fl-line-strong px-2.5 font-plex-mono text-[11px] lowercase text-fl-ink hover:bg-fl-card ${FOCUS_RING}`}
             >
               retry
             </button>
@@ -178,7 +186,10 @@ export function PreviewPane({
 /** The pane's chrome controls speak the fleet's quiet lowercase mono voice, the
  * same one the shell's nav and theme toggle use. They are deliberately not
  * shadcn `Button`s: those are painted from the greyscale shadcn tokens, which
- * are a different palette from the fleet's parchment/ink one. */
+ * are a different palette from the fleet's parchment/ink one.
+ *
+ * `h-6` is a floor, not decoration — 11px mono leaves a ~18px box on its own,
+ * and these are thumb targets on the mobile preview tab. */
 function ToolbarButton({
   onClick,
   children,
@@ -190,7 +201,7 @@ function ToolbarButton({
     <button
       type="button"
       onClick={onClick}
-      className={`rounded-[4px] px-1.5 py-px font-plex-mono text-[11px] lowercase text-fl-ink-2 hover:text-fl-ink ${FOCUS_RING}`}
+      className={`flex h-6 items-center rounded-[4px] px-2 font-plex-mono text-[11px] lowercase text-fl-ink-2 hover:text-fl-ink ${FOCUS_RING}`}
     >
       {children}
     </button>

--- a/src/components/task-chat.tsx
+++ b/src/components/task-chat.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { SlimShell } from "@/components/app-shell";
+import { FOCUS_RING } from "@/components/fleet/fleet-bits";
 import { TaskStream } from "./task-stream";
 import { MessageInput } from "./message-input";
 import { PreviewPane } from "./preview-pane";
@@ -102,12 +103,15 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
       title={initialTask.title}
       accessory={
         <>
+          {/* The label states what the container is doing; the dot beside it is
+              what breathes. The fleet's one ambient animation belongs to the
+              dot, so the running label reads green but holds still. */}
           {containerLabel && (
             <span
-              className={`text-xs ${
+              className={`font-plex-mono text-[11px] ${
                 taskStatus.containerStatus === "running"
-                  ? "text-green-400 animate-pulse"
-                  : "text-zinc-400"
+                  ? "text-fl-green"
+                  : "text-fl-ink-2"
               }`}
             >
               {containerLabel}
@@ -118,20 +122,20 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
       }
     >
       {hasReferences && (
-        <div className="border-b border-zinc-800 px-4 py-2 shrink-0">
+        <div className="shrink-0 border-b border-fl-line px-4 py-2">
           {initialTask.branch && (
-            <p className="text-xs text-zinc-500 font-mono">
+            <p className="font-plex-mono text-[11px] text-fl-ink-2">
               {initialTask.branch}
             </p>
           )}
           {(githubIssue || pullRequestUrl) && (
-            <div className="flex items-center gap-3 mt-0.5">
+            <div className="mt-0.5 flex items-center gap-3">
               {githubIssue && (
                 <a
                   href={`https://github.com/${githubIssue.replace("#", "/issues/")}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-xs text-blue-400 hover:text-blue-300 font-mono"
+                  className={`font-plex-mono text-[11px] text-fl-cool hover:text-fl-ink ${FOCUS_RING}`}
                 >
                   {githubIssue}
                 </a>
@@ -141,7 +145,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
                   href={pullRequestUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-xs text-blue-400 hover:text-blue-300 font-mono"
+                  className={`font-plex-mono text-[11px] text-fl-cool hover:text-fl-ink ${FOCUS_RING}`}
                 >
                   PR #{pullRequestNumber}
                 </a>
@@ -151,29 +155,26 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
         </div>
       )}
 
-      {/* Mobile tabs — only when preview available */}
+      {/* Mobile tabs — only when preview available. The selected tab is marked
+          the way the shell's nav marks the current section: full-strength ink
+          over an ink rule, not a colour. Colour in this system is semantic, and
+          "which pane am I looking at" means nothing about the run. */}
       {devPort && (
-        <div className="flex border-b border-zinc-800 lg:hidden shrink-0">
-          <button
-            onClick={() => setActiveTab("chat")}
-            className={`flex-1 py-2 text-sm font-medium ${
-              activeTab === "chat"
-                ? "text-zinc-100 border-b-2 border-purple-500"
-                : "text-zinc-500"
-            }`}
-          >
-            Chat
-          </button>
-          <button
-            onClick={() => setActiveTab("preview")}
-            className={`flex-1 py-2 text-sm font-medium ${
-              activeTab === "preview"
-                ? "text-zinc-100 border-b-2 border-purple-500"
-                : "text-zinc-500"
-            }`}
-          >
-            Preview
-          </button>
+        <div className="flex shrink-0 border-b border-fl-line lg:hidden">
+          {(["chat", "preview"] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 border-b-2 py-2 font-plex-mono text-[12px] lowercase ${FOCUS_RING} ${
+                activeTab === tab
+                  ? "border-fl-ink text-fl-ink"
+                  : "border-transparent text-fl-ink-2 hover:text-fl-ink"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
         </div>
       )}
 
@@ -183,7 +184,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
         <div
           className={`flex-1 flex flex-col min-h-0 ${
             devPort && activeTab !== "chat" ? "hidden lg:flex" : ""
-          } ${devPort ? "lg:w-2/5 lg:border-r lg:border-zinc-800" : ""}`}
+          } ${devPort ? "lg:w-2/5 lg:border-r lg:border-fl-line" : ""}`}
         >
           <TaskStream
             taskId={initialTask.id}
@@ -219,8 +220,8 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
 
       {/* Terminal state footer */}
       {isTerminal && (
-        <div className="border-t border-zinc-800 px-4 py-3 text-center shrink-0">
-          <span className="text-xs text-zinc-500">
+        <div className="shrink-0 border-t border-fl-line px-4 py-3 text-center">
+          <span className="font-plex-mono text-[11px] tabular-nums text-fl-ink-2">
             Task {taskStatus.status}
             {taskStatus.totalCostUsd > 0 &&
               ` · $${taskStatus.totalCostUsd.toFixed(4)}`}
@@ -231,19 +232,23 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
   );
 }
 
-function StatusDot({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    queued: "bg-zinc-400",
-    running: "bg-green-400",
-    completed: "bg-zinc-400",
-    failed: "bg-red-400",
-    cancelled: "bg-zinc-600",
-  };
+// Same neutral/green/red split as before, in fleet tokens: only failure and a
+// live run earn a colour, and the two quiet neutrals keep their old ordering
+// (queued and completed read louder than a cancelled run). `fleet-dot-live` is
+// the system's one ambient animation, and it honours reduced-motion.
+const STATUS_DOT: Record<string, string> = {
+  queued: "bg-fl-ink-2",
+  running: "bg-fl-green fleet-dot-live",
+  completed: "bg-fl-ink-2",
+  failed: "bg-fl-red",
+  cancelled: "bg-fl-ink-3",
+};
 
+function StatusDot({ status }: { status: string }) {
   return (
     <span
-      className={`inline-block h-2 w-2 rounded-full ${
-        colors[status] ?? "bg-zinc-400"
+      className={`inline-block h-1.5 w-1.5 rounded-full ${
+        STATUS_DOT[status] ?? "bg-fl-ink-2"
       }`}
     />
   );

--- a/src/components/task-chat.tsx
+++ b/src/components/task-chat.tsx
@@ -103,21 +103,19 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
       title={initialTask.title}
       accessory={
         <>
-          {/* The label states what the container is doing; the dot beside it is
-              what breathes. The fleet's one ambient animation belongs to the
-              dot, so the running label reads green but holds still. */}
+          {/* The label says what the container is doing and the dot beside it
+              carries the liveness, so the label itself stays neutral ink: green
+              at 11px on the bare light ground is 3.8:1, and the places this
+              system does tint text green all sit on a wash or a card. */}
           {containerLabel && (
-            <span
-              className={`font-plex-mono text-[11px] ${
-                taskStatus.containerStatus === "running"
-                  ? "text-fl-green"
-                  : "text-fl-ink-2"
-              }`}
-            >
+            <span className="font-plex-mono text-[11px] text-fl-ink-2">
               {containerLabel}
             </span>
           )}
-          <StatusDot status={taskStatus.status} />
+          <StatusDot
+            status={taskStatus.status}
+            live={taskStatus.containerStatus === "running"}
+          />
         </>
       }
     >
@@ -135,7 +133,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
                   href={`https://github.com/${githubIssue.replace("#", "/issues/")}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`font-plex-mono text-[11px] text-fl-cool hover:text-fl-ink ${FOCUS_RING}`}
+                  className={`font-plex-mono text-[11px] text-fl-cool underline decoration-fl-cool/45 underline-offset-2 hover:decoration-fl-cool ${FOCUS_RING}`}
                 >
                   {githubIssue}
                 </a>
@@ -145,7 +143,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
                   href={pullRequestUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`font-plex-mono text-[11px] text-fl-cool hover:text-fl-ink ${FOCUS_RING}`}
+                  className={`font-plex-mono text-[11px] text-fl-cool underline decoration-fl-cool/45 underline-offset-2 hover:decoration-fl-cool ${FOCUS_RING}`}
                 >
                   PR #{pullRequestNumber}
                 </a>
@@ -155,10 +153,12 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
         </div>
       )}
 
-      {/* Mobile tabs — only when preview available. The selected tab is marked
-          the way the shell's nav marks the current section: full-strength ink
-          over an ink rule, not a colour. Colour in this system is semantic, and
-          "which pane am I looking at" means nothing about the run. */}
+      {/* Mobile tabs — only when preview available. Selection is marked in ink,
+          not a colour: colour in this system is semantic, and which pane you are
+          looking at says nothing about the run. The rule is heavier than the
+          shell nav's hairline because this is a thumb-sized control on a phone,
+          not a header link. `aria-current` carries the same state the underline
+          does, so it survives without sight of the underline. */}
       {devPort && (
         <div className="flex shrink-0 border-b border-fl-line lg:hidden">
           {(["chat", "preview"] as const).map((tab) => (
@@ -166,7 +166,8 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
               key={tab}
               type="button"
               onClick={() => setActiveTab(tab)}
-              className={`flex-1 border-b-2 py-2 font-plex-mono text-[12px] lowercase ${FOCUS_RING} ${
+              aria-current={activeTab === tab ? "true" : undefined}
+              className={`flex-1 border-b-2 py-2.5 font-plex-mono text-[12px] lowercase ${FOCUS_RING} ${
                 activeTab === tab
                   ? "border-fl-ink text-fl-ink"
                   : "border-transparent text-fl-ink-2 hover:text-fl-ink"
@@ -234,22 +235,30 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
 
 // Same neutral/green/red split as before, in fleet tokens: only failure and a
 // live run earn a colour, and the two quiet neutrals keep their old ordering
-// (queued and completed read louder than a cancelled run). `fleet-dot-live` is
-// the system's one ambient animation, and it honours reduced-motion.
+// (queued and completed read louder than a cancelled run).
 const STATUS_DOT: Record<string, string> = {
   queued: "bg-fl-ink-2",
-  running: "bg-fl-green fleet-dot-live",
+  running: "bg-fl-green",
   completed: "bg-fl-ink-2",
   failed: "bg-fl-red",
   cancelled: "bg-fl-ink-3",
 };
 
-function StatusDot({ status }: { status: string }) {
+/**
+ * `live` is the container working, not the task being open — the two part
+ * company constantly. A task sits at status `running` while its agent is idle
+ * between turns waiting on you, which is precisely the moment the view should
+ * stop moving. Keying the breath to the task's status instead would leave it
+ * running forever on every open task. `fleet-dot-live` is the system's one
+ * ambient animation and it honours reduced-motion, which `animate-pulse` —
+ * what this replaces — did not.
+ */
+function StatusDot({ status, live }: { status: string; live: boolean }) {
   return (
     <span
       className={`inline-block h-1.5 w-1.5 rounded-full ${
         STATUS_DOT[status] ?? "bg-fl-ink-2"
-      }`}
+      } ${live ? "fleet-dot-live" : ""}`}
     />
   );
 }


### PR DESCRIPTION
Closes #123

#117 moved the fleet theme into the root layout, so a light-preference OS now resolves the live view to the light ground (`#eae5dc`) with no user action — but the live view's hardcoded dark islands did not move with it. This restyles the preview pane and the live-view container chrome into fleet tokens and type. Behavior is untouched.

The headline case is the one the ticket calls out: the active mobile tab rendered `text-zinc-100` on the light ground, about **1.1:1** — effectively invisible, on the control you use to switch between chat and preview on a phone. It is now `text-fl-ink`: **12.9:1** light, **15.6:1** dark. The idle tab moves from `zinc-500` to `fl-ink-2` (4.6:1 / 7.3:1).

## What changed

**`preview-pane.tsx`** — toolbar, empty state, and the over-iframe loading/error messages. The toolbar controls are plain buttons rather than shadcn `Button`s: the ghost/outline variants resolve to the *greyscale shadcn* tokens, which don't track the fleet theme, so a shadcn `outline` button sits on parchment as a grey card. A message over the iframe gets its own opaque ground (`StatusNote`) instead of relying on a translucent scrim — whatever the dev server painted underneath isn't a background this palette controls.

**`task-chat.tsx`** — mobile tab strip, references block, desktop split divider, terminal footer, container label and status dot.

Selection on the tab strip is marked in ink, not colour. Colour in this system is semantic and which pane you're looking at says nothing about the run, so the old `purple-500` had no meaning to carry. The rule is heavier than the shell nav's hairline because this is a thumb-sized control, not a header link.

The running label loses `animate-pulse` and the dot gains `fleet-dot-live` — the fleet's one ambient animation, which unlike `animate-pulse` honours `prefers-reduced-motion`.

## Verification

`pnpm build` passes; 693 tests pass; `pnpm lint` adds no new errors (see the one caveat below). No `zinc-*` survives in either file, and no other hardcoded palette class either — the remaining `zinc` in the rendered live view comes from `task-stream.tsx` and `message-input.tsx`, which belong to #121 and #122.

**On "verified in both themes":** Chromium's system libraries (`libnspr4`/`libnss3`) aren't installed in this environment and sudo needs a password, so I could not take screenshots. Instead I verified the two things a screenshot would have caught:

1. **Every token class actually compiles.** All 14 `text-/bg-/border-fl-*` utilities used across both files resolve to a real rule against the right custom property in the built CSS, and each referenced `--fl-*` var is defined in all three theme scopes (`.fleet`, the `prefers-color-scheme: light` block, and `[data-fleet-theme="light"]`). A typo'd token — the realistic failure, since it renders as *nothing* rather than erroring — would have shown here.
2. **Contrast, computed from the tokens in `globals.css`** for every foreground/background pair in the diff, in both themes. Figures quoted above.

I also rendered `PreviewPane` through `react-dom/server` and diffed the markup, and seeded task rows to check the container chrome in the real SSR output.

A reviewer with a working browser should still eyeball it; the above is not a substitute for looking at it on a phone.

## Self-review

The `/code-review` pass against `origin/main` found a **real regression I'd introduced**, fixed in f3e2b82: I moved the running cue from the label's `animate-pulse` (keyed to `containerStatus`) onto the dot (keyed to task `status`), and those part company — `turn-manager.ts:349` sets `containerStatus: "idle"` at end of turn while the task stays `running`. An agent waiting on a follow-up, the exact "needs you" state, would have breathed forever. `live` is now its own prop off `containerStatus`. Verified both ways in SSR output.

Also acted on: `noopener` on the preview's `window.open` (it's agent-authored code); scrim back to 50% (I'd raised it to 80%, forgetting this overlay fires on *every* agent write via the 500ms reload — it would blink the preview out on each save); explicit heights on the toolbar/retry buttons (11px mono in a bare button is ~18px, and these are thumb targets); the running label to neutral ink (`text-fl-green` on the bare light ground is 3.8:1, under AA at 11px — the system's other green text sits on a wash or card, so precedent didn't cover it); `aria-current` on the tabs; and the system's `ActionLink` underline idiom on the issue/PR links.

**Findings I did not act on, deliberately:**

- **`FOCUS_RING` is 2.44:1 on the light ground**, under the 3:1 non-text minimum. This is real, but `FOCUS_RING` is a shared constant from #117 used app-wide — retuning it from a preview-pane ticket would silently restyle every screen. It deserves its own ticket, and I'd support one.
- **`StatusDot` duplicates `LiveDot`/`DOT_COLOR` in fleet-bits.** Reusing `LiveDot` would either change the header's appearance (it renders a text label beside every non-live state) or require extending its state union with task statuses — a shared-component change affecting the dashboard. The duplication is a 5-entry record and a span.
- **`ToolbarButton`/`StatusNote` could live in fleet-bits.** Fair, and #119/#120/#122 will likely each want the same quiet mono button — but promoting an atom on one usage is speculative. Better promoted when the second caller appears.
- **The `!devPort` empty state is unreachable**, since `task-chat.tsx` guards with `devPort &&`. True. Deleting it is a structural change beyond a styling ticket, and it keeps the component coherent standalone.
- **`pnpm lint` reports one error on `preview-pane.tsx:92`** (`react-hooks/set-state-in-effect`). It is **pre-existing** — byte-identical on `main`, same line and rule, and the diff doesn't touch that effect. Fixing it means restructuring an effect that drives the TLS pre-warm, which is real behavior risk in a styling ticket. Flagging rather than smuggling it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)