### PR TITLE
Completing a task while the agent starts a turn dead-ends silently

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@types/dockerode": "^4.0.1",
     "@types/hast": "^3.0.5",
@@ -53,6 +55,7 @@
     "drizzle-kit": "^0.31.9",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -132,6 +138,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.6
         version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@1.8.0)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -140,7 +149,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.0(@types/node@20.19.37)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))
 
 packages:
 
@@ -151,6 +160,14 @@ packages:
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -308,6 +325,46 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discordjs/builders@1.14.1':
     resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
@@ -692,6 +749,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1432,11 +1498,33 @@ packages:
   '@tailwindcss/postcss@4.2.1':
     resolution: {integrity: sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
@@ -1757,12 +1845,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1903,6 +1998,9 @@ packages:
   better-sqlite3@12.6.2:
     resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -2094,6 +2192,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2108,6 +2210,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2137,6 +2243,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -2221,6 +2330,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -2358,6 +2470,10 @@ packages:
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -2859,6 +2975,10 @@ packages:
     resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -3022,6 +3142,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -3112,6 +3235,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3395,6 +3527,10 @@ packages:
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3402,6 +3538,10 @@ packages:
     resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
@@ -3451,6 +3591,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -3777,6 +3920,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3853,6 +3999,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -3908,6 +4058,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -4022,6 +4175,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4247,6 +4404,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -4323,6 +4483,14 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4418,6 +4586,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -4577,9 +4749,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4643,6 +4835,13 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4705,6 +4904,21 @@ snapshots:
       fzf: 0.5.2
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4919,6 +5133,34 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@discordjs/builders@1.14.1':
     dependencies:
@@ -5202,6 +5444,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -5822,6 +6068,27 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -5832,6 +6099,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/aws-lambda@8.10.161': {}
 
@@ -6156,9 +6425,15 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.2.0: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -6306,6 +6581,10 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bindings@1.5.0:
     dependencies:
@@ -6488,6 +6767,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -6495,6 +6779,13 @@ snapshots:
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6521,6 +6812,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -6617,6 +6910,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   dotenv@17.3.1: {}
 
   drizzle-kit@0.31.9:
@@ -6670,6 +6965,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -7404,6 +7701,12 @@ snapshots:
 
   hono@4.12.7: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
@@ -7549,6 +7852,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -7628,6 +7933,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -7854,6 +8185,8 @@ snapshots:
       devlop: 1.1.0
       highlight.js: 11.11.2
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -7861,6 +8194,8 @@ snapshots:
   lucide-react@0.577.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lz-string@1.5.0: {}
 
   magic-bytes.js@1.13.0: {}
 
@@ -7985,6 +8320,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -8447,6 +8784,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -8510,6 +8851,12 @@ snapshots:
       tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -8583,6 +8930,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react@19.2.3: {}
 
@@ -8766,6 +9115,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -9103,6 +9456,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
@@ -9194,6 +9549,14 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.25
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.0.25
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -9309,6 +9672,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@6.24.1: {}
+
+  undici@8.10.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -9431,7 +9796,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.9.0
 
-  vitest@4.1.0(@types/node@20.19.37)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0)):
+  vitest@4.1.0(@types/node@20.19.37)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.0(@types/node@20.19.37)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.9.0))
@@ -9455,10 +9820,35 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
+      jsdom: 30.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -9536,6 +9926,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/src/components/__tests__/composer-refusal.test.tsx
+++ b/src/components/__tests__/composer-refusal.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageInput } from "../message-input";
+
+/**
+ * The composer interaction a static render cannot reach: the confirmation row,
+ * and what becomes of it when the session moves on underneath it (issue #149).
+ * The window is seconds wide and it is the normal end of a session — the owner
+ * decides they are done at the moment the agent picks the next turn up — so the
+ * behaviour is pinned here rather than left to be noticed in production.
+ *
+ * The rest of the composer is covered without a DOM: its decisions in
+ * `composer.test.ts`, its markup in `composer-render.test.tsx`.
+ */
+
+const PROPS = {
+  taskId: "01TASK",
+  taskStatus: "running",
+  containerStatus: "idle" as string | null,
+  queued: 0,
+  sessionSkill: null,
+};
+
+/** Neither exists in jsdom, and neither has anything to do with what is under
+ * test: the field's autosize watches its own width, and the Enter-vs-newline
+ * hint asks whether the pointer is coarse. */
+function stubBrowserAPIs() {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  if (!window.matchMedia) {
+    vi.stubGlobal("matchMedia", () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    }));
+  }
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  stubBrowserAPIs();
+  fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/** The owner presses complete on an idle agent and is asked to confirm. */
+function openConfirmation() {
+  const view = render(<MessageInput {...PROPS} />);
+  fireEvent.click(screen.getByRole("button", { name: "complete" }));
+  expect(screen.getByText("end this session?")).toBeTruthy();
+  return view;
+}
+
+/** A queued message is delivered and the next turn starts, arriving over SSE
+ * while the confirmation is still on screen. */
+const workingProps = { ...PROPS, containerStatus: "running" };
+
+describe("composer — completing as the agent starts a turn", () => {
+  it("closes the confirmation rather than leaving it open over a hidden status line", () => {
+    const { rerender } = openConfirmation();
+
+    rerender(<MessageInput {...workingProps} />);
+
+    expect(screen.queryByText("end this session?")).toBeNull();
+    // The status line the row was covering is back, and says what changed.
+    expect(screen.getByText("agent working")).toBeTruthy();
+  });
+
+  it("says why completion was refused rather than dead-ending silently", () => {
+    const { rerender } = openConfirmation();
+
+    rerender(<MessageInput {...workingProps} />);
+
+    expect(
+      screen.getByText("The agent started a turn. You can end the session once it's idle again.")
+    ).toBeTruthy();
+    // Refused means refused: nothing was posted on the owner's behalf.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the reason where a screen reader is already listening", () => {
+    const { rerender } = openConfirmation();
+
+    rerender(<MessageInput {...workingProps} />);
+
+    const field = screen.getByRole("textbox");
+    const described = document.getElementById(
+      field.getAttribute("aria-describedby") ?? ""
+    );
+    expect(described?.textContent).toContain("The agent started a turn");
+    // The live region is the same element that held the keyboard hint a moment
+    // ago, not one that appears with its message already in it.
+    expect(described?.getAttribute("role")).toBe("status");
+  });
+
+  it("puts focus back in the field instead of dropping it on the floor", () => {
+    const { rerender } = openConfirmation();
+    const confirm = screen.getByRole("button", { name: "confirm" });
+    confirm.focus();
+
+    rerender(<MessageInput {...workingProps} />);
+
+    expect(document.activeElement).toBe(screen.getByRole("textbox"));
+  });
+
+  it("hands the line back to the keyboard hint once the notice has been read", () => {
+    vi.useFakeTimers();
+    const { rerender } = openConfirmation();
+    rerender(<MessageInput {...workingProps} />);
+
+    act(() => void vi.advanceTimersByTime(8000));
+
+    expect(screen.queryByText(/The agent started a turn/)).toBeNull();
+    expect(screen.getByText(/enter to send/)).toBeTruthy();
+  });
+
+  it("names the same reason on the button the refusal disabled", () => {
+    render(<MessageInput {...workingProps} />);
+
+    expect(screen.getByRole("button", { name: "complete" })).toHaveProperty(
+      "title",
+      "The agent started a turn. You can end the session once it's idle again."
+    );
+  });
+
+  it("still completes when the agent is idle at the moment it is confirmed", async () => {
+    openConfirmation();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "confirm" }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks/01TASK/complete", {
+      method: "POST",
+    });
+    expect(screen.queryByText("end this session?")).toBeNull();
+  });
+});

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { SessionSkill } from "@/db/schema";
 import { FOCUS_RING } from "@/components/fleet/fleet-bits";
-import { composerState, resolvePrimary } from "@/lib/chat/composer";
+import { completionRefusal, composerState, resolvePrimary } from "@/lib/chat/composer";
 import { applySlashCommand, slashMenu, type SlashCommand } from "@/lib/chat/slash";
 
 /**
@@ -50,6 +50,19 @@ const DOT_TONE = {
   quiet: "bg-fl-ink-3",
 } as const;
 
+/**
+ * The line under the field, when it isn't the keyboard hint. A request that
+ * failed is an error; a completion the session refused is not — nothing went
+ * wrong, the agent simply moved on under you — so the two are toned apart
+ * rather than both arriving in red.
+ */
+type Note = { text: string; tone: "error" | "notice" };
+
+const NOTE_TONE = {
+  error: "text-fl-red",
+  notice: "text-fl-amber",
+} as const;
+
 const QUIET_BUTTON = `font-plex-mono text-[11px] lowercase text-fl-ink-3 hover:text-fl-ink disabled:cursor-default disabled:text-fl-ink-3/50 disabled:hover:text-fl-ink-3/50 ${FOCUS_RING}`;
 
 /** A fixed id, not `useId`: there is exactly one composer on a page, and the
@@ -68,7 +81,7 @@ export function MessageInput({
   const [sending, setSending] = useState(false);
   const [completing, setCompleting] = useState(false);
   const [confirmingComplete, setConfirmingComplete] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<Note | null>(null);
   // The draft the slash menu was dismissed for: Escape closes it until you type
   // something else, which is the only thing "dismissed" can sensibly mean for a
   // menu whose trigger is the draft itself.
@@ -81,6 +94,8 @@ export function MessageInput({
   // text means the draft is blank and no bare continue is on offer.
   const primary = resolvePrimary(draft, state.allowsContinue);
   const canSubmit = state.accepting && !sending && primary.text !== "";
+  // Non-null exactly when ending the session is off the table, and it says why.
+  const refusal = completionRefusal(state);
 
   const menu = useMemo(
     () => (sessionSkill && dismissed !== draft ? slashMenu(draft) : null),
@@ -137,11 +152,29 @@ export function MessageInput({
     return () => observer.disconnect();
   }, [resize]);
 
+  /**
+   * The confirmation row takes the status line's place while it is open, so a
+   * row left open once the agent starts a turn is a question whose answer would
+   * now do nothing, sitting on top of the one line that would explain why
+   * (issue #149). Close it the moment completion stops being on offer and name
+   * what changed — and take the note back down once it is on offer again, so a
+   * stale "wait for idle" can't outlive the turn it was about.
+   */
+  useEffect(() => {
+    if (refusal === null) {
+      setNote((n) => (n?.tone === "notice" ? null : n));
+      return;
+    }
+    if (!confirmingComplete || completing) return;
+    setConfirmingComplete(false);
+    setNote({ text: refusal, tone: "notice" });
+  }, [refusal, confirmingComplete, completing]);
+
   async function submit(text: string) {
     if (!canSubmit) return;
 
     setSending(true);
-    setError(null);
+    setNote(null);
     try {
       const res = await fetch(`/api/tasks/${taskId}/messages`, {
         method: "POST",
@@ -151,12 +184,12 @@ export function MessageInput({
       if (!res.ok) {
         // The draft is deliberately left in the field — a failed send must not
         // eat what you wrote.
-        setError("Couldn't send that message. Try again.");
+        setNote({ text: "Couldn't send that message. Try again.", tone: "error" });
         return;
       }
       setDraft("");
     } catch {
-      setError("Couldn't reach the server. Try again.");
+      setNote({ text: "Couldn't reach the server. Try again.", tone: "error" });
     } finally {
       setSending(false);
       textareaRef.current?.focus();
@@ -164,26 +197,32 @@ export function MessageInput({
   }
 
   async function handleComplete() {
-    // Re-checked, not just disabled at the point the question was asked: the
-    // agent can start a turn while the confirmation sits open, and the API
-    // completes a running, idle task only.
-    if (!state.canComplete || completing) return;
+    if (completing) return;
+
+    // Re-checked here as well as in the effect above, because a click can land
+    // in the same render as the change that refuses it. The question is
+    // answered either way, so the row closes first — and if the answer is no,
+    // it says so where the hint line goes rather than returning silently.
+    setConfirmingComplete(false);
+    if (refusal !== null) {
+      setNote({ text: refusal, tone: "notice" });
+      return;
+    }
 
     setCompleting(true);
-    setError(null);
+    setNote(null);
     try {
       const res = await fetch(`/api/tasks/${taskId}/complete`, { method: "POST" });
       if (!res.ok) {
-        setError("Couldn't complete the task. Try again.");
+        setNote({ text: "Couldn't complete the task. Try again.", tone: "error" });
         setCompleting(false);
       }
       // On success the view flips to its terminal state over SSE, so the button
       // stays in its "completing…" state until it does.
     } catch {
-      setError("Couldn't reach the server. Try again.");
+      setNote({ text: "Couldn't reach the server. Try again.", tone: "error" });
       setCompleting(false);
     }
-    setConfirmingComplete(false);
   }
 
   function pick(command: SlashCommand) {
@@ -344,17 +383,17 @@ export function MessageInput({
       </div>
 
       {/* One line under the field, and it carries the id the textarea is
-          described by either way — a failed send must not leave
-          `aria-describedby` pointing at nothing. Wrapping, not truncating: on a
-          phone the whole line is the point, and an ellipsis would eat the half
-          that says how to type a newline. */}
-      {error ? (
+          described by either way — a failed send, or a refused completion, must
+          not leave `aria-describedby` pointing at nothing. Wrapping, not
+          truncating: on a phone the whole line is the point, and an ellipsis
+          would eat the half that says how to type a newline. */}
+      {note ? (
         <p
           id={HINT_ID}
-          role="alert"
-          className="mt-1 font-plex-mono text-[11px] leading-snug text-fl-red"
+          role={note.tone === "error" ? "alert" : "status"}
+          className={`mt-1 font-plex-mono text-[11px] leading-snug ${NOTE_TONE[note.tone]}`}
         >
-          {error}
+          {note.text}
         </p>
       ) : (
         <p

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -53,15 +53,23 @@ const DOT_TONE = {
 /**
  * The line under the field, when it isn't the keyboard hint. A request that
  * failed is an error; a completion the session refused is not — nothing went
- * wrong, the agent simply moved on under you — so the two are toned apart
- * rather than both arriving in red.
+ * wrong, the agent simply moved on under you — so a notice is full-strength
+ * ink rather than red: read it, nothing to fix. Colour is not what separates
+ * them, because 11px amber does not clear contrast on the light surface — the
+ * same reason the status line's own colour lives in its dot.
  */
 type Note = { text: string; tone: "error" | "notice" };
 
 const NOTE_TONE = {
   error: "text-fl-red",
-  notice: "text-fl-amber",
+  notice: "text-fl-ink",
 } as const;
+
+/** How long a notice keeps the hint line. Long enough to read a sentence,
+ * short enough that the keyboard contract is back before you next type — a
+ * turn can run for ten minutes and the status line says so throughout, so the
+ * notice does not have to. */
+const NOTICE_MS = 8000;
 
 const QUIET_BUTTON = `font-plex-mono text-[11px] lowercase text-fl-ink-3 hover:text-fl-ink disabled:cursor-default disabled:text-fl-ink-3/50 disabled:hover:text-fl-ink-3/50 ${FOCUS_RING}`;
 
@@ -88,6 +96,7 @@ export function MessageInput({
   const [dismissed, setDismissed] = useState<string | null>(null);
   const [active, setActive] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const confirmRowRef = useRef<HTMLSpanElement>(null);
 
   const state = composerState({ taskStatus, containerStatus, queued });
   // What the button would send *is* whether there is anything to send: an empty
@@ -156,19 +165,33 @@ export function MessageInput({
    * The confirmation row takes the status line's place while it is open, so a
    * row left open once the agent starts a turn is a question whose answer would
    * now do nothing, sitting on top of the one line that would explain why
-   * (issue #149). Close it the moment completion stops being on offer and name
-   * what changed — and take the note back down once it is on offer again, so a
-   * stale "wait for idle" can't outlive the turn it was about.
+   * (issue #149). Close it the moment completion stops being on offer, and say
+   * what changed.
+   *
+   * Before paint, not after: a frame of a live confirmation that has quietly
+   * stopped meaning anything is the bug in miniature, and a tap landing in it
+   * would be answering a question that is already gone. Closing the row also
+   * unmounts whatever the owner was tabbed onto, and focus dropped to the
+   * document is its own dead end — so it goes back to the field, which is where
+   * the next move was going to be made anyway.
    */
-  useEffect(() => {
-    if (refusal === null) {
-      setNote((n) => (n?.tone === "notice" ? null : n));
-      return;
-    }
-    if (!confirmingComplete || completing) return;
+  useIsomorphicLayoutEffect(() => {
+    if (!confirmingComplete || refusal === null) return;
+    const hadFocus = confirmRowRef.current?.contains(document.activeElement) ?? false;
     setConfirmingComplete(false);
     setNote({ text: refusal, tone: "notice" });
-  }, [refusal, confirmingComplete, completing]);
+    if (hadFocus) textareaRef.current?.focus();
+  }, [confirmingComplete, refusal]);
+
+  // A notice is an announcement, not a state — the status line it explains is
+  // back on screen and keeps saying it — so it hands the line back to the
+  // keyboard hint after a few seconds. An error stays: it is about a request
+  // that can be retried, and nothing else on screen records it.
+  useEffect(() => {
+    if (note?.tone !== "notice") return;
+    const timer = setTimeout(() => setNote(null), NOTICE_MS);
+    return () => clearTimeout(timer);
+  }, [note]);
 
   async function submit(text: string) {
     if (!canSubmit) return;
@@ -199,10 +222,10 @@ export function MessageInput({
   async function handleComplete() {
     if (completing) return;
 
-    // Re-checked here as well as in the effect above, because a click can land
-    // in the same render as the change that refuses it. The question is
-    // answered either way, so the row closes first — and if the answer is no,
-    // it says so where the hint line goes rather than returning silently.
+    // Re-checked here as well as in the layout effect above, because a click
+    // can land in the same render as the change that refuses it. The question
+    // is answered either way, so the row closes first — and if the answer is
+    // no, it says so where the hint line goes rather than returning silently.
     setConfirmingComplete(false);
     if (refusal !== null) {
       setNote({ text: refusal, tone: "notice" });
@@ -316,7 +339,10 @@ export function MessageInput({
         </p>
 
         {confirmingComplete ? (
-          <span className="flex shrink-0 items-center gap-2.5 font-plex-mono text-[11px] lowercase">
+          <span
+            ref={confirmRowRef}
+            className="flex shrink-0 items-center gap-2.5 font-plex-mono text-[11px] lowercase"
+          >
             <span className="text-fl-ink-2">end this session?</span>
             <button
               type="button"
@@ -337,12 +363,10 @@ export function MessageInput({
           <button
             type="button"
             onClick={() => setConfirmingComplete(true)}
-            disabled={!state.canComplete || completing}
-            title={
-              state.canComplete
-                ? "End this session and mark its PR ready"
-                : "Available between turns, once the agent is idle"
-            }
+            disabled={refusal !== null || completing}
+            // The same sentence the refused confirmation would have said, so the
+            // disabled button and the note can't drift into two explanations.
+            title={refusal ?? "End this session and mark its PR ready"}
             className={`shrink-0 ${QUIET_BUTTON}`}
           >
             {completing ? "completing…" : "complete"}
@@ -382,27 +406,25 @@ export function MessageInput({
         </button>
       </div>
 
-      {/* One line under the field, and it carries the id the textarea is
-          described by either way — a failed send, or a refused completion, must
-          not leave `aria-describedby` pointing at nothing. Wrapping, not
-          truncating: on a phone the whole line is the point, and an ellipsis
-          would eat the half that says how to type a newline. */}
-      {note ? (
-        <p
-          id={HINT_ID}
-          role={note.tone === "error" ? "alert" : "status"}
-          className={`mt-1 font-plex-mono text-[11px] leading-snug ${NOTE_TONE[note.tone]}`}
-        >
-          {note.text}
-        </p>
-      ) : (
-        <p
-          id={HINT_ID}
-          className="mt-1 font-plex-mono text-[11px] leading-snug text-fl-ink-3"
-        >
-          {hint}
-        </p>
-      )}
+      {/* One line under the field, and one element: the hint, or whatever the
+          composer has to say instead. It is a live region from first paint
+          rather than one that appears with its message — a region that arrives
+          already full is commonly not announced at all, which for a refused
+          completion would be the very dead end this is here to close (issue
+          #149). It also always carries the id the textarea is described by, so
+          neither a note nor a hint leaves `aria-describedby` pointing at
+          nothing. Wrapping, not truncating: on a phone the whole line is the
+          point, and an ellipsis would eat the half that says how to type a
+          newline. */}
+      <p
+        id={HINT_ID}
+        role="status"
+        className={`mt-1 font-plex-mono text-[11px] leading-snug ${
+          note ? NOTE_TONE[note.tone] : "text-fl-ink-3"
+        }`}
+      >
+        {note?.text ?? hint}
+      </p>
     </div>
   );
 }

--- a/src/lib/chat/__tests__/composer.test.ts
+++ b/src/lib/chat/__tests__/composer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  completionRefusal,
   composerState,
   isTerminalTaskStatus,
   queuedCount,
@@ -92,6 +93,46 @@ describe("composerState — queue feedback", () => {
     // message still in hand is a real, brief state — and the honest thing to
     // show is that the message has not landed yet.
     expect(state("running", "idle", 1).queuedNote).toBe("1 queued");
+  });
+});
+
+describe("completionRefusal — completing while the session moves on", () => {
+  it("refuses, and says why, when the agent starts a turn under an open confirmation", () => {
+    // The race this exists for: the owner presses complete on an idle agent,
+    // and in the seconds the confirmation sits open a queued message is
+    // delivered and the next turn starts.
+    const asked = state("running", "idle");
+    expect(completionRefusal(asked)).toBeNull();
+
+    const confirmed = state("running", "running");
+    expect(completionRefusal(confirmed)).toBe(
+      "The agent started a turn. You can end the session once it's idle again."
+    );
+  });
+
+  it("gives a reason for every state that refuses, so none can dead-end silently", () => {
+    const everyPhase: Array<[string, string | null]> = [
+      ["queued", null],
+      ["running", null],
+      ["running", "setup"],
+      ["running", "running"],
+      ["running", "idle"],
+      ["running", "completing"],
+      ["blocked", null],
+      ["completed", "idle"],
+      ["failed", null],
+      ["cancelled", null],
+    ];
+
+    for (const [taskStatus, containerStatus] of everyPhase) {
+      const s = state(taskStatus, containerStatus);
+      const refusal = completionRefusal(s);
+
+      // A reason exists exactly when the button would refuse — no phase can be
+      // added that refuses without being able to say why.
+      expect(refusal === null).toBe(s.canComplete);
+      if (refusal !== null) expect(refusal.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/src/lib/chat/__tests__/composer.test.ts
+++ b/src/lib/chat/__tests__/composer.test.ts
@@ -96,42 +96,49 @@ describe("composerState — queue feedback", () => {
   });
 });
 
-describe("completionRefusal — completing while the session moves on", () => {
-  it("refuses, and says why, when the agent starts a turn under an open confirmation", () => {
-    // The race this exists for: the owner presses complete on an idle agent,
-    // and in the seconds the confirmation sits open a queued message is
-    // delivered and the next turn starts.
-    const asked = state("running", "idle");
-    expect(completionRefusal(asked)).toBeNull();
+describe("completionRefusal — why ending the session isn't on offer", () => {
+  // The reason is what the composer shows when a confirmation is refused under
+  // the owner (issue #149) and what the disabled complete button's tooltip
+  // says the rest of the time, so each one is pinned to the state it explains
+  // — a table of six near-identical sentences is exactly where two would drift
+  // into being swapped.
+  const cases: Array<[string, string | null, string | null]> = [
+    ["running", "idle", null],
+    [
+      "running",
+      "running",
+      "The agent started a turn. You can end the session once it's idle again.",
+    ],
+    [
+      "running",
+      "setup",
+      "The agent is still starting up. You can end the session once it's idle.",
+    ],
+    ["queued", null, "The agent hasn't started yet — there's nothing to end."],
+    [
+      "blocked",
+      "idle",
+      "The agent is waiting on your answer — send it, then end the session.",
+    ],
+    ["running", "completing", "This session is already wrapping up."],
+    ["completed", "idle", "This session has already ended."],
+  ];
 
-    const confirmed = state("running", "running");
-    expect(completionRefusal(confirmed)).toBe(
-      "The agent started a turn. You can end the session once it's idle again."
-    );
-  });
+  for (const [taskStatus, containerStatus, expected] of cases) {
+    const what = expected === null ? "offers completion" : "refuses";
+    it(`${what} on ${taskStatus}/${containerStatus ?? "no container"}`, () => {
+      expect(completionRefusal(state(taskStatus, containerStatus))).toBe(expected);
+    });
+  }
 
-  it("gives a reason for every state that refuses, so none can dead-end silently", () => {
-    const everyPhase: Array<[string, string | null]> = [
-      ["queued", null],
-      ["running", null],
-      ["running", "setup"],
-      ["running", "running"],
-      ["running", "idle"],
-      ["running", "completing"],
-      ["blocked", null],
-      ["completed", "idle"],
-      ["failed", null],
-      ["cancelled", null],
-    ];
-
-    for (const [taskStatus, containerStatus] of everyPhase) {
+  it("has words for every refusal the button can make", () => {
+    // The table above is keyed over every phase but `idle`, so this is the type
+    // system's promise restated at the boundary the composer relies on: a
+    // reason exists exactly when completion is off the table, and the composer
+    // gates the POST on that reason rather than on `canComplete` separately.
+    for (const [taskStatus, containerStatus] of cases) {
       const s = state(taskStatus, containerStatus);
-      const refusal = completionRefusal(s);
-
-      // A reason exists exactly when the button would refuse — no phase can be
-      // added that refuses without being able to say why.
-      expect(refusal === null).toBe(s.canComplete);
-      if (refusal !== null) expect(refusal.length).toBeGreaterThan(0);
+      expect(completionRefusal(s) === null).toBe(s.canComplete);
     }
   });
 });

--- a/src/lib/chat/composer.ts
+++ b/src/lib/chat/composer.ts
@@ -152,20 +152,21 @@ export function composerState(input: {
   };
 }
 
-/** Why ending the session is not on offer, by what the agent is doing. None of
- * these is a failure — each one is the session having moved on. */
-const REFUSALS: Record<ComposerPhase, string | null> = {
+/** Why ending the session is not on offer, by what the agent is doing. Keyed
+ * over every phase but `idle` — the one phase completion *is* offered in — so a
+ * refusal without words cannot be written. None of these is a failure; each one
+ * is the session having moved on. */
+const REFUSALS: Record<Exclude<ComposerPhase, "idle">, string> = {
   waiting: "The agent hasn't started yet — there's nothing to end.",
   starting: "The agent is still starting up. You can end the session once it's idle.",
   working: "The agent started a turn. You can end the session once it's idle again.",
-  idle: null,
   blocked: "The agent is waiting on your answer — send it, then end the session.",
   closing: "This session is already wrapping up.",
   closed: "This session has already ended.",
 };
 
 /**
- * Why completion was refused, or null while it is on offer (issue #149).
+ * Why completion is not on offer, or null while it is (issue #149).
  *
  * The composer asks this again at the moment the owner confirms, rather than
  * trusting that the button was enabled when they pressed it: a turn can start
@@ -173,11 +174,12 @@ const REFUSALS: Record<ComposerPhase, string | null> = {
  * as the agent picks the next turn up is not a rare coincidence — it is the
  * normal end of one. Refusing then is right, and nothing bad happens. Refusing
  * *silently* is what leaves the owner pressing a control that does nothing, so
- * the reason is a value the composer can say out loud rather than a bare early
- * return.
+ * the reason is a value the composer can say out loud — under the field when a
+ * confirmation is refused, and on the disabled button the rest of the time —
+ * rather than a bare early return.
  */
 export function completionRefusal(state: ComposerState): string | null {
-  return state.canComplete ? null : REFUSALS[state.phase];
+  return state.phase === "idle" ? null : REFUSALS[state.phase];
 }
 
 /**

--- a/src/lib/chat/composer.ts
+++ b/src/lib/chat/composer.ts
@@ -152,6 +152,34 @@ export function composerState(input: {
   };
 }
 
+/** Why ending the session is not on offer, by what the agent is doing. None of
+ * these is a failure — each one is the session having moved on. */
+const REFUSALS: Record<ComposerPhase, string | null> = {
+  waiting: "The agent hasn't started yet — there's nothing to end.",
+  starting: "The agent is still starting up. You can end the session once it's idle.",
+  working: "The agent started a turn. You can end the session once it's idle again.",
+  idle: null,
+  blocked: "The agent is waiting on your answer — send it, then end the session.",
+  closing: "This session is already wrapping up.",
+  closed: "This session has already ended.",
+};
+
+/**
+ * Why completion was refused, or null while it is on offer (issue #149).
+ *
+ * The composer asks this again at the moment the owner confirms, rather than
+ * trusting that the button was enabled when they pressed it: a turn can start
+ * in the seconds a confirmation sits open, and deciding a session is over just
+ * as the agent picks the next turn up is not a rare coincidence — it is the
+ * normal end of one. Refusing then is right, and nothing bad happens. Refusing
+ * *silently* is what leaves the owner pressing a control that does nothing, so
+ * the reason is a value the composer can say out loud rather than a bare early
+ * return.
+ */
+export function completionRefusal(state: ComposerState): string | null {
+  return state.canComplete ? null : REFUSALS[state.phase];
+}
+
 /**
  * What the primary button does. An empty draft on an idle agent means "carry
  * on" — the same move as replying in Discord to an idle notification — so the

--- a/src/lib/orchestrator/turn-manager.ts
+++ b/src/lib/orchestrator/turn-manager.ts
@@ -627,7 +627,7 @@ export async function processQueuedMessages(
     }
 
     // Mark as delivered. `updatedAt` is stamped with it because that column is
-    // what the SSE stream re-emits a already-sent row on — without it the live
+    // what the SSE stream re-emits an already-sent row on — without it the live
     // view would keep counting this message as queued for the rest of the
     // session (issue #122).
     const deliveredAt = new Date();


### PR DESCRIPTION
Closes #149

## What changed

`handleComplete` re-checked `canComplete` and returned silently when the agent had started a turn under the open confirmation — so the owner was left looking at a question that did nothing when answered, with the status line that would explain it covered by that very row.

The reason is now a value. `completionRefusal` (`src/lib/chat/composer.ts`) names, per phase, why ending the session is not on offer; the composer closes the confirmation the moment completion stops being possible — giving the status line back — and says what changed on the line under the field. Same sentence on the disabled complete button's tooltip, so the two surfaces can't drift.

A refusal is toned as a notice, not an error: nothing went wrong, the session moved on. It steps aside after 8s and hands the line back to the keyboard hint, which the status line beside it keeps saying anyway.

Also in scope, as the ticket asks: the `a already-sent row` typo at `turn-manager.ts:629`.

## Acceptance criteria

- [x] The early return surfaces why completion was refused — `completionRefusal(state)`, shown under the field
- [x] The confirmation row does not stay open where confirming does nothing — a layout effect closes it before paint, so not even a frame of it survives
- [x] The reason is legible — the status line is restored *and* the reason is written out; the disabled button repeats it
- [x] A unit test covers the refusal path — `src/components/__tests__/composer-refusal.test.tsx`, plus the per-phase table in `composer.test.ts`
- [x] `pnpm build` and `pnpm lint` pass (lint clean on all changed files; `tsc --noEmit` reports only the two pre-existing errors in `src/lib/docker/__tests__/container-manager.test.ts`, untouched here)

## Self-review

Ran `/code-review` against `origin/main` with #149 as the spec before pushing; the second commit acts on six findings — the untested effect, the after-paint close, dropped focus, the sub-AA amber, the contradictory tooltip, and the `null`-permitting `REFUSALS` type. Details in that commit message.

**One judgement call worth flagging:** the AC asks for a unit test of "the agent becoming non-completable while the confirmation is open", which lives in a component effect, and this repo had no DOM test capability — `composer-render.test.tsx` is `renderToStaticMarkup`, where effects never run. I added `jsdom` and `@testing-library/react` as devDependencies rather than settle for testing the pure lookup alone, because without them deleting the effect body left the whole suite green. They are dev-only: CI here is deploy-only, and the runtime image copies the standalone build, so neither ships. Four of the new file's seven tests fail if the effect is removed (verified). If you'd rather not carry the test infra, the alternative is dropping that file and accepting the pure-function coverage.

**Not fixed, deliberately:** the review also flagged that a successful complete POST latches `completing` forever — `/api/tasks/[id]/complete` is fire-and-forget, so a `completeTask` that throws or an SSE drop leaves "completing…" with no note. That is pre-existing and is the same defect class #151 owns (a completed session holding a slot until restart), so it stays out of this ticket's UI half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)