### PR TITLE
Settings: fleet reskin + per-project autonomy control (#119)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -28,11 +28,14 @@ or on the `AUTONOMY_ALLOWED_AUTHORS` allow-list. Priority is expressed purely by
 
 Autonomy is off by default at two levels, and **both** must be on for pickup:
 
-1. **Global kill switch** — `AUTONOMY_ENABLED` (env, from Doppler `interlude/prd`).
+1. **Boot master** — `AUTONOMY_ENABLED` (env, from Doppler `interlude/prd`).
+   False and no sweep ever starts; read once, so changing it means a restart.
 2. **Per-project toggle** — `projects.autonomyEnabled` (off by default; enabled
-   deliberately, per project, never in bulk).
+   deliberately, per project, never in bulk). Arm and disarm it on `/settings`,
+   where each project also shows its preflight verdict.
 
-A project is only claimable when both are on **and** its preflight passes.
+A project is only claimable when both are on, the runtime kill switch is lifted
+(*Pause pickup* below), **and** its preflight passes.
 
 ### Preflight: is a repo safe to run unattended?
 
@@ -145,8 +148,9 @@ the dashboard answers "what's happening".
 Pausing only stops autonomous **pickup**. In-flight runs finish, and interactive
 chat/preview is never affected.
 
-- **Globally, right now (kill switch):** flip the durable runtime switch — no
-  restart, effective at the next sweep tick (≤30s).
+- **Globally, right now (kill switch):** press **stop the fleet** on `/settings`,
+  or flip the durable runtime switch by hand — either way no restart, effective
+  at the next sweep tick (≤30s).
 
   ```bash
   # Engage: nothing new is claimed anywhere (implement or triage)
@@ -167,7 +171,8 @@ chat/preview is never affected.
 - **Globally, hard off (boot master):** set `AUTONOMY_ENABLED=false` in Doppler
   `interlude/prd` and restart. Sweeps never start at all. Use this to stand the
   fleet down for a while; use the kill switch to stop it now.
-- **Per project:** disable the toggle —
+- **Per project:** press **disarm** on the project's card in `/settings`, or
+  disable the toggle by hand —
 
   ```bash
   curl -s -X PATCH http://localhost:3000/api/projects/<id> \

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,22 +1,40 @@
 import { AppShell } from "@/components/app-shell";
+import { Eyebrow } from "@/components/fleet/fleet-bits";
 import { ProjectList } from "@/components/project-list";
 import { DockerStatus } from "@/components/docker-status";
+import { KillSwitch } from "@/components/kill-switch";
 
-// Settings is reskinned (and gains the autonomy controls) by its own ticket;
-// here it just moves inside the shared shell (issue #117).
+/**
+ * The fleet's control room (issue #119). Read top to bottom it answers the
+ * three questions the owner actually arrives with: is the fleet allowed to pick
+ * up work at all, which projects is it allowed to pick it up for, and is the
+ * box underneath healthy enough to run it.
+ */
 export default function SettingsPage() {
   return (
     <AppShell section="settings">
-      <div className="space-y-6 py-2">
-        <h1 className="text-2xl font-bold">Settings</h1>
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Docker</h2>
-          <DockerStatus />
+      <div className="space-y-10">
+        <div className="mb-6 mt-2">
+          <h1 className="text-lg text-fl-ink">Settings</h1>
+          <p className="mt-0.5 text-[13px] text-fl-ink-3">
+            What the fleet may do while you&apos;re not watching.
+          </p>
         </div>
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Projects</h2>
+
+        <section aria-label="Autonomy" className="space-y-3">
+          <Eyebrow>Autonomy</Eyebrow>
+          <KillSwitch />
+        </section>
+
+        <section aria-label="Projects" className="space-y-3">
+          <Eyebrow>Projects</Eyebrow>
           <ProjectList />
-        </div>
+        </section>
+
+        <section aria-label="Environment" className="space-y-3">
+          <Eyebrow>Environment</Eyebrow>
+          <DockerStatus />
+        </section>
       </div>
     </AppShell>
   );

--- a/src/components/confirm-strip.tsx
+++ b/src/components/confirm-strip.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ControlButton, PANEL, TONES } from "@/components/fleet/fleet-bits";
+
+/**
+ * The pause between pressing a control and it happening, for the two controls
+ * on the settings screen that authorise unattended spend: arming a project, and
+ * lifting the fleet-wide kill switch. One component so the two can't drift into
+ * asking differently — the tone says which kind of yes this is (`cool` for the
+ * ordinary one, `amber` when it overrides a warning), and the prose above the
+ * buttons says exactly what will happen.
+ *
+ * Full width and last in its row: it opens *under* whatever was pressed, so the
+ * card doesn't rearrange itself beneath the owner's finger.
+ */
+export function ConfirmStrip({
+  label,
+  tone,
+  confirm,
+  busyLabel,
+  busy,
+  error,
+  onConfirm,
+  onCancel,
+  children,
+}: {
+  /** Names the decision for a screen reader, e.g. "Confirm arming lemons". */
+  label: string;
+  tone: "cool" | "amber";
+  /** The affirmative button's text — always a verb, never "OK". */
+  confirm: string;
+  busyLabel: string;
+  busy: boolean;
+  /** Why the last confirmation didn't take, if it didn't. */
+  error: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** What is about to happen, in the owner's language. */
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className={`order-last w-full ${PANEL} ${TONES[tone]}`}
+    >
+      {children}
+      <div className="flex flex-wrap gap-2">
+        <ControlButton tone={tone} disabled={busy} onClick={onConfirm}>
+          {busy ? busyLabel : confirm}
+        </ControlButton>
+        <ControlButton disabled={busy} onClick={onCancel}>
+          cancel
+        </ControlButton>
+      </div>
+      {error !== null && (
+        <p role="alert" className="text-[13px] text-fl-red">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/docker-status.tsx
+++ b/src/components/docker-status.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { useCallback, useEffect, useState } from "react";
+import { Chip, ControlButton } from "@/components/fleet/fleet-bits";
+
+/**
+ * The environment readout on the settings screen (issue #119): whether the
+ * Docker daemon is reachable and whether the agent image has been built. Both
+ * are preconditions for any task running at all, so this is the first thing to
+ * look at when nothing starts.
+ *
+ * A probe that fails now says so and offers a retry — it used to sit on
+ * "Checking…" forever, which reads exactly like a hung daemon and is the one
+ * answer this panel must never give by accident.
+ */
 
 type DockerInfo = {
   docker: boolean;
@@ -12,45 +22,97 @@ type DockerInfo = {
 
 export function DockerStatus() {
   const [info, setInfo] = useState<DockerInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    fetch("/api/settings/docker")
-      .then((r) => r.json())
-      .then(setInfo)
-      .catch(() => setInfo(null));
+    const controller = new AbortController();
+    let stopped = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/docker", {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`the server answered ${res.status}`);
+        const data: DockerInfo = await res.json();
+        if (stopped) return;
+        setInfo(data);
+        setError(null);
+      } catch (err) {
+        if (stopped || controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "the request failed");
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      controller.abort();
+    };
+  }, [reloadKey]);
+
+  const retry = useCallback(() => {
+    setError(null);
+    setReloadKey((key) => key + 1);
   }, []);
 
-  if (!info) {
+  if (error !== null && info === null) {
     return (
-      <Card>
-        <CardHeader className="py-3">
-          <span className="font-medium">Docker</span>
-        </CardHeader>
-        <CardContent className="py-2 text-sm text-muted-foreground">
-          Checking...
-        </CardContent>
-      </Card>
+      <Panel>
+        <p role="alert" className="text-[13px] text-fl-red">
+          Couldn&apos;t read the Docker status — {error}.
+        </p>
+        <ControlButton onClick={retry}>retry</ControlButton>
+      </Panel>
+    );
+  }
+
+  if (info === null) {
+    return (
+      <Panel>
+        <p className="font-plex-mono text-[11px] text-fl-ink-3">checking…</p>
+      </Panel>
     );
   }
 
   return (
-    <Card>
-      <CardHeader className="py-3 flex flex-row items-center justify-between">
-        <span className="font-medium">Docker</span>
-        <Badge variant={info.docker ? "default" : "destructive"}>
-          {info.docker ? "Connected" : "Not Available"}
-        </Badge>
-      </CardHeader>
-      <CardContent className="py-2 text-sm space-y-1">
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">Agent image</span>
-          <span>{info.image ? "Ready" : "Not built"}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">Image name</span>
-          <span className="font-mono text-xs">{info.imageName}</span>
-        </div>
-      </CardContent>
-    </Card>
+    <Panel>
+      <Row label="daemon">
+        <Chip tone={info.docker ? "green" : "red"}>
+          {info.docker ? "connected" : "unreachable"}
+        </Chip>
+      </Row>
+      <Row label="agent image">
+        {/* Amber, not red: with the daemon down the image can't be probed at
+            all, so "not built" would be a guess dressed as a verdict. */}
+        <Chip tone={info.docker ? (info.image ? "green" : "amber") : "quiet"}>
+          {!info.docker ? "unknown" : info.image ? "ready" : "not built"}
+        </Chip>
+      </Row>
+      <Row label="image">
+        <span className="truncate font-plex-mono text-[11px] text-fl-ink-2">
+          {info.imageName}
+        </span>
+      </Row>
+    </Panel>
+  );
+}
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="space-y-2 rounded-[4px] border border-fl-line bg-fl-card px-3 py-2.5">
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="font-plex-mono text-[11px] lowercase text-fl-ink-3">
+        {label}
+      </span>
+      {children}
+    </div>
   );
 }

--- a/src/components/docker-status.tsx
+++ b/src/components/docker-status.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Chip, ControlButton } from "@/components/fleet/fleet-bits";
+import { Chip, LoadFailure, PANEL_PLAIN } from "@/components/fleet/fleet-bits";
+import { useLoad } from "@/lib/use-load";
 
 /**
  * The environment readout on the settings screen (issue #119): whether the
@@ -21,62 +21,22 @@ type DockerInfo = {
 };
 
 export function DockerStatus() {
-  const [info, setInfo] = useState<DockerInfo | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadKey, setReloadKey] = useState(0);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    let stopped = false;
-
-    (async () => {
-      try {
-        const res = await fetch("/api/settings/docker", {
-          signal: controller.signal,
-        });
-        if (!res.ok) throw new Error(`the server answered ${res.status}`);
-        const data: DockerInfo = await res.json();
-        if (stopped) return;
-        setInfo(data);
-        setError(null);
-      } catch (err) {
-        if (stopped || controller.signal.aborted) return;
-        setError(err instanceof Error ? err.message : "the request failed");
-      }
-    })();
-
-    return () => {
-      stopped = true;
-      controller.abort();
-    };
-  }, [reloadKey]);
-
-  const retry = useCallback(() => {
-    setError(null);
-    setReloadKey((key) => key + 1);
-  }, []);
-
-  if (error !== null && info === null) {
-    return (
-      <Panel>
-        <p role="alert" className="text-[13px] text-fl-red">
-          Couldn&apos;t read the Docker status — {error}.
-        </p>
-        <ControlButton onClick={retry}>retry</ControlButton>
-      </Panel>
-    );
-  }
+  const { data: info, error, reload } = useLoad<DockerInfo>("/api/settings/docker");
 
   if (info === null) {
     return (
-      <Panel>
-        <p className="font-plex-mono text-[11px] text-fl-ink-3">checking…</p>
-      </Panel>
+      <div className={PANEL_PLAIN}>
+        {error === null ? (
+          <p className="font-plex-mono text-[11px] text-fl-ink-3">checking…</p>
+        ) : (
+          <LoadFailure what="the Docker status" error={error} onRetry={reload} />
+        )}
+      </div>
     );
   }
 
   return (
-    <Panel>
+    <div className={PANEL_PLAIN}>
       <Row label="daemon">
         <Chip tone={info.docker ? "green" : "red"}>
           {info.docker ? "connected" : "unreachable"}
@@ -94,14 +54,6 @@ export function DockerStatus() {
           {info.imageName}
         </span>
       </Row>
-    </Panel>
-  );
-}
-
-function Panel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="space-y-2 rounded-[4px] border border-fl-line bg-fl-card px-3 py-2.5">
-      {children}
     </div>
   );
 }

--- a/src/components/fleet/fleet-bits.tsx
+++ b/src/components/fleet/fleet-bits.tsx
@@ -9,6 +9,13 @@
 export const FOCUS_RING =
   "focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-fl-ink-3";
 
+/** The one text-input skin in the system — a fleet card behind a hairline, Plex
+ * on top. Shared by every form the app has so a field can't drift between
+ * screens. */
+export const FIELD =
+  "w-full rounded-[4px] border border-fl-line bg-fl-card px-3 py-2 text-sm text-fl-ink " +
+  "placeholder:text-fl-ink-3 focus:border-fl-line-strong focus:outline-none";
+
 export function Eyebrow({ children }: { children: React.ReactNode }) {
   return (
     <h2 className="font-plex-mono text-[11px] font-medium uppercase tracking-[0.14em] text-fl-ink-3">
@@ -81,6 +88,42 @@ export function Chip({
     >
       {children}
     </span>
+  );
+}
+
+/** A control in the instrument-panel voice: a chip you can press. Tone carries
+ * the same meaning it carries everywhere — `cool` is the owner acting, `amber`
+ * a deliberate hold or an override, `quiet` everything reversible — so a button
+ * never invents a colour of its own. */
+const BUTTON_TONES = {
+  quiet: "border-fl-line text-fl-ink-2 hover:border-fl-line-strong hover:text-fl-ink",
+  cool: `${TONES.cool} hover:opacity-90`,
+  amber: `${TONES.amber} hover:opacity-90`,
+  red: `${TONES.red} hover:opacity-90`,
+} as const;
+
+export function ControlButton({
+  tone = "quiet",
+  onClick,
+  disabled,
+  children,
+  ...rest
+}: {
+  tone?: keyof typeof BUTTON_TONES;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+} & Pick<React.ButtonHTMLAttributes<HTMLButtonElement>, "aria-expanded" | "aria-label">) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded-[4px] border px-2 py-0.5 font-plex-mono text-[11px] lowercase transition-opacity disabled:opacity-40 ${BUTTON_TONES[tone]} ${FOCUS_RING}`}
+      {...rest}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/src/components/fleet/fleet-bits.tsx
+++ b/src/components/fleet/fleet-bits.tsx
@@ -16,6 +16,14 @@ export const FIELD =
   "w-full rounded-[4px] border border-fl-line bg-fl-card px-3 py-2 text-sm text-fl-ink " +
   "placeholder:text-fl-ink-3 focus:border-fl-line-strong focus:outline-none";
 
+/** The geometry every panel and card in the system shares. Left untinted so a
+ * caller can compose it with a `TONES` entry when the panel carries a state the
+ * owner must not miss — a held fleet, a confirmation waiting on a press. */
+export const PANEL = "space-y-2.5 rounded-[4px] border px-3 py-2.5";
+
+/** A panel in its ordinary clothes: hairline over the card ground. */
+export const PANEL_PLAIN = `${PANEL} border-fl-line bg-fl-card`;
+
 export function Eyebrow({ children }: { children: React.ReactNode }) {
   return (
     <h2 className="font-plex-mono text-[11px] font-medium uppercase tracking-[0.14em] text-fl-ink-3">
@@ -99,7 +107,6 @@ const BUTTON_TONES = {
   quiet: "border-fl-line text-fl-ink-2 hover:border-fl-line-strong hover:text-fl-ink",
   cool: `${TONES.cool} hover:opacity-90`,
   amber: `${TONES.amber} hover:opacity-90`,
-  red: `${TONES.red} hover:opacity-90`,
 } as const;
 
 export function ControlButton({
@@ -124,6 +131,33 @@ export function ControlButton({
     >
       {children}
     </button>
+  );
+}
+
+/** The system's one filled control, for the single primary action on a form —
+ * cool, because everything started from a form is the owner acting. */
+export const PRIMARY_BUTTON =
+  "rounded-[4px] bg-fl-cool px-4 py-2.5 text-sm font-medium text-fl-ground " +
+  `transition-opacity hover:opacity-90 disabled:opacity-40 ${FOCUS_RING}`;
+
+/** A resource that wouldn't load, said once for the whole app: what was being
+ * read, why it failed, and the way back. */
+export function LoadFailure({
+  what,
+  error,
+  onRetry,
+}: {
+  what: string;
+  error: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <p role="alert" className="text-[13px] text-fl-red">
+        Couldn&apos;t load {what} — {error}.
+      </p>
+      <ControlButton onClick={onRetry}>retry</ControlButton>
+    </div>
   );
 }
 

--- a/src/components/kill-switch.tsx
+++ b/src/components/kill-switch.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ControlButton, TONES } from "@/components/fleet/fleet-bits";
+
+/**
+ * The global autonomy kill switch, in the room where the owner arms things
+ * (issues #118, #119). It drives the existing `PATCH /api/settings/autonomy`;
+ * the flag is durable and the sweep reads it fresh every tick, so engaging it
+ * stops all new pickup at the next tick with no restart, and survives one.
+ *
+ * The two directions are deliberately asymmetric. Engaging is one press:
+ * stopping the fleet is always safe, and a control room where "stop" asks you
+ * to confirm is a control room you hesitate in. Lifting re-arms every armed
+ * project at once, so it takes the same deliberate confirmation as arming a
+ * single one.
+ *
+ * `envMaster` is reported beside the flag because they are different controls:
+ * with `AUTONOMY_ENABLED` unset no sweep runs at all, and lifting the switch
+ * cannot arm a fleet the boot master has disarmed. Saying so here is what stops
+ * "I lifted it and nothing happened".
+ */
+
+interface AutonomySettings {
+  globalAutonomyPaused: boolean;
+  /** ISO-8601; null = the switch has never been touched on this install. */
+  updatedAt: string | null;
+  envMaster: boolean;
+}
+
+export function KillSwitch() {
+  const [state, setState] = useState<AutonomySettings | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirmingLift, setConfirmingLift] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let stopped = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/autonomy", {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`the server answered ${res.status}`);
+        const data: AutonomySettings = await res.json();
+        if (stopped) return;
+        setState(data);
+        setError(null);
+      } catch (err) {
+        if (stopped || controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "the request failed");
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      controller.abort();
+    };
+  }, [reloadKey]);
+
+  const set = useCallback(async (paused: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings/autonomy", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paused }),
+      });
+      if (!res.ok) throw new Error(`the server answered ${res.status}`);
+      // The endpoint answers with the whole state, so the panel shows what was
+      // actually stored rather than what was asked for.
+      setState(await res.json());
+      setConfirmingLift(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "the request failed");
+    }
+    setBusy(false);
+  }, []);
+
+  if (state === null) {
+    return (
+      <Panel tone="quiet">
+        {error === null ? (
+          <p className="font-plex-mono text-[11px] text-fl-ink-3">checking…</p>
+        ) : (
+          <>
+            <p role="alert" className="text-[13px] text-fl-red">
+              Couldn&apos;t read the kill switch — {error}.
+            </p>
+            <ControlButton
+              onClick={() => {
+                setError(null);
+                setReloadKey((key) => key + 1);
+              }}
+            >
+              retry
+            </ControlButton>
+          </>
+        )}
+      </Panel>
+    );
+  }
+
+  const held = state.globalAutonomyPaused;
+
+  return (
+    <Panel tone={held ? "amber" : "quiet"}>
+      <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
+        <div className="min-w-0 space-y-1">
+          <p className={`text-sm ${held ? "" : "text-fl-ink"}`}>
+            {held
+              ? "Autonomous pickup is held."
+              : "Autonomous pickup is running."}
+          </p>
+          <p className="text-[13px] text-fl-ink-3">
+            {held
+              ? "Nothing new is claimed — no implement pickup, no triage pass. Runs already in flight carry on and can be cancelled one by one."
+              : "Armed projects claim their ready-for-agent tickets unattended. Engaging the switch stops that at the next sweep tick."}
+          </p>
+          {!state.envMaster && (
+            <p className="text-[13px] text-fl-ink-3">
+              <span className="font-plex-mono">AUTONOMY_ENABLED</span> is off, so
+              no sweep runs at all on this install — lifting the switch cannot
+              start one.
+            </p>
+          )}
+          {state.updatedAt !== null && (
+            <p className="font-plex-mono text-[11px] text-fl-ink-3">
+              last changed {formatChanged(state.updatedAt)}
+            </p>
+          )}
+        </div>
+
+        {!confirmingLift && (
+          <ControlButton
+            tone={held ? "cool" : "amber"}
+            disabled={busy}
+            onClick={() => (held ? setConfirmingLift(true) : set(true))}
+          >
+            {busy ? "…" : held ? "lift…" : "stop the fleet"}
+          </ControlButton>
+        )}
+      </div>
+
+      {confirmingLift && (
+        <div
+          role="group"
+          aria-label="Confirm lifting the kill switch"
+          className={`space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES.cool}`}
+        >
+          <p className="text-[13px]">
+            Lift the kill switch? Every armed project resumes claiming tickets
+            unattended from the next sweep tick.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <ControlButton tone="cool" disabled={busy} onClick={() => set(false)}>
+              {busy ? "lifting…" : "confirm lift"}
+            </ControlButton>
+            <ControlButton disabled={busy} onClick={() => setConfirmingLift(false)}>
+              cancel
+            </ControlButton>
+          </div>
+        </div>
+      )}
+
+      {error !== null && (
+        <p role="alert" className="text-[13px] text-fl-red">
+          The switch didn&apos;t move — {error}.
+        </p>
+      )}
+    </Panel>
+  );
+}
+
+/** Rendered only after the client fetch resolves, so a locale-formatted time
+ * can never disagree with the server's first paint. */
+function formatChanged(iso: string): string {
+  const at = new Date(iso);
+  return Number.isNaN(at.getTime())
+    ? iso
+    : at.toLocaleString("en-GB", { hour12: false });
+}
+
+function Panel({
+  tone,
+  children,
+}: {
+  tone: keyof typeof TONES;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`space-y-2.5 rounded-[4px] border px-3 py-2.5 ${
+        tone === "quiet" ? "border-fl-line bg-fl-card" : TONES[tone]
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/kill-switch.tsx
+++ b/src/components/kill-switch.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { ControlButton, TONES } from "@/components/fleet/fleet-bits";
+import { useState } from "react";
+import {
+  ControlButton,
+  LoadFailure,
+  PANEL,
+  PANEL_PLAIN,
+  TONES,
+} from "@/components/fleet/fleet-bits";
+import { ConfirmStrip } from "@/components/confirm-strip";
+import { useLoad } from "@/lib/use-load";
 
 /**
  * The global autonomy kill switch, in the room where the owner arms things
@@ -29,41 +37,19 @@ interface AutonomySettings {
 }
 
 export function KillSwitch() {
-  const [state, setState] = useState<AutonomySettings | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: state,
+    error: loadError,
+    reload,
+    setData,
+  } = useLoad<AutonomySettings>("/api/settings/autonomy");
   const [busy, setBusy] = useState(false);
   const [confirmingLift, setConfirmingLift] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
+  const [moveError, setMoveError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    let stopped = false;
-
-    (async () => {
-      try {
-        const res = await fetch("/api/settings/autonomy", {
-          signal: controller.signal,
-        });
-        if (!res.ok) throw new Error(`the server answered ${res.status}`);
-        const data: AutonomySettings = await res.json();
-        if (stopped) return;
-        setState(data);
-        setError(null);
-      } catch (err) {
-        if (stopped || controller.signal.aborted) return;
-        setError(err instanceof Error ? err.message : "the request failed");
-      }
-    })();
-
-    return () => {
-      stopped = true;
-      controller.abort();
-    };
-  }, [reloadKey]);
-
-  const set = useCallback(async (paused: boolean) => {
+  async function setPaused(paused: boolean) {
     setBusy(true);
-    setError(null);
+    setMoveError(null);
     try {
       const res = await fetch("/api/settings/autonomy", {
         method: "PATCH",
@@ -73,42 +59,32 @@ export function KillSwitch() {
       if (!res.ok) throw new Error(`the server answered ${res.status}`);
       // The endpoint answers with the whole state, so the panel shows what was
       // actually stored rather than what was asked for.
-      setState(await res.json());
+      setData(await res.json());
       setConfirmingLift(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "the request failed");
+      setMoveError(
+        `The switch didn't move — ${err instanceof Error ? err.message : "the request failed"}.`
+      );
     }
     setBusy(false);
-  }, []);
+  }
 
   if (state === null) {
     return (
-      <Panel tone="quiet">
-        {error === null ? (
+      <div className={PANEL_PLAIN}>
+        {loadError === null ? (
           <p className="font-plex-mono text-[11px] text-fl-ink-3">checking…</p>
         ) : (
-          <>
-            <p role="alert" className="text-[13px] text-fl-red">
-              Couldn&apos;t read the kill switch — {error}.
-            </p>
-            <ControlButton
-              onClick={() => {
-                setError(null);
-                setReloadKey((key) => key + 1);
-              }}
-            >
-              retry
-            </ControlButton>
-          </>
+          <LoadFailure what="the kill switch" error={loadError} onRetry={reload} />
         )}
-      </Panel>
+      </div>
     );
   }
 
   const held = state.globalAutonomyPaused;
 
   return (
-    <Panel tone={held ? "amber" : "quiet"}>
+    <div className={held ? `${PANEL} ${TONES.amber}` : PANEL_PLAIN}>
       <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
         <div className="min-w-0 space-y-1">
           <p className={`text-sm ${held ? "" : "text-fl-ink"}`}>
@@ -139,7 +115,7 @@ export function KillSwitch() {
           <ControlButton
             tone={held ? "cool" : "amber"}
             disabled={busy}
-            onClick={() => (held ? setConfirmingLift(true) : set(true))}
+            onClick={() => (held ? setConfirmingLift(true) : setPaused(true))}
           >
             {busy ? "…" : held ? "lift…" : "stop the fleet"}
           </ControlButton>
@@ -147,32 +123,31 @@ export function KillSwitch() {
       </div>
 
       {confirmingLift && (
-        <div
-          role="group"
-          aria-label="Confirm lifting the kill switch"
-          className={`space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES.cool}`}
+        <ConfirmStrip
+          label="Confirm lifting the kill switch"
+          tone="cool"
+          confirm="confirm lift"
+          busyLabel="lifting…"
+          busy={busy}
+          error={moveError}
+          onConfirm={() => setPaused(false)}
+          onCancel={() => setConfirmingLift(false)}
         >
           <p className="text-[13px]">
             Lift the kill switch? Every armed project resumes claiming tickets
             unattended from the next sweep tick.
           </p>
-          <div className="flex flex-wrap gap-2">
-            <ControlButton tone="cool" disabled={busy} onClick={() => set(false)}>
-              {busy ? "lifting…" : "confirm lift"}
-            </ControlButton>
-            <ControlButton disabled={busy} onClick={() => setConfirmingLift(false)}>
-              cancel
-            </ControlButton>
-          </div>
-        </div>
+        </ConfirmStrip>
       )}
 
-      {error !== null && (
+      {/* Engaging has no strip of its own to fail inside, so its failure is
+          reported here. */}
+      {!confirmingLift && moveError !== null && (
         <p role="alert" className="text-[13px] text-fl-red">
-          The switch didn&apos;t move — {error}.
+          {moveError}
         </p>
       )}
-    </Panel>
+    </div>
   );
 }
 
@@ -183,22 +158,4 @@ function formatChanged(iso: string): string {
   return Number.isNaN(at.getTime())
     ? iso
     : at.toLocaleString("en-GB", { hour12: false });
-}
-
-function Panel({
-  tone,
-  children,
-}: {
-  tone: keyof typeof TONES;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className={`space-y-2.5 rounded-[4px] border px-3 py-2.5 ${
-        tone === "quiet" ? "border-fl-line bg-fl-card" : TONES[tone]
-      }`}
-    >
-      {children}
-    </div>
-  );
 }

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { SessionSkill } from "@/db/schema";
 import type { OpenIssue } from "@/lib/github/issues";
-import { Eyebrow, FIELD } from "@/components/fleet/fleet-bits";
+import { Eyebrow, FIELD, PRIMARY_BUTTON } from "@/components/fleet/fleet-bits";
 
 // A new task is either a plain chat task (the default, unchanged) or a
 // generation session running one of the estate's generation skills (issue #64).
@@ -243,7 +243,7 @@ export function NewTaskForm() {
       <button
         type="submit"
         disabled={submitting || !title.trim() || !projectId}
-        className="w-full rounded-[4px] bg-fl-cool px-4 py-2.5 text-sm font-medium text-fl-ground transition-opacity hover:opacity-90 disabled:opacity-40"
+        className={`w-full ${PRIMARY_BUTTON}`}
       >
         {submitting
           ? isSession

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { SessionSkill } from "@/db/schema";
 import type { OpenIssue } from "@/lib/github/issues";
-import { Eyebrow } from "@/components/fleet/fleet-bits";
+import { Eyebrow, FIELD } from "@/components/fleet/fleet-bits";
 
 // A new task is either a plain chat task (the default, unchanged) or a
 // generation session running one of the estate's generation skills (issue #64).
@@ -25,10 +25,6 @@ const SESSION_BLURBS: Record<SessionSkill, string> = {
   wayfinder: "Chart a new map of the territory",
 };
 const SESSION_ORDER = Object.keys(SESSION_BLURBS) as SessionSkill[];
-
-const FIELD =
-  "w-full rounded-[4px] border border-fl-line bg-fl-card px-3 py-2 text-sm text-fl-ink " +
-  "placeholder:text-fl-ink-3 focus:border-fl-line-strong focus:outline-none";
 
 export function NewTaskForm() {
   const router = useRouter();

--- a/src/components/project-list.tsx
+++ b/src/components/project-list.tsx
@@ -252,7 +252,9 @@ function AutonomyControl({
     <div
       role="group"
       aria-label={`Confirm arming ${project.name}`}
-      className={`w-full space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES[tone]}`}
+      // `order-last` keeps the button row where it was and opens the
+      // confirmation beneath it, so the card doesn't jump under the press.
+      className={`order-last w-full space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES[tone]}`}
     >
       <p className="text-[13px]">
         Arm {project.name} for unattended work? The loop will claim its

--- a/src/components/project-list.tsx
+++ b/src/components/project-list.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Chip,
   ControlButton,
   FIELD,
+  LoadFailure,
+  PANEL_PLAIN,
+  PRIMARY_BUTTON,
   TONES,
 } from "@/components/fleet/fleet-bits";
+import { ConfirmStrip } from "@/components/confirm-strip";
+import { useLoad } from "@/lib/use-load";
 import {
   armBlocker,
   canArm,
   preflightVerdict,
+  type PreflightState,
   type ProjectAutonomy,
 } from "@/lib/projects/autonomy";
 import {
@@ -40,71 +46,57 @@ interface Project extends ProjectAutonomy {
   discordChannelId: string | null;
 }
 
+/** The chip's tint per verdict. A failing preflight is something to fix, not an
+ * incident, so it reads amber — the tone the dashboard gives it too. */
+const VERDICT_TONE: Record<PreflightState, "green" | "amber" | "quiet"> = {
+  passing: "green",
+  failing: "amber",
+  unchecked: "quiet",
+};
+
 export function ProjectList() {
-  // null = never loaded, so a failed load can't masquerade as "no projects" —
-  // the same distinction the archive draws.
-  const [projects, setProjects] = useState<Project[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadKey, setReloadKey] = useState(0);
-
-  const reload = useCallback(() => setReloadKey((key) => key + 1), []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    let stopped = false;
-
-    (async () => {
-      try {
-        const res = await fetch("/api/projects", { signal: controller.signal });
-        if (!res.ok) throw new Error(`the server answered ${res.status}`);
-        const data: Project[] = await res.json();
-        if (stopped) return;
-        setProjects(data);
-        setError(null);
-      } catch (err) {
-        if (stopped || controller.signal.aborted) return;
-        setError(err instanceof Error ? err.message : "the request failed");
-      }
-    })();
-
-    return () => {
-      stopped = true;
-      controller.abort();
-    };
-  }, [reloadKey]);
+  const { data: projects, error, reload, setData } = useLoad<Project[]>("/api/projects");
 
   /** A PATCH answers with the whole updated row — including the preflight the
    * server just re-ran — so the changed card is replaced from the response
    * rather than re-fetching the list and hoping it agrees. */
-  const replace = useCallback((updated: Project) => {
-    setProjects((current) =>
-      current === null
-        ? current
-        : current.map((p) => (p.id === updated.id ? updated : p))
+  const replace = useCallback(
+    (updated: Project) => {
+      setData((current) =>
+        current === null
+          ? current
+          : current.map((p) => (p.id === updated.id ? updated : p))
+      );
+    },
+    [setData]
+  );
+
+  if (projects === null) {
+    return error === null ? (
+      <p className="font-plex-mono text-[11px] text-fl-ink-3">loading…</p>
+    ) : (
+      <LoadFailure what="your projects" error={error} onRetry={reload} />
     );
-  }, []);
+  }
 
   return (
     <div className="space-y-4">
       <NewProjectForm onCreated={reload} />
 
-      {error !== null && projects === null ? (
-        <div className="space-y-2">
-          <p role="alert" className="text-[13px] text-fl-red">
-            Couldn&apos;t load your projects — {error}.
-          </p>
-          <ControlButton
-            onClick={() => {
-              setError(null);
-              reload();
-            }}
-          >
-            retry
-          </ControlButton>
-        </div>
-      ) : projects === null ? (
-        <p className="font-plex-mono text-[11px] text-fl-ink-3">loading…</p>
-      ) : projects.length === 0 ? (
+      {/* Something is on screen, so a failed reload is a staleness warning
+          rather than a wipe — including the reload a create fires, which is
+          how a new project can otherwise go missing without a word. */}
+      {error !== null && (
+        <p
+          role="alert"
+          className={`flex flex-wrap items-center gap-2 rounded-[4px] border px-3 py-2 text-[13px] ${TONES.amber}`}
+        >
+          <span>Not refreshing — {error}.</span>
+          <ControlButton onClick={reload}>retry</ControlButton>
+        </p>
+      )}
+
+      {projects.length === 0 ? (
         <p className="text-[13px] text-fl-ink-3">
           No projects yet — add one above to give the fleet something to work on.
         </p>
@@ -112,11 +104,7 @@ export function ProjectList() {
         <ul className="space-y-2">
           {projects.map((project) => (
             <li key={project.id}>
-              <ProjectCard
-                project={project}
-                onUpdated={replace}
-                onSaved={reload}
-              />
+              <ProjectCard project={project} onUpdated={replace} />
             </li>
           ))}
         </ul>
@@ -128,17 +116,15 @@ export function ProjectList() {
 function ProjectCard({
   project,
   onUpdated,
-  onSaved,
 }: {
   project: Project;
   onUpdated: (updated: Project) => void;
-  onSaved: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const verdict = preflightVerdict(project);
 
   return (
-    <div className="space-y-2.5 rounded-[4px] border border-fl-line bg-fl-card px-3 py-2.5">
+    <div className={PANEL_PLAIN}>
       <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
         <div className="min-w-0">
           <span className="block truncate text-sm text-fl-ink">
@@ -152,7 +138,9 @@ function ProjectCard({
           <Chip tone={project.autonomyEnabled ? "green" : "quiet"}>
             {project.autonomyEnabled ? "armed" : "disarmed"}
           </Chip>
-          <Chip tone={verdict.tone}>preflight {verdict.state}</Chip>
+          <Chip tone={VERDICT_TONE[verdict.state]}>
+            preflight {verdict.state}
+          </Chip>
         </div>
       </div>
 
@@ -179,7 +167,7 @@ function ProjectCard({
         </ControlButton>
       </div>
 
-      {editing && <ProjectEditForm project={project} onSaved={onSaved} />}
+      {editing && <ProjectEditForm project={project} onUpdated={onUpdated} />}
     </div>
   );
 }
@@ -216,7 +204,11 @@ function AutonomyControl({
       onUpdated(await res.json());
       setIntent(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "the request failed");
+      setError(
+        `Couldn't ${enabled ? "arm" : "disarm"} this project — ${
+          err instanceof Error ? err.message : "the request failed"
+        }.`
+      );
     }
     setBusy(false);
   }
@@ -227,7 +219,7 @@ function AutonomyControl({
         <ControlButton disabled={busy} onClick={() => setAutonomy(false)}>
           {busy ? "disarming…" : "disarm"}
         </ControlButton>
-        <Failure error={error} verb="disarm" />
+        <Failure error={error} />
       </>
     );
   }
@@ -242,7 +234,7 @@ function AutonomyControl({
         <ControlButton tone="amber" onClick={() => setIntent("override")}>
           arm anyway…
         </ControlButton>
-        <Failure error={error} verb="arm" />
+        <Failure error={error} />
       </>
     );
   }
@@ -250,14 +242,16 @@ function AutonomyControl({
   // The copy follows the state, not the press that opened the strip: if the
   // block cleared underneath it, this stopped being an override.
   const overriding = intent === "override" && blocker !== null;
-  const tone = overriding ? "amber" : "cool";
   return (
-    <div
-      role="group"
-      aria-label={`Confirm arming ${project.name}`}
-      // `order-last` keeps the button row where it was and opens the
-      // confirmation beneath it, so the card doesn't jump under the press.
-      className={`order-last w-full space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES[tone]}`}
+    <ConfirmStrip
+      label={`Confirm arming ${project.name}`}
+      tone={overriding ? "amber" : "cool"}
+      confirm="confirm arm"
+      busyLabel="arming…"
+      busy={busy}
+      error={error}
+      onConfirm={() => setAutonomy(true)}
+      onCancel={() => setIntent(null)}
     >
       <p className="text-[13px]">
         Arm {project.name} for unattended work? The loop will claim its
@@ -271,24 +265,17 @@ function AutonomyControl({
           loop still claims nothing until that is fixed.
         </p>
       )}
-      <div className="flex flex-wrap gap-2">
-        <ControlButton tone={tone} disabled={busy} onClick={() => setAutonomy(true)}>
-          {busy ? "arming…" : "confirm arm"}
-        </ControlButton>
-        <ControlButton disabled={busy} onClick={() => setIntent(null)}>
-          cancel
-        </ControlButton>
-      </div>
-      <Failure error={error} verb="arm" />
-    </div>
+    </ConfirmStrip>
   );
 }
 
-function Failure({ error, verb }: { error: string | null; verb: string }) {
+/** A press that didn't take, reported where the press was. Full width so it
+ * lands on its own line in the button row rather than squeezing it. */
+function Failure({ error }: { error: string | null }) {
   if (error === null) return null;
   return (
     <p role="alert" className="w-full text-[13px] text-fl-red">
-      Couldn&apos;t {verb} this project — {error}.
+      {error}
     </p>
   );
 }
@@ -344,7 +331,7 @@ function NewProjectForm({ onCreated }: { onCreated: () => void }) {
         <button
           type="submit"
           disabled={creating || !name.trim()}
-          className="shrink-0 rounded-[4px] bg-fl-cool px-4 py-2 text-sm font-medium text-fl-ground transition-opacity hover:opacity-90 disabled:opacity-40"
+          className={`shrink-0 ${PRIMARY_BUTTON}`}
         >
           {creating ? "Adding…" : "Add"}
         </button>
@@ -360,10 +347,10 @@ function NewProjectForm({ onCreated }: { onCreated: () => void }) {
 
 function ProjectEditForm({
   project,
-  onSaved,
+  onUpdated,
 }: {
   project: Project;
-  onSaved: () => void;
+  onUpdated: (updated: Project) => void;
 }) {
   const [name, setName] = useState(project.name);
   const [gitUrl, setGitUrl] = useState(project.gitUrl ?? "");
@@ -375,18 +362,20 @@ function ProjectEditForm({
 
   const hasDoppler = project.dopplerToken !== null;
 
+  /** Only what the owner actually changed is sent: a PATCH that restates the
+   * current values would be indistinguishable from an edit in the log, and
+   * `dopplerToken` in particular must never be echoed back as a write. */
+  const updates: Record<string, string | null> = {};
+  if (name.trim() !== project.name) updates.name = name.trim();
+  if (gitUrl.trim() !== (project.gitUrl ?? ""))
+    updates.gitUrl = gitUrl.trim() || null;
+  if (githubRepo.trim() !== (project.githubRepo ?? ""))
+    updates.githubRepo = githubRepo.trim() || null;
+  if (dopplerToken.trim()) updates.dopplerToken = dopplerToken.trim();
+  const dirty = Object.keys(updates).length > 0;
+
   async function save() {
-    if (saving) return;
-
-    const updates: Record<string, string | null> = {};
-    if (name.trim() !== project.name) updates.name = name.trim();
-    if (gitUrl.trim() !== (project.gitUrl ?? ""))
-      updates.gitUrl = gitUrl.trim() || null;
-    if (githubRepo.trim() !== (project.githubRepo ?? ""))
-      updates.githubRepo = githubRepo.trim() || null;
-    if (dopplerToken.trim()) updates.dopplerToken = dopplerToken.trim();
-
-    if (Object.keys(updates).length === 0) return;
+    if (saving || !dirty) return;
 
     setSaving(true);
     setError(null);
@@ -397,8 +386,8 @@ function ProjectEditForm({
         body: JSON.stringify(updates),
       });
       if (!res.ok) throw new Error(`the server answered ${res.status}`);
+      onUpdated(await res.json());
       setDopplerToken("");
-      onSaved();
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (err) {
@@ -461,7 +450,9 @@ function ProjectEditForm({
         )}
       </div>
       <div className="flex flex-wrap items-center gap-2">
-        <ControlButton tone="cool" disabled={saving} onClick={save}>
+        {/* Disabled until something differs, so "save" never looks like it was
+            ignored when there was nothing to do. */}
+        <ControlButton tone="cool" disabled={saving || !dirty} onClick={save}>
           {saving ? "saving…" : "save"}
         </ControlButton>
         {saved && (

--- a/src/components/project-list.tsx
+++ b/src/components/project-list.tsx
@@ -1,104 +1,355 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardHeader } from "@/components/ui/card";
+import { useCallback, useEffect, useState } from "react";
+import {
+  Chip,
+  ControlButton,
+  FIELD,
+  TONES,
+} from "@/components/fleet/fleet-bits";
+import {
+  armBlocker,
+  canArm,
+  preflightVerdict,
+  type ProjectAutonomy,
+} from "@/lib/projects/autonomy";
+import {
+  DEFAULT_ATTEMPT_BUDGET_USD,
+  MAX_ATTEMPTS,
+} from "@/lib/orchestrator/autonomy/budgets";
 
-type Project = {
+/**
+ * The project half of the control room (issue #119). Each card says what the
+ * fleet will do with the project unattended — armed or not, and whether its
+ * preflight passes — and is where the owner arms it.
+ *
+ * Arming is the one control here that starts unattended spend, so it is the one
+ * control that asks twice: `canArm` (pure, tested) decides whether the ordinary
+ * affordance is offered at all, and a failing preflight replaces it with an
+ * explicit override beside its reason. Disarming and every other edit are
+ * single-press — reversible things shouldn't be made to feel dangerous.
+ */
+
+interface Project extends ProjectAutonomy {
   id: string;
   name: string;
   githubRepo: string | null;
   gitUrl: string | null;
+  /** Presence only — the screen never renders the token itself. */
   dopplerToken: string | null;
   discordChannelId: string | null;
-  createdAt: string;
-};
+}
 
 export function ProjectList() {
-  const [projects, setProjects] = useState<Project[]>([]);
+  // null = never loaded, so a failed load can't masquerade as "no projects" —
+  // the same distinction the archive draws.
+  const [projects, setProjects] = useState<Project[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => setReloadKey((key) => key + 1), []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let stopped = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/projects", { signal: controller.signal });
+        if (!res.ok) throw new Error(`the server answered ${res.status}`);
+        const data: Project[] = await res.json();
+        if (stopped) return;
+        setProjects(data);
+        setError(null);
+      } catch (err) {
+        if (stopped || controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "the request failed");
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      controller.abort();
+    };
+  }, [reloadKey]);
+
+  /** A PATCH answers with the whole updated row — including the preflight the
+   * server just re-ran — so the changed card is replaced from the response
+   * rather than re-fetching the list and hoping it agrees. */
+  const replace = useCallback((updated: Project) => {
+    setProjects((current) =>
+      current === null
+        ? current
+        : current.map((p) => (p.id === updated.id ? updated : p))
+    );
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <NewProjectForm onCreated={reload} />
+
+      {error !== null && projects === null ? (
+        <div className="space-y-2">
+          <p role="alert" className="text-[13px] text-fl-red">
+            Couldn&apos;t load your projects — {error}.
+          </p>
+          <ControlButton
+            onClick={() => {
+              setError(null);
+              reload();
+            }}
+          >
+            retry
+          </ControlButton>
+        </div>
+      ) : projects === null ? (
+        <p className="font-plex-mono text-[11px] text-fl-ink-3">loading…</p>
+      ) : projects.length === 0 ? (
+        <p className="text-[13px] text-fl-ink-3">
+          No projects yet — add one above to give the fleet something to work on.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {projects.map((project) => (
+            <li key={project.id}>
+              <ProjectCard
+                project={project}
+                onUpdated={replace}
+                onSaved={reload}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  onUpdated,
+  onSaved,
+}: {
+  project: Project;
+  onUpdated: (updated: Project) => void;
+  onSaved: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const verdict = preflightVerdict(project);
+
+  return (
+    <div className="space-y-2.5 rounded-[4px] border border-fl-line bg-fl-card px-3 py-2.5">
+      <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1.5">
+        <div className="min-w-0">
+          <span className="block truncate text-sm text-fl-ink">
+            {project.name}
+          </span>
+          <span className="block truncate font-plex-mono text-[11px] text-fl-ink-3">
+            {project.githubRepo ?? project.gitUrl ?? "no repo configured"}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Chip tone={project.autonomyEnabled ? "green" : "quiet"}>
+            {project.autonomyEnabled ? "armed" : "disarmed"}
+          </Chip>
+          <Chip tone={verdict.tone}>preflight {verdict.state}</Chip>
+        </div>
+      </div>
+
+      {verdict.detail !== null && (
+        <p className="text-[13px] text-fl-ink-3">{verdict.detail}</p>
+      )}
+
+      {/* The loop fails closed on any preflight that isn't passing, so an armed
+          project sitting on one is armed and idle — which looks identical to
+          armed and quiet unless the card says so. */}
+      {project.autonomyEnabled && verdict.state !== "passing" && (
+        <p className="text-[13px] text-fl-amber">
+          Armed, but nothing is claimed until preflight passes.
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <AutonomyControl project={project} onUpdated={onUpdated} />
+        <ControlButton
+          aria-expanded={editing}
+          onClick={() => setEditing((open) => !open)}
+        >
+          {editing ? "close" : "edit"}
+        </ControlButton>
+      </div>
+
+      {editing && <ProjectEditForm project={project} onSaved={onSaved} />}
+    </div>
+  );
+}
+
+/** Arm / disarm, and the confirmation that stands between the owner and
+ * unattended spend. `intent` is what the owner has asked for but not yet
+ * confirmed: `arm` from the ordinary affordance, `override` from the one a
+ * failing preflight leaves in its place. */
+function AutonomyControl({
+  project,
+  onUpdated,
+}: {
+  project: Project;
+  onUpdated: (updated: Project) => void;
+}) {
+  const [intent, setIntent] = useState<null | "arm" | "override">(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const blocker = armBlocker(project);
+
+  async function setAutonomy(enabled: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/projects/${project.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        // An explicit boolean: the endpoint refuses anything else, and this is
+        // not a field to be clever about.
+        body: JSON.stringify({ autonomyEnabled: enabled }),
+      });
+      if (!res.ok) throw new Error(`the server answered ${res.status}`);
+      onUpdated(await res.json());
+      setIntent(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "the request failed");
+    }
+    setBusy(false);
+  }
+
+  if (project.autonomyEnabled) {
+    return (
+      <>
+        <ControlButton disabled={busy} onClick={() => setAutonomy(false)}>
+          {busy ? "disarming…" : "disarm"}
+        </ControlButton>
+        <Failure error={error} verb="disarm" />
+      </>
+    );
+  }
+
+  if (intent === null) {
+    return canArm(project) ? (
+      <ControlButton tone="cool" onClick={() => setIntent("arm")}>
+        arm…
+      </ControlButton>
+    ) : (
+      <>
+        <ControlButton tone="amber" onClick={() => setIntent("override")}>
+          arm anyway…
+        </ControlButton>
+        <Failure error={error} verb="arm" />
+      </>
+    );
+  }
+
+  const tone = intent === "override" ? "amber" : "cool";
+  return (
+    <div
+      role="group"
+      aria-label={`Confirm arming ${project.name}`}
+      className={`w-full space-y-2 rounded-[4px] border px-3 py-2.5 ${TONES[tone]}`}
+    >
+      <p className="text-[13px]">
+        Arm {project.name} for unattended work? The loop will claim its
+        ready-for-agent tickets on its own, spending up to $
+        {DEFAULT_ATTEMPT_BUDGET_USD} an attempt and {MAX_ATTEMPTS} attempts a
+        ticket.
+      </p>
+      {intent === "override" && (
+        <p className="text-[13px]">
+          Preflight is failing ({blocker}). Arming records your intent, but the
+          loop still claims nothing until that is fixed.
+        </p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <ControlButton tone={tone} disabled={busy} onClick={() => setAutonomy(true)}>
+          {busy ? "arming…" : "confirm arm"}
+        </ControlButton>
+        <ControlButton disabled={busy} onClick={() => setIntent(null)}>
+          cancel
+        </ControlButton>
+      </div>
+      <Failure error={error} verb="arm" />
+    </div>
+  );
+}
+
+function Failure({ error, verb }: { error: string | null; verb: string }) {
+  if (error === null) return null;
+  return (
+    <p role="alert" className="w-full text-[13px] text-fl-red">
+      Couldn&apos;t {verb} this project — {error}.
+    </p>
+  );
+}
+
+function NewProjectForm({ onCreated }: { onCreated: () => void }) {
   const [name, setName] = useState("");
   const [gitUrl, setGitUrl] = useState("");
   const [creating, setCreating] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  useEffect(() => {
-    fetch("/api/projects").then(async (res) => {
-      if (res.ok) setProjects(await res.json());
-    });
-  }, [refreshKey]);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim() || creating) return;
 
     setCreating(true);
-    await fetch("/api/projects", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: name.trim(), gitUrl: gitUrl.trim() || undefined }),
-    });
-    setName("");
-    setGitUrl("");
+    setError(null);
+    try {
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          gitUrl: gitUrl.trim() || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(`the server answered ${res.status}`);
+      setName("");
+      setGitUrl("");
+      onCreated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "the request failed");
+    }
     setCreating(false);
-    setRefreshKey((k) => k + 1);
   }
 
   return (
-    <div className="space-y-4">
-      <form onSubmit={handleCreate} className="flex gap-2">
-        <Input
+    <form onSubmit={handleCreate} className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          className={FIELD}
+          aria-label="Project name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Project name"
-          className="flex-1"
         />
-        <Input
+        <input
+          className={FIELD}
+          aria-label="Git URL"
           value={gitUrl}
           onChange={(e) => setGitUrl(e.target.value)}
           placeholder="https://github.com/user/repo.git"
-          className="flex-1"
         />
-        <Button type="submit" disabled={creating || !name.trim()}>
-          Add
-        </Button>
-      </form>
-
-      {projects.length === 0 ? (
-        <p className="text-muted-foreground">No projects yet.</p>
-      ) : (
-        <div className="space-y-2">
-          {projects.map((p) => (
-            <Card key={p.id}>
-              <CardHeader className="py-3">
-                <div
-                  className="flex items-center justify-between cursor-pointer"
-                  onClick={() => setEditingId(editingId === p.id ? null : p.id)}
-                >
-                  <div>
-                    <span className="font-medium">{p.name}</span>
-                    {p.gitUrl && (
-                      <span className="text-sm text-muted-foreground ml-2">{p.gitUrl}</span>
-                    )}
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {editingId === p.id ? "collapse" : "edit"}
-                  </span>
-                </div>
-                {editingId === p.id && (
-                  <ProjectEditForm
-                    project={p}
-                    onSaved={() => setRefreshKey((k) => k + 1)}
-                  />
-                )}
-              </CardHeader>
-            </Card>
-          ))}
-        </div>
+        <button
+          type="submit"
+          disabled={creating || !name.trim()}
+          className="shrink-0 rounded-[4px] bg-fl-cool px-4 py-2 text-sm font-medium text-fl-ground transition-opacity hover:opacity-90 disabled:opacity-40"
+        >
+          {creating ? "Adding…" : "Add"}
+        </button>
+      </div>
+      {error !== null && (
+        <p role="alert" className="text-[13px] text-fl-red">
+          Couldn&apos;t add the project — {error}.
+        </p>
       )}
-    </div>
+    </form>
   );
 }
 
@@ -115,86 +366,125 @@ function ProjectEditForm({
   const [dopplerToken, setDopplerToken] = useState("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const hasDoppler = project.dopplerToken !== null;
 
-  async function handleSave(e: React.FormEvent) {
-    e.preventDefault();
-    setSaving(true);
+  async function save() {
+    if (saving) return;
 
     const updates: Record<string, string | null> = {};
     if (name.trim() !== project.name) updates.name = name.trim();
-    if (gitUrl.trim() !== (project.gitUrl ?? "")) updates.gitUrl = gitUrl.trim() || null;
-    if (githubRepo.trim() !== (project.githubRepo ?? "")) updates.githubRepo = githubRepo.trim() || null;
+    if (gitUrl.trim() !== (project.gitUrl ?? ""))
+      updates.gitUrl = gitUrl.trim() || null;
+    if (githubRepo.trim() !== (project.githubRepo ?? ""))
+      updates.githubRepo = githubRepo.trim() || null;
     if (dopplerToken.trim()) updates.dopplerToken = dopplerToken.trim();
 
-    if (Object.keys(updates).length > 0) {
-      await fetch(`/api/projects/${project.id}`, {
+    if (Object.keys(updates).length === 0) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/projects/${project.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(updates),
       });
+      if (!res.ok) throw new Error(`the server answered ${res.status}`);
+      setDopplerToken("");
       onSaved();
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "the request failed");
     }
-
     setSaving(false);
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
   }
 
   return (
-    <form onSubmit={handleSave} className="mt-3 space-y-2">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        <div>
-          <label className="text-xs text-muted-foreground">Name</label>
-          <Input value={name} onChange={(e) => setName(e.target.value)} />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground">Git URL</label>
-          <Input
+    <form
+      // Enter in any field saves, exactly as pressing the button does — both
+      // routes go through the one `save`.
+      onSubmit={(e) => {
+        e.preventDefault();
+        save();
+      }}
+      className="space-y-2 border-t border-fl-line pt-2.5"
+    >
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <Field label="name">
+          <input
+            className={FIELD}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </Field>
+        <Field label="git url">
+          <input
+            className={FIELD}
             value={gitUrl}
             onChange={(e) => setGitUrl(e.target.value)}
             placeholder="https://github.com/user/repo.git"
           />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground">GitHub Repo</label>
-          <Input
+        </Field>
+        <Field label="github repo">
+          <input
+            className={FIELD}
             value={githubRepo}
             onChange={(e) => setGithubRepo(e.target.value)}
             placeholder="owner/repo"
           />
-        </div>
-        <div>
-          <label className="text-xs text-muted-foreground">
-            Doppler Token {hasDoppler && <span className="text-green-400">(set)</span>}
-          </label>
-          <Input
+        </Field>
+        <Field label={hasDoppler ? "doppler token · set" : "doppler token"}>
+          <input
+            className={FIELD}
+            type="password"
             value={dopplerToken}
             onChange={(e) => setDopplerToken(e.target.value)}
-            placeholder={hasDoppler ? "Leave blank to keep current" : "dp.st.stg.xxxxx"}
-            type="password"
+            placeholder={hasDoppler ? "Leave blank to keep current" : "dp.st.dev.xxxxx"}
           />
-        </div>
-        {project.discordChannelId && (
-          <div>
-            <label className="text-xs text-muted-foreground">
-              Discord Channel <span className="text-green-400">(linked)</span>
-            </label>
-            <Input
+        </Field>
+        {project.discordChannelId !== null && (
+          <Field label="discord channel · linked">
+            <input
+              className={`${FIELD} font-plex-mono text-xs opacity-60`}
               value={project.discordChannelId}
               disabled
-              className="font-mono text-xs opacity-60"
             />
-          </div>
+          </Field>
         )}
       </div>
-      <div className="flex items-center gap-2">
-        <Button type="submit" size="sm" disabled={saving}>
-          {saving ? "Saving..." : "Save"}
-        </Button>
-        {saved && <span className="text-xs text-green-400">Saved</span>}
+      <div className="flex flex-wrap items-center gap-2">
+        <ControlButton tone="cool" disabled={saving} onClick={save}>
+          {saving ? "saving…" : "save"}
+        </ControlButton>
+        {saved && (
+          <span className="font-plex-mono text-[11px] text-fl-green">saved</span>
+        )}
+        {error !== null && (
+          <span role="alert" className="text-[13px] text-fl-red">
+            Couldn&apos;t save — {error}.
+          </span>
+        )}
       </div>
     </form>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block space-y-1">
+      <span className="block font-plex-mono text-[11px] lowercase text-fl-ink-3">
+        {label}
+      </span>
+      {children}
+    </label>
   );
 }

--- a/src/components/project-list.tsx
+++ b/src/components/project-list.tsx
@@ -247,7 +247,10 @@ function AutonomyControl({
     );
   }
 
-  const tone = intent === "override" ? "amber" : "cool";
+  // The copy follows the state, not the press that opened the strip: if the
+  // block cleared underneath it, this stopped being an override.
+  const overriding = intent === "override" && blocker !== null;
+  const tone = overriding ? "amber" : "cool";
   return (
     <div
       role="group"
@@ -262,7 +265,7 @@ function AutonomyControl({
         {DEFAULT_ATTEMPT_BUDGET_USD} an attempt and {MAX_ATTEMPTS} attempts a
         ticket.
       </p>
-      {intent === "override" && (
+      {overriding && (
         <p className="text-[13px]">
           Preflight is failing ({blocker}). Arming records your intent, but the
           loop still claims nothing until that is fixed.

--- a/src/components/task-feed.tsx
+++ b/src/components/task-feed.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Eyebrow, FOCUS_RING } from "@/components/fleet/fleet-bits";
+import { ControlButton, Eyebrow, FOCUS_RING } from "@/components/fleet/fleet-bits";
 import { TaskCard } from "./task-card";
 import {
   organizeTasks,
@@ -260,13 +260,5 @@ function FilterOption({
 }
 
 function RetryButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`rounded-[4px] border border-fl-line px-2 py-0.5 font-plex-mono text-[11px] lowercase text-fl-ink-2 hover:border-fl-line-strong hover:text-fl-ink ${FOCUS_RING}`}
-    >
-      retry
-    </button>
-  );
+  return <ControlButton onClick={onClick}>retry</ControlButton>;
 }

--- a/src/lib/projects/__tests__/autonomy.test.ts
+++ b/src/lib/projects/__tests__/autonomy.test.ts
@@ -99,15 +99,14 @@ describe("armBlocker", () => {
 });
 
 describe("preflightVerdict", () => {
-  it("reads a passing preflight as green with nothing more to say", () => {
+  it("reads a passing preflight with nothing more to say", () => {
     expect(preflightVerdict(makeProject({ preflightStatus: "passing" }))).toEqual({
       state: "passing",
-      tone: "green",
       detail: null,
     });
   });
 
-  it("reads a failing preflight as amber, carrying the reason", () => {
+  it("reads a failing preflight, carrying the reason", () => {
     expect(
       preflightVerdict(
         makeProject({
@@ -117,16 +116,14 @@ describe("preflightVerdict", () => {
       )
     ).toEqual({
       state: "failing",
-      tone: "amber",
       detail: "the App cannot reach lennons301/lemons",
     });
   });
 
-  it("reads a never-run preflight as quiet, saying arming will run it", () => {
+  it("reads a never-run preflight as unchecked, saying arming will run it", () => {
     const verdict = preflightVerdict(makeProject({ preflightStatus: null }));
 
     expect(verdict.state).toBe("unchecked");
-    expect(verdict.tone).toBe("quiet");
     expect(verdict.detail).toContain("never run");
   });
 });

--- a/src/lib/projects/__tests__/autonomy.test.ts
+++ b/src/lib/projects/__tests__/autonomy.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  armBlocker,
+  canArm,
+  preflightVerdict,
+  type ProjectAutonomy,
+} from "../autonomy";
+
+function makeProject(
+  overrides: Partial<ProjectAutonomy> = {}
+): ProjectAutonomy {
+  return {
+    autonomyEnabled: false,
+    preflightStatus: null,
+    preflightReason: null,
+    ...overrides,
+  };
+}
+
+describe("canArm", () => {
+  it("arms a project whose preflight passes", () => {
+    expect(canArm(makeProject({ preflightStatus: "passing" }))).toBe(true);
+  });
+
+  it("arms a project preflight has never run for — arming is what runs it", () => {
+    expect(canArm(makeProject({ preflightStatus: null }))).toBe(true);
+  });
+
+  it("refuses a project whose preflight is failing", () => {
+    expect(
+      canArm(
+        makeProject({
+          preflightStatus: "failing",
+          preflightReason: "lennons301/lemons: default branch is unprotected",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses a failing project even with a stale reason from a past pass", () => {
+    // The status is the verdict; a reason left over from an earlier check must
+    // never be what decides whether the affordance is offered.
+    expect(
+      canArm(
+        makeProject({ preflightStatus: "failing", preflightReason: null })
+      )
+    ).toBe(false);
+  });
+
+  it("does not care whether the project is already armed", () => {
+    // Arming is gated on the repo being ready, not on the switch's position:
+    // an armed-but-failing project must not become armable by being armed.
+    expect(
+      canArm(
+        makeProject({ autonomyEnabled: true, preflightStatus: "failing" })
+      )
+    ).toBe(false);
+    expect(
+      canArm(
+        makeProject({ autonomyEnabled: true, preflightStatus: "passing" })
+      )
+    ).toBe(true);
+  });
+});
+
+describe("armBlocker", () => {
+  it("names what is missing, so the owner can act on it", () => {
+    expect(
+      armBlocker(
+        makeProject({
+          preflightStatus: "failing",
+          preflightReason: "reviewer is not a collaborator on lennons301/lemons",
+        })
+      )
+    ).toBe("reviewer is not a collaborator on lennons301/lemons");
+  });
+
+  it("still says the preflight failed when no reason was recorded", () => {
+    expect(
+      armBlocker(makeProject({ preflightStatus: "failing" }))
+    ).toBe("preflight failed for an unrecorded reason");
+  });
+
+  it("blocks nothing when preflight passes or has never run", () => {
+    expect(armBlocker(makeProject({ preflightStatus: "passing" }))).toBeNull();
+    expect(armBlocker(makeProject({ preflightStatus: null }))).toBeNull();
+  });
+
+  it("ignores a reason carried alongside a passing status", () => {
+    expect(
+      armBlocker(
+        makeProject({
+          preflightStatus: "passing",
+          preflightReason: "branch protection missing",
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe("preflightVerdict", () => {
+  it("reads a passing preflight as green with nothing more to say", () => {
+    expect(preflightVerdict(makeProject({ preflightStatus: "passing" }))).toEqual({
+      state: "passing",
+      tone: "green",
+      detail: null,
+    });
+  });
+
+  it("reads a failing preflight as amber, carrying the reason", () => {
+    expect(
+      preflightVerdict(
+        makeProject({
+          preflightStatus: "failing",
+          preflightReason: "the App cannot reach lennons301/lemons",
+        })
+      )
+    ).toEqual({
+      state: "failing",
+      tone: "amber",
+      detail: "the App cannot reach lennons301/lemons",
+    });
+  });
+
+  it("reads a never-run preflight as quiet, saying arming will run it", () => {
+    const verdict = preflightVerdict(makeProject({ preflightStatus: null }));
+
+    expect(verdict.state).toBe("unchecked");
+    expect(verdict.tone).toBe("quiet");
+    expect(verdict.detail).toContain("never run");
+  });
+});

--- a/src/lib/projects/autonomy.ts
+++ b/src/lib/projects/autonomy.ts
@@ -34,7 +34,9 @@ export interface ProjectAutonomy {
  *
  * A never-checked project is *not* blocked: enabling autonomy runs preflight
  * there and then (`PATCH /api/projects/[id]`, fail-closed), so the unknown
- * resolves into a verdict on the card as a direct result of the arming.
+ * resolves into a verdict on the card as a direct result of the arming — on an
+ * install with no GitHub App there is nothing to check against, and the project
+ * stays unchecked, which is also the honest answer.
  */
 export function armBlocker(project: ProjectAutonomy): string | null {
   if (project.preflightStatus !== "failing") return null;
@@ -72,6 +74,7 @@ export function preflightVerdict(project: ProjectAutonomy): PreflightVerdict {
   return {
     state: "unchecked",
     tone: "quiet",
-    detail: "Preflight has never run — arming runs it.",
+    detail:
+      "Preflight has never run — arming runs it, once the GitHub App is configured.",
   };
 }

--- a/src/lib/projects/autonomy.ts
+++ b/src/lib/projects/autonomy.ts
@@ -49,16 +49,14 @@ export function canArm(project: ProjectAutonomy): boolean {
   return armBlocker(project) === null;
 }
 
-/** Three states, because "failing" and "nobody has looked" are different news
- * and want different tones. */
+/** Three states, because "failing" and "nobody has looked" are different news.
+ * How each one is *tinted* is the card's business, not this module's — the same
+ * split the dashboard makes, where the read model names a cause and
+ * `needs-you.tsx` holds the tone map. */
 export type PreflightState = "passing" | "failing" | "unchecked";
 
 export interface PreflightVerdict {
   state: PreflightState;
-  /** Fleet tone for the chip: green passing, amber failing, quiet unchecked —
-   * a failing preflight is something to fix, not an incident (the dashboard's
-   * `needs you` bucket tones it amber for the same reason). */
-  tone: "green" | "amber" | "quiet";
   /** The line under the chip: what is missing, or what the state means. Null
    * when passing, where the chip already says everything. */
   detail: string | null;
@@ -66,14 +64,13 @@ export interface PreflightVerdict {
 
 export function preflightVerdict(project: ProjectAutonomy): PreflightVerdict {
   if (project.preflightStatus === "passing") {
-    return { state: "passing", tone: "green", detail: null };
+    return { state: "passing", detail: null };
   }
   if (project.preflightStatus === "failing") {
-    return { state: "failing", tone: "amber", detail: armBlocker(project) };
+    return { state: "failing", detail: armBlocker(project) };
   }
   return {
     state: "unchecked",
-    tone: "quiet",
     detail:
       "Preflight has never run — arming runs it, once the GitHub App is configured.",
   };

--- a/src/lib/projects/autonomy.ts
+++ b/src/lib/projects/autonomy.ts
@@ -1,0 +1,77 @@
+/**
+ * The settings screen's autonomy read model (issue #119). Whether a project can
+ * be armed, and how its preflight verdict reads, are pure functions of the row,
+ * so the meaning of the control room is table-testable and the components stay
+ * dumb renderers — the same seam `buildFleetView` and `organizeTasks` give the
+ * dashboard and the archive.
+ *
+ * The status union is derived from the schema through a *type-only* import,
+ * which TypeScript erases: the column enum stays the one source of truth and no
+ * drizzle runtime reaches the browser bundle that imports this module.
+ */
+
+import type { projects } from "@/db/schema";
+
+type ProjectRow = typeof projects.$inferSelect;
+
+/** Everything arming depends on. Structural rather than the whole row, so both
+ * shapes the screen holds — a row from the list route and the one PATCH answers
+ * with — can be asked the same questions. */
+export interface ProjectAutonomy {
+  autonomyEnabled: boolean;
+  /** null = preflight has never run for this project. */
+  preflightStatus: ProjectRow["preflightStatus"];
+  preflightReason: string | null;
+}
+
+/**
+ * Why the UI refuses to arm this project, or null when nothing stands in the
+ * way. Exactly one thing blocks: a preflight that ran and failed. The reducer
+ * fails closed on it (`decide.ts` claims nothing for a project whose preflight
+ * isn't passing), so arming one would look like work starting and produce
+ * none — the owner needs the reason and a deliberate override, not a switch
+ * that silently does nothing.
+ *
+ * A never-checked project is *not* blocked: enabling autonomy runs preflight
+ * there and then (`PATCH /api/projects/[id]`, fail-closed), so the unknown
+ * resolves into a verdict on the card as a direct result of the arming.
+ */
+export function armBlocker(project: ProjectAutonomy): string | null {
+  if (project.preflightStatus !== "failing") return null;
+  return project.preflightReason ?? "preflight failed for an unrecorded reason";
+}
+
+/** The predicate the arm affordance is gated on: true when the project may be
+ * armed from the UI without an explicit override. */
+export function canArm(project: ProjectAutonomy): boolean {
+  return armBlocker(project) === null;
+}
+
+/** Three states, because "failing" and "nobody has looked" are different news
+ * and want different tones. */
+export type PreflightState = "passing" | "failing" | "unchecked";
+
+export interface PreflightVerdict {
+  state: PreflightState;
+  /** Fleet tone for the chip: green passing, amber failing, quiet unchecked —
+   * a failing preflight is something to fix, not an incident (the dashboard's
+   * `needs you` bucket tones it amber for the same reason). */
+  tone: "green" | "amber" | "quiet";
+  /** The line under the chip: what is missing, or what the state means. Null
+   * when passing, where the chip already says everything. */
+  detail: string | null;
+}
+
+export function preflightVerdict(project: ProjectAutonomy): PreflightVerdict {
+  if (project.preflightStatus === "passing") {
+    return { state: "passing", tone: "green", detail: null };
+  }
+  if (project.preflightStatus === "failing") {
+    return { state: "failing", tone: "amber", detail: armBlocker(project) };
+  }
+  return {
+    state: "unchecked",
+    tone: "quiet",
+    detail: "Preflight has never run — arming runs it.",
+  };
+}

--- a/src/lib/use-load.ts
+++ b/src/lib/use-load.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * One GET, held honestly: the screens that read a small JSON resource all want
+ * the same three things, and each hand-rolling them is how one of them ends up
+ * telling a different story about a failure than its neighbour.
+ *
+ * - `data === null` means *not loaded yet*, never "loaded, and empty" — that
+ *   distinction is what stops a failed fetch rendering as an empty list.
+ * - A failure surfaces as `error` and leaves whatever is already on screen
+ *   alone, so a failed refresh is a staleness warning rather than a wipe.
+ * - The request is aborted on unmount and on every reload, so a slow answer
+ *   can't land on a screen that has moved on.
+ *
+ * `setData` is here because a mutation's own response is usually the freshest
+ * copy there is (`PATCH /api/projects/[id]` answers with the re-preflighted
+ * row): taking it beats re-fetching and hoping the two agree.
+ *
+ * The archive's poller (`task-feed.tsx`) deliberately stays its own: it
+ * schedules by backoff on a cadence this has no opinion about, and folding both
+ * into one hook would make it a configuration exercise.
+ */
+export interface Loaded<T> {
+  /** null until the first successful load. */
+  data: T | null;
+  /** Why the last attempt failed, or null. Cleared by a successful load. */
+  error: string | null;
+  /** Re-run the GET; clears the current error. */
+  reload: () => void;
+  /** Put a value on screen the caller already has. */
+  setData: React.Dispatch<React.SetStateAction<T | null>>;
+}
+
+export function useLoad<T>(url: string): Loaded<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let stopped = false;
+
+    (async () => {
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error(`the server answered ${res.status}`);
+        const body: T = await res.json();
+        if (stopped) return;
+        setData(body);
+        setError(null);
+      } catch (err) {
+        if (stopped || controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "the request failed");
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      controller.abort();
+    };
+  }, [url, attempt]);
+
+  const reload = useCallback(() => {
+    setError(null);
+    setAttempt((n) => n + 1);
+  }, []);
+
+  return { data, error, reload, setData };
+}


### PR DESCRIPTION
Closes #119

`/settings` becomes the fleet's control room. Read top to bottom it answers the three questions the owner arrives with: may the fleet pick up work at all, for which projects, and is the box under it healthy.

## What's here

- **`canArm` (pure, tested)** — `src/lib/projects/autonomy.ts`. One thing blocks arming: a preflight that ran and failed, because that is the one state `decideNext` already fails closed on. A never-checked project *is* armable — arming is what runs preflight. 12 cases cover `canArm` / `armBlocker` / `preflightVerdict`.
- **Project cards** — name, repo, `armed`/`disarmed`, `preflight passing|failing|unchecked`, and the reason when there is one. An armed project sitting on a non-passing preflight says so ("armed, but nothing is claimed until preflight passes"), because armed-and-idle otherwise looks exactly like armed-and-quiet.
- **Arming asks twice.** `arm…` opens a confirmation naming the spend it authorises ($20/attempt, 3 attempts). A failing preflight removes that affordance entirely and leaves `arm anyway…` beside the failing reason — the explicit override — which opens the same confirmation in amber. Disarming is single-press: reversible things shouldn't feel dangerous.
- **Global kill switch** on `PATCH /api/settings/autonomy`, deliberately asymmetric: **stop the fleet** is one press, lifting takes a confirmation (it re-arms every armed project at once). `AUTONOMY_ENABLED` being off is named on the panel, so "I lifted it and nothing happened" has an answer on screen.
- **Docker status** restyled to chips and a hairline panel, with the failure path it never had.
- Runbook updated: the two autonomy controls are presses now, curl kept for when the UI is what's broken. It also called `AUTONOMY_ENABLED` the kill switch, which is the one thing it isn't.

## Self-review (`/code-review` vs `origin/main`, spec #119)

Acted on: the three panels each hand-rolled the same GET (now one `useLoad` hook) and the same card geometry (now `PANEL`/`PANEL_PLAIN`); the two confirmations asked in two shapes (now `ConfirmStrip`); `preflightVerdict` returned a colour, which belongs in the card, as `needs-you.tsx` does with its causes. It also caught two real defects, both fixed:

- a reload that failed *after* the list was on screen set an error nothing rendered — add a project, let the follow-on reload fail, and the form clears as if it worked while the list never shows it. Now the staleness banner the archive already uses;
- the Add button was the one new control without a focus ring, because it hand-rolled the filled skin. Both filled buttons now share `PRIMARY_BUTTON`.

Where I disagreed, and why:

- **Docker status gaining an error state** was flagged as beyond "restyle it". Keeping it: the restyle rewrote that fetch, and a rejected probe used to leave "Checking…" on screen forever — which reads exactly like a hung daemon, the one answer this panel must never give by accident.
- **Lifting the kill switch takes a confirmation** though #116 asks for one only on arming. Lifting arms every armed project at once; engaging stays one press.
- **`new-task-form.tsx` / `task-feed.tsx` touched** — both only adopt the skins extracted here, no behaviour change. #116's "consistency dividend" is the spirit; the alternative was a second copy of each skin.
- **Doppler placeholder `dp.st.stg.` → `dp.st.dev.`** — agent containers use the Doppler `dev` config (CLAUDE.md), so the old placeholder pointed at the wrong environment.

## Scope

`GET /api/projects` still ships `dopplerToken` in cleartext to the browser. Real, known, and explicitly **out of scope** per #116 ("gets its own ticket") — this screen reads presence only (`!== null`), so it is unaffected by whichever way that ticket redacts it.

## Verification

`pnpm build` ✅ · `pnpm test` 732/732 ✅ · `eslint` clean on every changed file (repo-wide lint keeps its 16 pre-existing errors, none in this diff). Arm → preflight re-run → disarm, the kill switch both ways, and a non-boolean rejection (400) exercised against a local server.

Not verified: pixels. No browser is installable here (missing system libs), so the visual pass is the reviewer's — this is a `human-signoff` PR anyway: it touches `components/**` and `app/**/page.tsx`, both gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
