### PR TITLE
Live view: first-class composer

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -36,6 +36,7 @@ export default async function TaskDetailPage({
         githubIssue: task.githubIssue ?? null,
         pullRequestNumber: task.pullRequestNumber ?? null,
         pullRequestUrl: task.pullRequestUrl ?? null,
+        sessionSkill: task.sessionSkill ?? null,
       }}
       domain={process.env.DOMAIN ?? null}
     />

--- a/src/components/__tests__/chat-render.test.tsx
+++ b/src/components/__tests__/chat-render.test.tsx
@@ -116,6 +116,8 @@ describe("fleet palette", () => {
     "src/components/tool-card.tsx",
     "src/components/task-stream.tsx",
     "src/components/task-chat.tsx",
+    // The composer was the last dark island on the light ground (issue #122).
+    "src/components/message-input.tsx",
   ];
 
   const OFF_PALETTE =

--- a/src/components/__tests__/composer-render.test.tsx
+++ b/src/components/__tests__/composer-render.test.tsx
@@ -109,8 +109,9 @@ describe("composer — controls", () => {
     expect(html).toContain("blocked on a question");
     expect(tag(html, /<textarea[^>]*>/)).not.toMatch(DISABLED);
     // Nothing to continue — the agent asked something, so the primary control
-    // waits for an answer to send.
-    expect(tag(html, /<button[^>]*>continue<\/button>/)).toMatch(DISABLED);
+    // waits, as a send, for an answer to send.
+    expect(html).not.toContain(">continue</button>");
+    expect(tag(html, /<button[^>]*>send<\/button>/)).toMatch(DISABLED);
   });
 });
 

--- a/src/components/__tests__/composer-render.test.tsx
+++ b/src/components/__tests__/composer-render.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MessageInput } from "../message-input";
+
+/**
+ * The composer's decisions live in `composerState` / `slash` and are tested
+ * there. What these cover is that the component actually wires them to the
+ * field: the states reach the markup, the controls carry the right enabled-ness
+ * and labels, and the keyboard contract is stated where you can read it.
+ *
+ * Effects do not run in a static render, so this sees the composer's
+ * first-paint state — which is the desktop one (Enter sends). The touch
+ * variant is resolved on mount from a pointer media query.
+ */
+/** The rendered `disabled` attribute, not the `disabled:` utility classes the
+ * same markup is full of. */
+const DISABLED = /disabled=""/;
+
+function tag(html: string, pattern: RegExp): string {
+  return pattern.exec(html)?.[0] ?? "";
+}
+
+function render(props: Partial<React.ComponentProps<typeof MessageInput>> = {}) {
+  return renderToStaticMarkup(
+    <MessageInput
+      taskId="01TASK"
+      taskStatus="running"
+      containerStatus="idle"
+      queued={0}
+      sessionSkill={null}
+      {...props}
+    />
+  );
+}
+
+describe("composer — field", () => {
+  it("is a multiline field that autosizes rather than being dragged", () => {
+    const html = render();
+
+    expect(html).toContain("<textarea");
+    expect(html).toContain('rows="1"');
+    expect(html).toContain("resize-none");
+    // The growth is capped in CSS so a long answer scrolls instead of eating
+    // the transcript.
+    expect(html).toContain("max-h-40");
+  });
+
+  it("labels itself for a screen reader", () => {
+    expect(render()).toContain('aria-label="Message the agent"');
+  });
+
+  it("states the keyboard contract under the field", () => {
+    expect(render()).toContain("enter to send · shift+enter for a newline");
+  });
+});
+
+describe("composer — feedback", () => {
+  it("says the agent is idle and awaiting you", () => {
+    const html = render({ containerStatus: "idle" });
+
+    expect(html).toContain("agent idle");
+    expect(html).toContain("Message the agent…");
+  });
+
+  it("says the agent is working, and that a message would queue", () => {
+    const html = render({ containerStatus: "running" });
+
+    expect(html).toContain("agent working");
+    expect(html).toContain("your message will be queued");
+  });
+
+  it("counts messages the agent has not been handed yet", () => {
+    expect(render({ containerStatus: "running", queued: 2 })).toContain("2 queued");
+    expect(render({ containerStatus: "running", queued: 0 })).not.toContain("queued</span>");
+  });
+
+  it("announces its status rather than leaving it to be noticed", () => {
+    expect(render()).toContain('role="status"');
+  });
+
+  it("takes nothing before the task has a container, and says why", () => {
+    const html = render({ taskStatus: "queued", containerStatus: null });
+
+    expect(html).toContain("queued for a slot");
+    expect(tag(html, /<textarea[^>]*>/)).toMatch(DISABLED);
+  });
+});
+
+describe("composer — controls", () => {
+  it("offers continue on an idle agent with an empty draft", () => {
+    expect(render({ containerStatus: "idle" })).toContain(">continue</button>");
+  });
+
+  it("offers completion between turns", () => {
+    const html = render({ containerStatus: "idle" });
+
+    expect(tag(html, /<button[^>]*>complete<\/button>/)).not.toMatch(DISABLED);
+  });
+
+  it("withholds completion mid-turn, when the API would refuse it anyway", () => {
+    const html = render({ containerStatus: "running" });
+
+    expect(tag(html, /<button[^>]*>complete<\/button>/)).toMatch(DISABLED);
+  });
+
+  it("takes an answer to a blocked run, but offers no bare continue", () => {
+    const html = render({ taskStatus: "blocked", containerStatus: null });
+
+    expect(html).toContain("blocked on a question");
+    expect(tag(html, /<textarea[^>]*>/)).not.toMatch(DISABLED);
+    // Nothing to continue — the agent asked something, so the primary control
+    // waits for an answer to send.
+    expect(tag(html, /<button[^>]*>continue<\/button>/)).toMatch(DISABLED);
+  });
+});
+
+describe("composer — slash commands", () => {
+  it("advertises the session commands in a generation session", () => {
+    expect(render({ sessionSkill: "grill-me" })).toContain("/ for session commands");
+  });
+
+  it("says nothing about them on a plain chat task, where they are not routed", () => {
+    expect(render({ sessionSkill: null })).not.toContain("session commands");
+  });
+});

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -1,53 +1,130 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { FOCUS_RING } from "@/components/fleet/fleet-bits";
+import { composerState, resolvePrimary } from "@/lib/chat/composer";
+import { applySlashCommand, slashMenu, type SlashCommand } from "@/lib/chat/slash";
+
+/**
+ * The live view's write side (issue #122). Answering a grilling agent is the
+ * interaction this app most needs to do well, so the composer is a first-class
+ * input rather than a bare textarea: it grows with the answer, says plainly
+ * whether the agent is working, idle or holding your message in a queue, makes
+ * the session skills discoverable from a slash, and puts continuing or ending
+ * the session where you can see them.
+ *
+ * Every decision about what the task's state *means* is made by
+ * `composerState`; this file draws it and owns only draft-local concerns.
+ */
 
 interface MessageInputProps {
   taskId: string;
   containerStatus: string | null;
   taskStatus: string;
+  /** Messages of yours the agent has not been handed yet. */
+  queued: number;
+  /** Non-null on a generation session, where the orchestrator re-frames a
+   * leading skill slash (issue #63) — the only place the menu means anything.
+   * A plain chat task gets no menu, because the framing it advertises (and the
+   * `gh` token a publishing skill needs) is not there. */
+  sessionSkill: string | null;
 }
+
+/** The autosize measurement has to happen before paint or the field visibly
+ * jumps a frame behind the typing; on the server there is no paint to be before
+ * and useLayoutEffect would only warn. */
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+const DOT_TONE = {
+  green: "bg-fl-green",
+  amber: "bg-fl-amber",
+  quiet: "bg-fl-ink-3",
+} as const;
+
+const QUIET_BUTTON = `font-plex-mono text-[11px] lowercase text-fl-ink-3 hover:text-fl-ink disabled:cursor-default disabled:text-fl-ink-3/50 disabled:hover:text-fl-ink-3/50 ${FOCUS_RING}`;
 
 export function MessageInput({
   taskId,
   containerStatus,
   taskStatus,
+  queued,
+  sessionSkill,
 }: MessageInputProps) {
-  const [content, setContent] = useState("");
+  const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [completing, setCompleting] = useState(false);
+  const [confirmingComplete, setConfirmingComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // The draft the slash menu was dismissed for: Escape closes it until you type
+  // something else, which is the only thing "dismissed" can sensibly mean for a
+  // menu whose trigger is the draft itself.
+  const [dismissed, setDismissed] = useState<string | null>(null);
+  const [active, setActive] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const hintId = useId();
+  const menuId = useId();
 
-  const isActive = taskStatus === "running";
-  const isIdle = containerStatus === "idle";
-  const isRunning = containerStatus === "running" || containerStatus === "setup";
-  const canSend = isActive && !!content.trim() && !sending;
-  const canComplete = isActive && isIdle && !completing;
+  const state = composerState({ taskStatus, containerStatus, queued });
+  const primary = resolvePrimary(draft);
+  const canSubmit =
+    state.accepting && !sending && (draft.trim() !== "" || state.allowsContinue);
 
-  const placeholder = isRunning
-    ? "Agent is working... your message will be queued"
-    : isIdle
-      ? "Message the agent..."
-      : "Agent is not active";
+  const menu = useMemo(
+    () => (sessionSkill && dismissed !== draft ? slashMenu(draft) : null),
+    [draft, dismissed, sessionSkill]
+  );
+  const matches = menu?.matches ?? [];
+  const menuOpen = matches.length > 0;
+  const activeIndex = Math.min(active, matches.length - 1);
 
-  async function handleSend() {
-    if (!canSend) return;
+  /**
+   * A phone's return key is the only newline it has — there is no Shift on a
+   * touch keyboard — so Enter-to-send everywhere would make the multiline
+   * composer this ticket asks for unusable on the device the owner reads
+   * sessions on. Enter sends where a real keyboard is likely; on touch the
+   * return key writes a newline and the send button sends. The hint below the
+   * field always says which of the two you have.
+   */
+  const [enterSends, setEnterSends] = useState(true);
+  useEffect(() => {
+    const coarse = window.matchMedia("(pointer: coarse)");
+    const apply = () => setEnterSends(!coarse.matches);
+    apply();
+    coarse.addEventListener("change", apply);
+    return () => coarse.removeEventListener("change", apply);
+  }, []);
+
+  // Grow to fit the draft, shrink back when it is sent. Height is measured from
+  // zero rather than from the current height, or the field could only ever get
+  // taller; the cap is CSS, so the field scrolls once it reaches it.
+  useIsomorphicLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "0px";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
+
+  async function submit(text: string) {
+    if (!canSubmit) return;
 
     setSending(true);
+    setError(null);
     try {
       const res = await fetch(`/api/tasks/${taskId}/messages`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content: content.trim(), role: "user" }),
+        body: JSON.stringify({ content: text, role: "user" }),
       });
       if (!res.ok) {
-        console.error("Failed to send message:", res.status);
+        // The draft is deliberately left in the field — a failed send must not
+        // eat what you wrote.
+        setError("Couldn't send that message. Try again.");
         return;
       }
-      setContent("");
-    } catch (err) {
-      console.error("Failed to send message:", err);
+      setDraft("");
+    } catch {
+      setError("Couldn't reach the server. Try again.");
     } finally {
       setSending(false);
       textareaRef.current?.focus();
@@ -55,61 +132,230 @@ export function MessageInput({
   }
 
   async function handleComplete() {
-    if (!canComplete) return;
-
     setCompleting(true);
-    await fetch(`/api/tasks/${taskId}/complete`, {
-      method: "POST",
-    });
+    setError(null);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/complete`, { method: "POST" });
+      if (!res.ok) {
+        setError("Couldn't complete the task. Try again.");
+        setCompleting(false);
+      }
+      // On success the view flips to its terminal state over SSE, so the button
+      // stays in its "completing…" state until it does.
+    } catch {
+      setError("Couldn't reach the server. Try again.");
+      setCompleting(false);
+    }
+    setConfirmingComplete(false);
+  }
+
+  function pick(command: SlashCommand) {
+    setDraft(applySlashCommand(command.name));
+    setActive(0);
+    textareaRef.current?.focus();
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Mid-composition (IME) Enter commits the candidate word; it is never a send.
+    const composing = e.nativeEvent.isComposing;
+
+    if (menuOpen && !composing) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((i) => (Math.min(i, matches.length - 1) + 1) % matches.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive(
+          (i) => (Math.min(i, matches.length - 1) - 1 + matches.length) % matches.length
+        );
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setDismissed(draft);
+        return;
+      }
+      if ((e.key === "Enter" && !e.shiftKey) || (e.key === "Tab" && !e.shiftKey)) {
+        e.preventDefault();
+        pick(matches[activeIndex]);
+        return;
+      }
+    }
+
+    if (e.key === "Escape" && confirmingComplete) {
       e.preventDefault();
-      handleSend();
+      setConfirmingComplete(false);
+      return;
+    }
+
+    if (e.key === "Enter" && !e.shiftKey && enterSends && !composing) {
+      e.preventDefault();
+      void submit(primary.text);
     }
   }
 
-  function handleInput(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    setContent(e.target.value);
-    const textarea = e.target;
-    textarea.style.height = "auto";
-    textarea.style.height = `${Math.min(textarea.scrollHeight, 120)}px`;
-  }
-
-  if (!isActive) return null;
+  const keyHint = enterSends
+    ? "enter to send · shift+enter for a newline"
+    : "return for a newline · tap send";
+  const hint = sessionSkill ? `${keyHint} · / for session commands` : keyHint;
 
   return (
-    <div className="border-t border-zinc-800 p-3">
-      <div className="flex gap-2 items-end">
+    <div className="shrink-0 border-t border-fl-line bg-fl-surface px-3 py-2.5">
+      {menuOpen && (
+        <SlashCommandMenu
+          id={menuId}
+          matches={matches}
+          activeIndex={activeIndex}
+          onPick={pick}
+        />
+      )}
+
+      <div className="mb-1.5 flex items-center justify-between gap-3">
+        {/* Announced, because "your message is queued behind a turn" is the one
+            thing about this screen you cannot see by looking at the field. */}
+        <p
+          role="status"
+          className="flex min-w-0 items-center gap-1.5 font-plex-mono text-[11px] lowercase text-fl-ink-2"
+        >
+          <span
+            aria-hidden
+            className={`h-1.5 w-1.5 shrink-0 rounded-full ${DOT_TONE[state.tone]} ${
+              state.phase === "working" ? "fleet-pulse" : ""
+            }`}
+          />
+          <span className="truncate">{state.label}</span>
+          {state.queuedNote && (
+            <span className="shrink-0 text-fl-ink-3">· {state.queuedNote}</span>
+          )}
+        </p>
+
+        {confirmingComplete ? (
+          <span className="flex shrink-0 items-center gap-2.5 font-plex-mono text-[11px] lowercase">
+            <span className="text-fl-ink-2">end this session?</span>
+            <button
+              type="button"
+              onClick={handleComplete}
+              className={`text-fl-amber hover:opacity-80 ${FOCUS_RING}`}
+            >
+              confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingComplete(false)}
+              className={QUIET_BUTTON}
+            >
+              cancel
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirmingComplete(true)}
+            disabled={!state.canComplete || completing}
+            title={
+              state.canComplete
+                ? "End this session and mark its PR ready"
+                : "Available between turns, once the agent is idle"
+            }
+            className={`shrink-0 ${QUIET_BUTTON}`}
+          >
+            {completing ? "completing…" : "complete"}
+          </button>
+        )}
+      </div>
+
+      <div
+        className={`flex items-end gap-2 rounded-[4px] border bg-fl-card px-2.5 py-1.5 ${
+          state.accepting
+            ? "border-fl-line focus-within:border-fl-line-strong"
+            : "border-fl-line opacity-60"
+        }`}
+      >
         <textarea
           ref={textareaRef}
-          value={content}
-          onChange={handleInput}
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setActive(0);
+          }}
           onKeyDown={handleKeyDown}
-          placeholder={placeholder}
+          placeholder={state.placeholder}
           rows={1}
-          className="flex-1 resize-none rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-purple-500"
-          disabled={!isActive}
+          disabled={!state.accepting}
+          aria-label="Message the agent"
+          aria-describedby={hintId}
+          className="max-h-40 min-w-0 flex-1 resize-none bg-transparent py-1 text-sm text-fl-ink outline-none placeholder:text-fl-ink-3 disabled:cursor-not-allowed"
         />
-        <Button
-          onClick={handleSend}
-          size="sm"
-          disabled={!canSend}
-          className="bg-purple-600 hover:bg-purple-700 text-white"
+        <button
+          type="button"
+          onClick={() => void submit(primary.text)}
+          disabled={!canSubmit}
+          className={`shrink-0 rounded-[4px] bg-fl-cool px-3 py-1.5 font-plex-mono text-[12px] lowercase text-fl-ground transition-opacity hover:opacity-90 disabled:opacity-40 ${FOCUS_RING}`}
         >
-          Send
-        </Button>
-        <Button
-          onClick={handleComplete}
-          size="sm"
-          variant="outline"
-          disabled={!canComplete}
-          className="text-zinc-400 border-zinc-700"
-        >
-          Complete
-        </Button>
+          {sending ? "sending…" : primary.label}
+        </button>
       </div>
+
+      {error ? (
+        <p role="alert" className="mt-1 font-plex-mono text-[11px] text-fl-red">
+          {error}
+        </p>
+      ) : (
+        <p id={hintId} className="mt-1 truncate font-plex-mono text-[11px] text-fl-ink-3">
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The session skills, offered above the field. Buttons rather than listbox
+ * options: they are reachable by Tab as well as by the arrow keys the textarea
+ * handles, which is the accessible behaviour that costs nothing here. The
+ * highlighted row is marked `aria-current`, so what Enter will accept is not
+ * carried by the tint alone.
+ */
+function SlashCommandMenu({
+  id,
+  matches,
+  activeIndex,
+  onPick,
+}: {
+  id: string;
+  matches: readonly SlashCommand[];
+  activeIndex: number;
+  onPick: (command: SlashCommand) => void;
+}) {
+  return (
+    <div
+      id={id}
+      aria-label="Session commands"
+      className="mb-2 overflow-hidden rounded-[4px] border border-fl-line bg-fl-card"
+    >
+      {matches.map((command, i) => (
+        <button
+          key={command.name}
+          type="button"
+          aria-current={i === activeIndex ? "true" : undefined}
+          // Keep the caret in the field: a mousedown that blurs the textarea
+          // would close the menu before the click lands.
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onPick(command)}
+          className={`flex w-full items-baseline gap-2 px-3 py-1.5 text-left ${FOCUS_RING} ${
+            i === activeIndex ? "bg-fl-surface" : "hover:bg-fl-surface"
+          }`}
+        >
+          <span className="shrink-0 font-plex-mono text-[12px] text-fl-ink">
+            /{command.name}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[12px] text-fl-ink-3">
+            {command.summary}
+          </span>
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FOCUS_RING } from "@/components/fleet/fleet-bits";
 import { composerState, resolvePrimary } from "@/lib/chat/composer";
 import { applySlashCommand, slashMenu, type SlashCommand } from "@/lib/chat/slash";
@@ -44,6 +44,11 @@ const DOT_TONE = {
 
 const QUIET_BUTTON = `font-plex-mono text-[11px] lowercase text-fl-ink-3 hover:text-fl-ink disabled:cursor-default disabled:text-fl-ink-3/50 disabled:hover:text-fl-ink-3/50 ${FOCUS_RING}`;
 
+/** A fixed id, not `useId`: there is exactly one composer on a page, and the
+ * generated id came out different on the server and the client here, which is
+ * a hydration mismatch for an attribute that only has to point at a sibling. */
+const HINT_ID = "composer-hint";
+
 export function MessageInput({
   taskId,
   containerStatus,
@@ -62,11 +67,9 @@ export function MessageInput({
   const [dismissed, setDismissed] = useState<string | null>(null);
   const [active, setActive] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const hintId = useId();
-  const menuId = useId();
 
   const state = composerState({ taskStatus, containerStatus, queued });
-  const primary = resolvePrimary(draft);
+  const primary = resolvePrimary(draft, state.allowsContinue);
   const canSubmit =
     state.accepting && !sending && (draft.trim() !== "" || state.allowsContinue);
 
@@ -204,12 +207,7 @@ export function MessageInput({
   return (
     <div className="shrink-0 border-t border-fl-line bg-fl-surface px-3 py-2.5">
       {menuOpen && (
-        <SlashCommandMenu
-          id={menuId}
-          matches={matches}
-          activeIndex={activeIndex}
-          onPick={pick}
-        />
+        <SlashCommandMenu matches={matches} activeIndex={activeIndex} onPick={pick} />
       )}
 
       <div className="mb-1.5 flex items-center justify-between gap-3">
@@ -225,9 +223,15 @@ export function MessageInput({
               state.phase === "working" ? "fleet-pulse" : ""
             }`}
           />
-          <span className="truncate">{state.label}</span>
-          {state.queuedNote && (
-            <span className="shrink-0 text-fl-ink-3">· {state.queuedNote}</span>
+          {/* The confirmation takes the row: on a phone there is not width for
+              both, and for the second it is up, the question is the status. */}
+          {!confirmingComplete && (
+            <>
+              <span className="truncate">{state.label}</span>
+              {state.queuedNote && (
+                <span className="shrink-0 text-fl-ink-3">· {state.queuedNote}</span>
+              )}
+            </>
           )}
         </p>
 
@@ -285,7 +289,7 @@ export function MessageInput({
           rows={1}
           disabled={!state.accepting}
           aria-label="Message the agent"
-          aria-describedby={hintId}
+          aria-describedby={HINT_ID}
           className="max-h-40 min-w-0 flex-1 resize-none bg-transparent py-1 text-sm text-fl-ink outline-none placeholder:text-fl-ink-3 disabled:cursor-not-allowed"
         />
         <button
@@ -303,7 +307,12 @@ export function MessageInput({
           {error}
         </p>
       ) : (
-        <p id={hintId} className="mt-1 truncate font-plex-mono text-[11px] text-fl-ink-3">
+        // Wrapping, not truncating: on a phone the whole line is the point,
+        // and an ellipsis would eat the half that says how to type a newline.
+        <p
+          id={HINT_ID}
+          className="mt-1 font-plex-mono text-[11px] leading-snug text-fl-ink-3"
+        >
           {hint}
         </p>
       )}
@@ -319,21 +328,18 @@ export function MessageInput({
  * carried by the tint alone.
  */
 function SlashCommandMenu({
-  id,
   matches,
   activeIndex,
   onPick,
 }: {
-  id: string;
   matches: readonly SlashCommand[];
   activeIndex: number;
   onPick: (command: SlashCommand) => void;
 }) {
   return (
     <div
-      id={id}
       aria-label="Session commands"
-      className="mb-2 overflow-hidden rounded-[4px] border border-fl-line bg-fl-card"
+      className="mb-2 max-h-52 overflow-y-auto rounded-[4px] border border-fl-line bg-fl-card"
     >
       {matches.map((command, i) => (
         <button
@@ -344,8 +350,11 @@ function SlashCommandMenu({
           // would close the menu before the click lands.
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => onPick(command)}
+          // Cool marks the highlighted row, the same hue the session-entry
+          // form marks a picked session with: colour here means the owner is
+          // choosing, not that anything is live or wrong.
           className={`flex w-full items-baseline gap-2 px-3 py-1.5 text-left ${FOCUS_RING} ${
-            i === activeIndex ? "bg-fl-surface" : "hover:bg-fl-surface"
+            i === activeIndex ? "bg-fl-cool/13" : "hover:bg-fl-surface"
           }`}
         >
           <span className="shrink-0 font-plex-mono text-[12px] text-fl-ink">

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { FOCUS_RING } from "@/components/fleet/fleet-bits";
 import { composerState, resolvePrimary } from "@/lib/chat/composer";
 import { applySlashCommand, slashMenu, type SlashCommand } from "@/lib/chat/slash";
@@ -101,12 +108,22 @@ export function MessageInput({
   // Grow to fit the draft, shrink back when it is sent. Height is measured from
   // zero rather than from the current height, or the field could only ever get
   // taller; the cap is CSS, so the field scrolls once it reaches it.
-  useIsomorphicLayoutEffect(() => {
+  const resize = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "0px";
     el.style.height = `${el.scrollHeight}px`;
-  }, [draft]);
+  }, []);
+
+  useIsomorphicLayoutEffect(resize, [draft, resize]);
+
+  // How the draft wraps is what decides that height, so a width change has to
+  // re-measure it — rotating a phone, or the preview pane opening beside the
+  // chat, otherwise leaves the field the wrong size until the next keystroke.
+  useEffect(() => {
+    window.addEventListener("resize", resize);
+    return () => window.removeEventListener("resize", resize);
+  }, [resize]);
 
   async function submit(text: string) {
     if (!canSubmit) return;

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { SessionSkill } from "@/db/schema";
 import { FOCUS_RING } from "@/components/fleet/fleet-bits";
 import { composerState, resolvePrimary } from "@/lib/chat/composer";
 import { applySlashCommand, slashMenu, type SlashCommand } from "@/lib/chat/slash";
@@ -34,7 +35,7 @@ interface MessageInputProps {
    * leading skill slash (issue #63) — the only place the menu means anything.
    * A plain chat task gets no menu, because the framing it advertises (and the
    * `gh` token a publishing skill needs) is not there. */
-  sessionSkill: string | null;
+  sessionSkill: SessionSkill | null;
 }
 
 /** The autosize measurement has to happen before paint or the field visibly
@@ -76,9 +77,10 @@ export function MessageInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const state = composerState({ taskStatus, containerStatus, queued });
+  // What the button would send *is* whether there is anything to send: an empty
+  // text means the draft is blank and no bare continue is on offer.
   const primary = resolvePrimary(draft, state.allowsContinue);
-  const canSubmit =
-    state.accepting && !sending && (draft.trim() !== "" || state.allowsContinue);
+  const canSubmit = state.accepting && !sending && primary.text !== "";
 
   const menu = useMemo(
     () => (sessionSkill && dismissed !== draft ? slashMenu(draft) : null),
@@ -118,11 +120,21 @@ export function MessageInput({
   useIsomorphicLayoutEffect(resize, [draft, resize]);
 
   // How the draft wraps is what decides that height, so a width change has to
-  // re-measure it — rotating a phone, or the preview pane opening beside the
-  // chat, otherwise leaves the field the wrong size until the next keystroke.
+  // re-measure it: rotating a phone, but also the preview pane appearing beside
+  // the chat mid-session, which narrows this column without the window moving
+  // at all. Width only — the element's *height* is what `resize` just set, and
+  // reacting to that would be a loop.
   useEffect(() => {
-    window.addEventListener("resize", resize);
-    return () => window.removeEventListener("resize", resize);
+    const el = textareaRef.current;
+    if (!el) return;
+    let lastWidth = el.clientWidth;
+    const observer = new ResizeObserver(() => {
+      if (el.clientWidth === lastWidth) return;
+      lastWidth = el.clientWidth;
+      resize();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [resize]);
 
   async function submit(text: string) {
@@ -152,6 +164,11 @@ export function MessageInput({
   }
 
   async function handleComplete() {
+    // Re-checked, not just disabled at the point the question was asked: the
+    // agent can start a turn while the confirmation sits open, and the API
+    // completes a running, idle task only.
+    if (!state.canComplete || completing) return;
+
     setCompleting(true);
     setError(null);
     try {
@@ -175,6 +192,15 @@ export function MessageInput({
     textareaRef.current?.focus();
   }
 
+  /** Move the highlight, wrapping at both ends. Clamped first, because a
+   * narrowing query can leave the stored index past the end of the list. */
+  function stepActive(delta: number) {
+    setActive(
+      (i) =>
+        (Math.min(i, matches.length - 1) + delta + matches.length) % matches.length
+    );
+  }
+
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     // Mid-composition (IME) Enter commits the candidate word; it is never a send.
     const composing = e.nativeEvent.isComposing;
@@ -182,14 +208,12 @@ export function MessageInput({
     if (menuOpen && !composing) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setActive((i) => (Math.min(i, matches.length - 1) + 1) % matches.length);
+        stepActive(1);
         return;
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        setActive(
-          (i) => (Math.min(i, matches.length - 1) - 1 + matches.length) % matches.length
-        );
+        stepActive(-1);
         return;
       }
       if (e.key === "Escape") {
@@ -319,13 +343,20 @@ export function MessageInput({
         </button>
       </div>
 
+      {/* One line under the field, and it carries the id the textarea is
+          described by either way — a failed send must not leave
+          `aria-describedby` pointing at nothing. Wrapping, not truncating: on a
+          phone the whole line is the point, and an ellipsis would eat the half
+          that says how to type a newline. */}
       {error ? (
-        <p role="alert" className="mt-1 font-plex-mono text-[11px] text-fl-red">
+        <p
+          id={HINT_ID}
+          role="alert"
+          className="mt-1 font-plex-mono text-[11px] leading-snug text-fl-red"
+        >
           {error}
         </p>
       ) : (
-        // Wrapping, not truncating: on a phone the whole line is the point,
-        // and an ellipsis would eat the half that says how to type a newline.
         <p
           id={HINT_ID}
           className="mt-1 font-plex-mono text-[11px] leading-snug text-fl-ink-3"
@@ -338,11 +369,13 @@ export function MessageInput({
 }
 
 /**
- * The session skills, offered above the field. Buttons rather than listbox
- * options: they are reachable by Tab as well as by the arrow keys the textarea
- * handles, which is the accessible behaviour that costs nothing here. The
- * highlighted row is marked `aria-current`, so what Enter will accept is not
- * carried by the tint alone.
+ * The session skills, offered above the field. Ordinary buttons rather than
+ * listbox options: from the field the arrow keys move the highlight and
+ * Enter/Tab accepts it, and because the menu sits before the field in the DOM,
+ * Shift+Tab still walks into the rows themselves — so the menu is operable
+ * without inventing combobox semantics for a textarea whose day job is prose.
+ * The highlighted row is marked `aria-current`, so what Enter will accept is
+ * not carried by the tint alone.
  */
 function SlashCommandMenu({
   matches,
@@ -354,7 +387,9 @@ function SlashCommandMenu({
   onPick: (command: SlashCommand) => void;
 }) {
   return (
+    // `group`, because a label on a role-less div is not announced at all.
     <div
+      role="group"
       aria-label="Session commands"
       className="mb-2 max-h-52 overflow-y-auto rounded-[4px] border border-fl-line bg-fl-card"
     >

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -5,26 +5,13 @@ import { useRouter } from "next/navigation";
 import type { SessionSkill } from "@/db/schema";
 import type { OpenIssue } from "@/lib/github/issues";
 import { Eyebrow } from "@/components/fleet/fleet-bits";
+// The blurbs the live composer's slash menu offers too (issue #122), so the
+// two surfaces describe a session the same way.
+import { SESSION_BLURBS, SESSION_ORDER } from "@/lib/sessions/skills";
 
 // A new task is either a plain chat task (the default, unchanged) or a
 // generation session running one of the estate's generation skills (issue #64).
 type TaskType = "chat" | SessionSkill;
-
-// One-line blurbs so the choice is legible one-handed on a phone. Keyed by
-// SessionSkill, so a skill added to the schema fails the type check here until
-// it gets a blurb — the selector can never silently drop one. Insertion order
-// is the display order (grills first, then the spec→tickets pipeline, then the
-// standalone passes); SESSION_SKILLS in the schema stays the runtime source of
-// truth.
-const SESSION_BLURBS: Record<SessionSkill, string> = {
-  "grill-me": "Stress-test an idea until its decisions resolve",
-  "grill-with-docs": "Grill an idea with the project's docs in context",
-  "to-spec": "Turn resolved decisions into a spec",
-  "to-tickets": "Decompose a spec into executable tickets",
-  triage: "Move an issue through the label lifecycle",
-  wayfinder: "Chart a new map of the territory",
-};
-const SESSION_ORDER = Object.keys(SESSION_BLURBS) as SessionSkill[];
 
 const FIELD =
   "w-full rounded-[4px] border border-fl-line bg-fl-card px-3 py-2 text-sm text-fl-ink " +

--- a/src/components/task-chat.tsx
+++ b/src/components/task-chat.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import type { SessionSkill } from "@/db/schema";
 import { SlimShell } from "@/components/app-shell";
 import { FOCUS_RING, Gauge, Money } from "@/components/fleet/fleet-bits";
 import { toChatView, type ChatMessageRow } from "@/lib/chat/chat-view";
+import { isTerminalTaskStatus } from "@/lib/chat/composer";
 import { TaskStream } from "./task-stream";
 import { MessageInput } from "./message-input";
 import { PreviewPane } from "./preview-pane";
@@ -23,7 +25,7 @@ interface TaskData {
   pullRequestUrl: string | null;
   /** Non-null on a generation session — the composer offers its slash menu
    * only where the orchestrator re-frames a typed skill slash (issue #63). */
-  sessionSkill: string | null;
+  sessionSkill: SessionSkill | null;
 }
 
 type TaskStatusUpdate = {
@@ -95,9 +97,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
       taskStatus.containerStatus
     : null;
 
-  const isTerminal = ["completed", "failed", "cancelled"].includes(
-    taskStatus.status
-  );
+  const isTerminal = isTerminalTaskStatus(taskStatus.status);
 
   // The slim shell carries the task's identity and live status (issue #117);
   // the row below it carries where the work lives and what it has cost.

--- a/src/components/task-chat.tsx
+++ b/src/components/task-chat.tsx
@@ -21,6 +21,9 @@ interface TaskData {
   githubIssue: string | null;
   pullRequestNumber: number | null;
   pullRequestUrl: string | null;
+  /** Non-null on a generation session — the composer offers its slash menu
+   * only where the orchestrator re-frames a typed skill slash (issue #63). */
+  sessionSkill: string | null;
 }
 
 type TaskStatusUpdate = {
@@ -58,6 +61,7 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
   const [branch, setBranch] = useState<string | null>(initialTask.branch);
   const [activeTab, setActiveTab] = useState<"chat" | "preview">("chat");
   const [lastActivity, setLastActivity] = useState<number>(0);
+  const [queued, setQueued] = useState(0);
 
   const handleStatusChange = useCallback(
     (status: TaskStatusUpdate) => {
@@ -213,12 +217,15 @@ export function TaskChat({ task: initialTask, domain }: { task: TaskData; domain
             containerStatus={taskStatus.containerStatus}
             onStatusChange={handleStatusChange}
             onMessage={handleMessage}
+            onQueuedChange={setQueued}
           />
           {!isTerminal && (
             <MessageInput
               taskId={initialTask.id}
               containerStatus={taskStatus.containerStatus}
               taskStatus={taskStatus.status}
+              queued={queued}
+              sessionSkill={initialTask.sessionSkill}
             />
           )}
         </div>

--- a/src/components/task-stream.tsx
+++ b/src/components/task-stream.tsx
@@ -2,10 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toChatView, type ChatMessageRow } from "@/lib/chat/chat-view";
+import { queuedCount } from "@/lib/chat/composer";
 import { ChatMessage } from "./chat-message";
 
 type Message = ChatMessageRow & {
   createdAt: string;
+  /** Null until the turn manager hands the message to the agent — which is how
+   * the composer knows a message of yours is still queued (issue #122). */
+  deliveredAt: string | null;
 };
 
 type TaskStatus = {
@@ -22,6 +26,10 @@ interface TaskStreamProps {
   containerStatus: string | null;
   onStatusChange?: (status: TaskStatus) => void;
   onMessage?: (msg: Message) => void;
+  /** The transcript holds every message row, so it is also the one place that
+   * knows how many of the owner's are still undelivered — the composer's
+   * "queued" feedback is derived from here rather than polled separately. */
+  onQueuedChange?: (queued: number) => void;
 }
 
 export function TaskStream({
@@ -29,6 +37,7 @@ export function TaskStream({
   containerStatus,
   onStatusChange,
   onMessage,
+  onQueuedChange,
 }: TaskStreamProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -36,6 +45,11 @@ export function TaskStream({
   const userScrolledUp = useRef(false);
 
   const items = useMemo(() => toChatView(messages), [messages]);
+  const queued = queuedCount(messages);
+
+  useEffect(() => {
+    onQueuedChange?.(queued);
+  }, [queued, onQueuedChange]);
 
   /**
    * The pulse marks the gap between asking and the first output — the one

--- a/src/lib/chat/__tests__/composer.test.ts
+++ b/src/lib/chat/__tests__/composer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  composerState,
+  queuedCount,
+  resolvePrimary,
+  type ComposerPhase,
+} from "../composer";
+
+const state = (
+  taskStatus: string,
+  containerStatus: string | null,
+  queued = 0
+) => composerState({ taskStatus, containerStatus, queued });
+
+describe("composerState — what the agent is doing", () => {
+  const cases: Array<[string, string | null, ComposerPhase]> = [
+    ["queued", null, "waiting"],
+    ["running", null, "starting"],
+    ["running", "setup", "starting"],
+    ["running", "running", "working"],
+    ["running", "idle", "idle"],
+    ["running", "completing", "closing"],
+    // A parked run's container is stopped, so its status says nothing — the
+    // task's own status is what makes this a question waiting on the owner.
+    ["blocked", "idle", "blocked"],
+    ["blocked", null, "blocked"],
+    ["completed", "idle", "closed"],
+    ["failed", null, "closed"],
+    ["cancelled", null, "closed"],
+  ];
+
+  for (const [taskStatus, containerStatus, phase] of cases) {
+    it(`${taskStatus}/${containerStatus ?? "no container"} is ${phase}`, () => {
+      expect(state(taskStatus, containerStatus).phase).toBe(phase);
+    });
+  }
+});
+
+describe("composerState — what the composer allows", () => {
+  it("takes a message while the agent is working, to be queued behind the turn", () => {
+    const working = state("running", "running");
+
+    expect(working.accepting).toBe(true);
+    expect(working.placeholder).toContain("queued");
+    // Telling a working agent to "continue" is noise, so an empty draft is not
+    // sendable until it falls idle.
+    expect(working.allowsContinue).toBe(false);
+  });
+
+  it("takes an answer to a blocked run, but not a bare continue", () => {
+    const blocked = state("blocked", null);
+
+    expect(blocked.accepting).toBe(true);
+    expect(blocked.allowsContinue).toBe(false);
+  });
+
+  it("takes nothing before the task has started or once it is closing", () => {
+    expect(state("queued", null).accepting).toBe(false);
+    expect(state("running", "completing").accepting).toBe(false);
+    expect(state("completed", null).accepting).toBe(false);
+  });
+
+  it("offers completion only between turns", () => {
+    expect(state("running", "idle").canComplete).toBe(true);
+    expect(state("running", "running").canComplete).toBe(false);
+    expect(state("running", "setup").canComplete).toBe(false);
+    // The API refuses a task that is not running, so the button must not offer
+    // what the server will reject.
+    expect(state("blocked", "idle").canComplete).toBe(false);
+    expect(state("queued", null).canComplete).toBe(false);
+  });
+
+  it("offers a bare continue only when the agent is idle", () => {
+    expect(state("running", "idle").allowsContinue).toBe(true);
+    expect(state("running", "setup").allowsContinue).toBe(false);
+  });
+});
+
+describe("composerState — queue feedback", () => {
+  it("says nothing about a queue when there isn't one", () => {
+    expect(state("running", "running", 0).queuedNote).toBeNull();
+  });
+
+  it("counts the owner's undelivered messages", () => {
+    expect(state("running", "running", 1).queuedNote).toBe("1 queued");
+    expect(state("running", "running", 3).queuedNote).toBe("3 queued");
+  });
+
+  it("reports a queue even once the agent has fallen idle", () => {
+    // The queue poll delivers on its own cadence, so an idle agent with a
+    // message still in hand is a real, brief state — and the honest thing to
+    // show is that the message has not landed yet.
+    expect(state("running", "idle", 1).queuedNote).toBe("1 queued");
+  });
+});
+
+describe("queuedCount", () => {
+  const row = (role: string, deliveredAt: string | null) => ({ role, deliveredAt });
+
+  it("counts only the owner's undelivered messages", () => {
+    expect(
+      queuedCount([
+        row("user", "2026-08-16T10:00:00.000Z"),
+        row("user", null),
+        row("user", null),
+        row("agent", null), // agent output is never queued
+        row("system", null),
+      ])
+    ).toBe(2);
+  });
+
+  it("is zero for an empty transcript", () => {
+    expect(queuedCount([])).toBe(0);
+  });
+
+  it("treats an undefined delivery as undelivered", () => {
+    // A row streamed before the column existed, or serialized without it.
+    expect(queuedCount([{ role: "user", deliveredAt: undefined as never }])).toBe(1);
+  });
+});
+
+describe("resolvePrimary", () => {
+  it("sends the draft, trimmed", () => {
+    expect(resolvePrimary("  colder  ")).toEqual({ label: "send", text: "colder" });
+  });
+
+  it("turns an empty draft into an explicit continue", () => {
+    expect(resolvePrimary("")).toEqual({ label: "continue", text: "continue" });
+    expect(resolvePrimary("   \n ")).toEqual({ label: "continue", text: "continue" });
+  });
+});

--- a/src/lib/chat/__tests__/composer.test.ts
+++ b/src/lib/chat/__tests__/composer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   composerState,
+  isTerminalTaskStatus,
   queuedCount,
   resolvePrimary,
   type ComposerPhase,
@@ -91,6 +92,16 @@ describe("composerState — queue feedback", () => {
     // message still in hand is a real, brief state — and the honest thing to
     // show is that the message has not landed yet.
     expect(state("running", "idle", 1).queuedNote).toBe("1 queued");
+  });
+});
+
+describe("isTerminalTaskStatus", () => {
+  it("agrees with the phase the state machine reports", () => {
+    // The live view gates the whole composer on this predicate, so the two must
+    // not drift: everything terminal is `closed`, and nothing else is.
+    for (const status of ["queued", "running", "blocked", "completed", "failed", "cancelled"]) {
+      expect(state(status, "idle").phase === "closed").toBe(isTerminalTaskStatus(status));
+    }
   });
 });
 

--- a/src/lib/chat/__tests__/composer.test.ts
+++ b/src/lib/chat/__tests__/composer.test.ts
@@ -121,11 +121,20 @@ describe("queuedCount", () => {
 
 describe("resolvePrimary", () => {
   it("sends the draft, trimmed", () => {
-    expect(resolvePrimary("  colder  ")).toEqual({ label: "send", text: "colder" });
+    expect(resolvePrimary("  colder  ", true)).toEqual({ label: "send", text: "colder" });
   });
 
-  it("turns an empty draft into an explicit continue", () => {
-    expect(resolvePrimary("")).toEqual({ label: "continue", text: "continue" });
-    expect(resolvePrimary("   \n ")).toEqual({ label: "continue", text: "continue" });
+  it("turns an empty draft into an explicit continue where that is offered", () => {
+    expect(resolvePrimary("", true)).toEqual({ label: "continue", text: "continue" });
+    expect(resolvePrimary("   \n ", true)).toEqual({
+      label: "continue",
+      text: "continue",
+    });
+  });
+
+  it("stays a send when continuing is not on offer", () => {
+    // Mid-turn the button is disabled anyway; labelling it "continue" would
+    // name something the composer will not do.
+    expect(resolvePrimary("", false)).toEqual({ label: "send", text: "" });
   });
 });

--- a/src/lib/chat/__tests__/slash.test.ts
+++ b/src/lib/chat/__tests__/slash.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_SKILLS } from "@/db/schema";
+import { applySlashCommand, matchCommands, slashMenu, SLASH_COMMANDS } from "../slash";
+
+const names = (list: readonly { name: string }[]) => list.map((c) => c.name);
+
+describe("SLASH_COMMANDS", () => {
+  it("offers every session skill the orchestrator re-frames", () => {
+    expect([...names(SLASH_COMMANDS)].sort()).toEqual([...SESSION_SKILLS].sort());
+  });
+
+  it("gives each command a summary", () => {
+    for (const command of SLASH_COMMANDS) {
+      expect(command.summary.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("slashMenu — when the menu opens", () => {
+  it("opens on a bare slash, offering everything", () => {
+    const menu = slashMenu("/");
+
+    expect(menu?.query).toBe("");
+    expect(names(menu!.matches)).toEqual(names(SLASH_COMMANDS));
+  });
+
+  it("stays shut for prose", () => {
+    expect(slashMenu("")).toBeNull();
+    expect(slashMenu("what about option 2")).toBeNull();
+  });
+
+  it("stays shut for a slash mid-sentence", () => {
+    expect(slashMenu("try src/lib/chat")).toBeNull();
+    expect(slashMenu("option a/b")).toBeNull();
+  });
+
+  it("closes once the agenda begins", () => {
+    // The space after the command means you are writing what it should do,
+    // and a menu over the field would be in the way.
+    expect(slashMenu("/to-spec ")).toBeNull();
+    expect(slashMenu("/to-spec the composer")).toBeNull();
+  });
+
+  it("closes on a second line", () => {
+    expect(slashMenu("/to-spec\nmore")).toBeNull();
+  });
+
+  it("tolerates leading whitespace, as the server's routing does", () => {
+    expect(slashMenu("  /to")?.query).toBe("to");
+  });
+
+  it("lowercases the query so case never hides a command", () => {
+    expect(names(slashMenu("/TO")!.matches)).toEqual(["to-spec", "to-tickets"]);
+  });
+});
+
+describe("matchCommands", () => {
+  it("ranks prefix matches above ones that merely contain the query", () => {
+    // `triage` matches "g" only on its middle, so it comes after the two
+    // commands that start with it.
+    expect(names(matchCommands("g"))).toEqual([
+      "grill-me",
+      "grill-with-docs",
+      "triage",
+    ]);
+  });
+
+  it("matches on the middle of a name when nothing starts with the query", () => {
+    expect(names(matchCommands("with"))).toEqual(["grill-with-docs"]);
+  });
+
+  it("keeps the canonical order within a group", () => {
+    expect(names(matchCommands("to"))).toEqual(["to-spec", "to-tickets"]);
+  });
+
+  it("returns nothing for a query no command matches", () => {
+    expect(matchCommands("zzz")).toEqual([]);
+  });
+});
+
+describe("applySlashCommand", () => {
+  it("leaves the caret before the agenda", () => {
+    expect(applySlashCommand("to-tickets")).toBe("/to-tickets ");
+  });
+});

--- a/src/lib/chat/composer.ts
+++ b/src/lib/chat/composer.ts
@@ -43,6 +43,14 @@ export interface ComposerState {
 
 const TERMINAL = new Set(["completed", "failed", "cancelled"]);
 
+/** A task that has stopped for good. Shared with the live view, which gates the
+ * whole composer on it — so the `closed` phase below is what the state machine
+ * says about a task the view will not in fact show a composer for, and the two
+ * cannot drift into disagreeing. */
+export function isTerminalTaskStatus(status: string): boolean {
+  return TERMINAL.has(status);
+}
+
 /** A message row's queue-relevant shape — its own `deliveredAt` is the only
  * record of whether the agent has seen it. */
 export interface QueueableRow {

--- a/src/lib/chat/composer.ts
+++ b/src/lib/chat/composer.ts
@@ -148,9 +148,16 @@ export function composerState(input: {
  * What the primary button does. An empty draft on an idle agent means "carry
  * on" — the same move as replying in Discord to an idle notification — so the
  * button says `continue` and sends that word rather than sitting disabled with
- * nothing to explain itself. The label always names what will happen.
+ * nothing to explain itself. Where continuing is not on offer it stays the send
+ * it will become: the label always names what will happen, never what won't.
  */
-export function resolvePrimary(draft: string): { label: string; text: string } {
+export function resolvePrimary(
+  draft: string,
+  allowsContinue: boolean
+): { label: string; text: string } {
   const trimmed = draft.trim();
-  return trimmed ? { label: "send", text: trimmed } : { label: "continue", text: "continue" };
+  if (trimmed) return { label: "send", text: trimmed };
+  return allowsContinue
+    ? { label: "continue", text: "continue" }
+    : { label: "send", text: "" };
 }

--- a/src/lib/chat/composer.ts
+++ b/src/lib/chat/composer.ts
@@ -1,0 +1,156 @@
+/**
+ * The composer's state machine (issue #122). One pure function turns what the
+ * orchestrator says about a task — its status, its container's state, and how
+ * many of your messages are still undelivered — into everything the composer
+ * shows and allows: the status line, the placeholder, whether a message can be
+ * handed over at all, and whether the session can be completed.
+ *
+ * It lives here rather than in the component because "is my message queued?"
+ * and "can I complete this?" are exactly the answers a reader needs to trust,
+ * and a table of cases is how you check them.
+ */
+
+/** What the agent is doing, from the composer's point of view. */
+export type ComposerPhase =
+  | "waiting" // task queued — no container yet
+  | "starting" // container coming up
+  | "working" // mid-turn
+  | "idle" // finished a turn; your move
+  | "blocked" // parked on a question to you (issue #19)
+  | "closing" // completing: pushing the branch, tearing down
+  | "closed"; // terminal
+
+export interface ComposerState {
+  phase: ComposerPhase;
+  /** The status line, lowercase like the rest of the fleet's mono. */
+  label: string;
+  /** Colour of the status dot only — the label itself stays neutral ink, the
+   * same rule the live view's header follows (11px colour on the bare ground
+   * does not clear contrast in the light theme). */
+  tone: "green" | "amber" | "quiet";
+  placeholder: string;
+  /** Whether a message can be handed over at all. False does not mean the
+   * agent is busy — a busy agent still takes messages, they queue. */
+  accepting: boolean;
+  /** Whether an empty draft may be sent as a bare "continue". Only when the
+   * agent is idle: telling a working agent to continue is noise, and it is not
+   * an answer to a blocked run's question. */
+  allowsContinue: boolean;
+  canComplete: boolean;
+  /** How many of your messages are waiting to be picked up, when any are. */
+  queuedNote: string | null;
+}
+
+const TERMINAL = new Set(["completed", "failed", "cancelled"]);
+
+/** A message row's queue-relevant shape — its own `deliveredAt` is the only
+ * record of whether the agent has seen it. */
+export interface QueueableRow {
+  role: string;
+  deliveredAt: string | number | Date | null;
+}
+
+/**
+ * Your messages the agent has not been handed yet. The turn manager delivers
+ * the oldest undelivered user message whenever the container falls idle, so an
+ * undelivered row is precisely one still in the queue — including messages sent
+ * from Discord, or from this view before a reload.
+ */
+export function queuedCount(rows: readonly QueueableRow[]): number {
+  return rows.filter((r) => r.role === "user" && r.deliveredAt == null).length;
+}
+
+function phaseOf(taskStatus: string, containerStatus: string | null): ComposerPhase {
+  if (TERMINAL.has(taskStatus)) return "closed";
+  if (taskStatus === "blocked") return "blocked";
+  if (taskStatus !== "running") return "waiting";
+  if (containerStatus === "completing") return "closing";
+  if (containerStatus === "idle") return "idle";
+  // A running task with no container status yet is one whose workspace is
+  // still being built — the same situation as `setup`, said differently.
+  return containerStatus === "running" ? "working" : "starting";
+}
+
+const PHASES: Record<
+  ComposerPhase,
+  Omit<ComposerState, "phase" | "queuedNote" | "canComplete">
+> = {
+  waiting: {
+    label: "queued for a slot",
+    tone: "quiet",
+    placeholder: "The agent hasn't started yet",
+    accepting: false,
+    allowsContinue: false,
+  },
+  starting: {
+    label: "setting up workspace",
+    tone: "green",
+    placeholder: "Setting up — your message will be queued",
+    accepting: true,
+    allowsContinue: false,
+  },
+  working: {
+    label: "agent working",
+    tone: "green",
+    placeholder: "Agent is working — your message will be queued",
+    accepting: true,
+    allowsContinue: false,
+  },
+  idle: {
+    label: "agent idle — your move",
+    tone: "amber",
+    placeholder: "Message the agent…",
+    accepting: true,
+    allowsContinue: true,
+  },
+  blocked: {
+    label: "blocked on a question",
+    tone: "amber",
+    placeholder: "Answer the agent's question…",
+    accepting: true,
+    allowsContinue: false,
+  },
+  closing: {
+    label: "wrapping up",
+    tone: "quiet",
+    placeholder: "Wrapping up…",
+    accepting: false,
+    allowsContinue: false,
+  },
+  closed: {
+    label: "session ended",
+    tone: "quiet",
+    placeholder: "This session has ended",
+    accepting: false,
+    allowsContinue: false,
+  },
+};
+
+export function composerState(input: {
+  taskStatus: string;
+  containerStatus: string | null;
+  queued: number;
+}): ComposerState {
+  const phase = phaseOf(input.taskStatus, input.containerStatus);
+
+  return {
+    phase,
+    ...PHASES[phase],
+    // Completion is the orchestrator's contract, not a UI preference: the API
+    // takes a running task only, and completing mid-turn would abandon work the
+    // agent is part-way through. So it is offered exactly between turns.
+    canComplete: phase === "idle",
+    queuedNote: input.queued > 0 ? `${input.queued} queued` : null,
+  };
+}
+
+/**
+ * What the primary button does. An empty draft on an idle agent means "carry
+ * on" — the same move as replying in Discord to an idle notification — so the
+ * button says `continue` and sends that word rather than sitting disabled with
+ * nothing to explain itself. The label always names what will happen.
+ */
+export function resolvePrimary(draft: string): { label: string; text: string } {
+  const trimmed = draft.trim();
+  return trimmed ? { label: "send", text: trimmed } : { label: "continue", text: "continue" };
+}

--- a/src/lib/chat/slash.ts
+++ b/src/lib/chat/slash.ts
@@ -1,0 +1,73 @@
+/**
+ * The composer's slash awareness (issue #122). Typing `/` in a generation
+ * session opens a menu of the estate's session skills, so the follow-on slash
+ * routing that already exists server-side (`composeSessionTurn`, issue #63) is
+ * discoverable instead of being lore you have to remember.
+ *
+ * Pure by design: what counts as a trigger, what matches a query, and what the
+ * draft becomes when a command is accepted are the decisions worth testing, so
+ * they live here and the menu component only draws the result.
+ */
+
+import type { SessionSkill } from "@/db/schema";
+import { SESSION_BLURBS, SESSION_ORDER } from "@/lib/sessions/skills";
+
+export interface SlashCommand {
+  name: SessionSkill;
+  summary: string;
+}
+
+/** The offered commands, in the session-entry form's order. Deliberately only
+ * the session skills: those are the ones the orchestrator re-frames on the way
+ * to the agent. Any other slash the CLI expands itself, unaided and unlisted. */
+export const SLASH_COMMANDS: readonly SlashCommand[] = SESSION_ORDER.map(
+  (name) => ({ name, summary: SESSION_BLURBS[name] })
+);
+
+export interface SlashMenu {
+  /** What has been typed after the slash, lowercased. */
+  query: string;
+  matches: readonly SlashCommand[];
+}
+
+/**
+ * The trigger: the whole draft is a slash and the command word being typed —
+ * nothing more. Once a space follows the command the agenda has begun and the
+ * menu gets out of the way, and a slash mid-sentence was never a command.
+ * Leading whitespace is tolerated because `composeSessionTurn` tolerates it
+ * too, so the menu offers exactly what the server would route.
+ */
+const TRIGGER = /^\s*\/(\S*)$/;
+
+/** The menu for a draft, or null when the draft is not a command being typed.
+ * An empty query lists everything — pressing `/` is how you find out what
+ * exists. */
+export function slashMenu(draft: string): SlashMenu | null {
+  const match = TRIGGER.exec(draft);
+  if (!match) return null;
+
+  const query = match[1].toLowerCase();
+  return { query, matches: matchCommands(query) };
+}
+
+/** Prefix matches first, then anything containing the query: typing `to` should
+ * offer `to-spec` and `to-tickets` before `grill-with-docs`, which only matches
+ * because of its middle. Each group keeps the canonical order. */
+export function matchCommands(query: string): readonly SlashCommand[] {
+  if (query === "") return SLASH_COMMANDS;
+
+  const prefix = SLASH_COMMANDS.filter((c) => c.name.startsWith(query));
+  const rest = SLASH_COMMANDS.filter(
+    (c) => !c.name.startsWith(query) && c.name.includes(query)
+  );
+  return [...prefix, ...rest];
+}
+
+/**
+ * Accepting a command replaces the draft outright — the trigger guarantees the
+ * draft was only the half-typed command — and leaves a trailing space, because
+ * what follows a session skill is its agenda.
+ */
+export function applySlashCommand(name: string): string {
+  return `/${name} `;
+}

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -626,9 +626,13 @@ export async function processQueuedMessages(
       break;
     }
 
-    // Mark as delivered
+    // Mark as delivered. `updatedAt` is stamped with it because that column is
+    // what the SSE stream re-emits a already-sent row on — without it the live
+    // view would keep counting this message as queued for the rest of the
+    // session (issue #122).
+    const deliveredAt = new Date();
     db.update(messages)
-      .set({ deliveredAt: new Date() })
+      .set({ deliveredAt, updatedAt: deliveredAt })
       .where(eq(messages.id, queued.id))
       .run();
 

--- a/src/lib/sessions/skills.ts
+++ b/src/lib/sessions/skills.ts
@@ -1,0 +1,24 @@
+import { type SessionSkill } from "@/db/schema";
+
+/**
+ * One-line blurbs for the estate's generation skills — the copy that says what
+ * each session is *for*. Keyed by SessionSkill, so a skill added to the schema
+ * fails the type check here until it gets a blurb: no surface can silently drop
+ * one. Insertion order is the display order (grills first, then the
+ * spec→tickets pipeline, then the standalone passes); SESSION_SKILLS in the
+ * schema stays the runtime source of truth.
+ *
+ * Shared rather than restated: the session-entry form (issue #64) and the live
+ * composer's slash menu (issue #122) offer the same six skills, and two copies
+ * of these strings would drift the moment one is edited.
+ */
+export const SESSION_BLURBS: Record<SessionSkill, string> = {
+  "grill-me": "Stress-test an idea until its decisions resolve",
+  "grill-with-docs": "Grill an idea with the project's docs in context",
+  "to-spec": "Turn resolved decisions into a spec",
+  "to-tickets": "Decompose a spec into executable tickets",
+  triage: "Move an issue through the label lifecycle",
+  wayfinder: "Chart a new map of the territory",
+};
+
+export const SESSION_ORDER = Object.keys(SESSION_BLURBS) as SessionSkill[];


### PR DESCRIPTION
Closes #122

The write side of the live task view. The composer was a bare `bg-zinc-900` textarea with two shadcn buttons — the last dark island on the light fleet ground, and the thing you have to use to answer a grilling agent. It is now a first-class input.

## What it does

- **Multiline and autosizing.** The field grows with the draft and scrolls at its cap (`max-h-40`), and re-measures on a width change so rotating a phone or opening the preview pane doesn't leave it the wrong height.
- **Enter sends, Shift+Enter writes a newline** — with a stated deviation on touch, below.
- **Slash commands are discoverable.** Typing `/` in a generation session opens a menu of the six session skills with the same blurbs `/tasks/new` uses (now shared from `src/lib/sessions/skills.ts` rather than restated). Arrow keys move, Enter/Tab accepts, Escape dismisses; the rows are ordinary buttons, so Shift+Tab walks into them and tap/click works. It builds on the existing follow-on slash routing (#63), so it is offered exactly where the orchestrator re-frames a typed slash — a generation session — and not on a plain chat task, where the framing (and the `gh` token a publishing skill needs) isn't there.
- **Queued / working / idle feedback**, driven by real data rather than optimism (below).
- **Continue and complete.** With an empty draft on an idle agent the primary button reads `continue` and sends that word — the same move as replying to Discord's idle notification; as soon as you type it becomes `send`. Completing asks first.
- **Keyboard-operable with visible focus:** the system's `FOCUS_RING` on every control, `focus-within` on the field, `role="status"` on the status line, `aria-label`/`aria-describedby` on the textarea.
- **Fleet palette only** — the palette guard in `chat-render.test.tsx` now covers `message-input.tsx`, and it is verified in both themes (see below).

## Design and structure

Two pure seams carry the decisions, per the repo's culture (and #121's shape):

- `composerState({taskStatus, containerStatus, queued})` → the phase, status label, dot tone, placeholder, whether a message is accepted, whether an empty draft may be "continue", and whether completion is offered. `message-input.tsx` draws it.
- `slash.ts` → when a draft is a command being typed, what matches it, and what the draft becomes when one is accepted.

Both are table-tested (`composer.test.ts`, `slash.test.ts`); the component is rendered through `react-dom/server` in `composer-render.test.tsx` for the states and control enabled-ness. No `@testing-library`, no Playwright — as the parent spec's testing decisions require.

## The queue is real, not optimistic

`queued` is derived from the transcript's own rows (`role === "user" && deliveredAt == null`), so it survives a reload and counts messages sent from Discord too. For it to *drain*, delivery now stamps `updatedAt` alongside `deliveredAt` in the turn manager — that column is what the SSE stream re-emits an already-seen row on. One line, and the only backend change in the PR.

Verified end to end in a browser: with two undelivered rows the composer reads `agent working · 2 queued`; marking them delivered the way the turn manager does drains it to `agent working` live, with no reload.

## Two deliberate deviations, both flagged

1. **Enter on touch.** On a coarse-pointer device the return key writes a newline and the send button sends. A phone keyboard has no Shift+Enter, so Enter-to-send everywhere would make the multiline composer the ticket asks for unusable on the device sessions are read on. The hint under the field always says which contract you have; on any keyboard device it is exactly the AC's "Enter sends; Shift+Enter inserts a newline".
2. **The composer accepts a message on a `blocked` task.** A run parked on a `BLOCKED:` question could previously only be answered from Discord — the composer hid itself. It uses the identical mechanism Discord does (an undelivered user message; `processQueuedMessages` already resumes a blocked task), so this is parity, not new autonomy semantics. `complete` stays disabled there, because the API only completes a `running` task.

Also slightly beyond the letter of the ticket: completion asks "end this session?" before it fires. An accidental thumb on a phone shouldn't end a session and mark its PR ready.

## Verification

`pnpm build`, `pnpm lint` (changed files) and `pnpm test` (832 tests, incl. 56 new) all pass. Checked in a real browser in **dark and light**, at phone (430px) and desktop (1280px) widths: idle, working with a queue, the slash menu open and filtered, a long multiline draft, the completion confirmation, and a focused control. That pass turned up four things now fixed — a `useId` hydration mismatch on the hint id, the hint truncating on a phone exactly where it explains newlines, a slash highlight marked with a shade instead of the app's cool selection hue, and the confirmation fighting the status line for one row.

Not in scope, deliberately: structured/tappable option buttons (Interactivity Level 2 is explicitly deferred by #116), and any change to what `/tasks` or the header show.

## Merged `main` (#145) in

`origin/main` moved under this branch, so `main` is merged in (merge, not rebase). The one conflict was `new-task-form.tsx`: #145 hoisted `FIELD`/`PRIMARY_BUTTON` into `fleet-bits`, this branch lifted `SESSION_BLURBS` out into `lib/sessions/skills.ts` — resolved by taking both.

Two things from #145 I deliberately did **not** adopt in the composer: `ConfirmStrip` (a full-width tinted `PANEL`, scoped by its own doc to the settings controls that authorise unattended spend — dropping one into the composer dock would shove the field down the screen on a phone, where the confirmation is a single 11px row), and `FIELD` (it styles one control and keys off `:focus`; the composer's field is a flex box holding the textarea *and* the send button, so it keys off `focus-within`).

## Self-review

Ran the two-axis review (standards + spec) against `origin/main` with #122 as the spec before pushing. Findings I agreed with are fixed in `61f7ead`: a dangling `aria-describedby` when a send fails, a completion confirmation that could fire after the agent restarted, autosize that only re-measured on a *window* resize (now a width-only `ResizeObserver`, which the preview pane opening also trips), a menu label on a role-less div, and four duplication/naming cleanups.

One finding I did not act on: both passes flagged that the slash menu is offered only in a generation session, while a typed slash still expands natively on a plain chat task (#59) — so it works there but is undiscoverable. I've left it, because the ticket asks for a composer "building on the existing follow-on slash routing", and that routing (`composeSessionTurn`, #63) only applies where `task.sessionSkill` is set; a chat container also has no `gh` token, so a publishing skill offered there would half-work. Advertising a command whose framing isn't applied seemed worse than not advertising it. Happy to widen it if you'd rather.
