### PR TITLE
GLM lane: worst-endpoint rate card + billed-truth cache auditing (#193)

### DIFF
--- a/lanes.yaml
+++ b/lanes.yaml
@@ -165,17 +165,21 @@ lanes:
   # slugs and three rows of prices. Nothing else — no new credential, no new
   # adapter, no code.
   #
-  # What was verified, and on what (2026-09-02, issue #175). The *endpoint* was
-  # exercised with the real Claude Code harness: tool use, extended thinking,
-  # `--resume` and prompt caching all passed through, and the pass did the work
-  # it was asked to do. That run used a free model
-  # (`minimax/minimax-m2.7:free`), because the OpenRouter account holds no
-  # credits and every paid model answers 402 — so the three slugs below are
-  # verified only as far as OpenRouter's model listing, which is where their
-  # prices come from. Re-check them with
-  # `node scripts/openrouter-lane-check.mjs --model z-ai/glm-5.3-flash` once
-  # the account is funded, and read the findings on issue #175 for what did not
-  # carry over: the harness's own cost figure, and quota telemetry.
+  # What was verified, and on what. The full autonomous loop ran on this lane
+  # end to end on the VPS (issue #175, 2026-09-02): triage, implement and
+  # review passes on moontide#82, producing a merged PR, with every turn booked
+  # against the prices below. What did not carry over from Anthropic-direct:
+  # the harness's own cost figure, and quota telemetry (issue #175's findings).
+  #
+  # Prompt caching WORKS on this lane (issue #193, measured 2026-09-02) —
+  # automatic on the GLM family's upstreams, no cache_control needed, cache
+  # writes free, and reads reported through the skin's
+  # `cache_read_input_tokens`. An earlier probe that read `cache_read: 0` was
+  # a routing artifact, not a lane property: OpenRouter fans each request out
+  # across ~20 upstream hosts per slug, and two stateless probes landing on
+  # different hosts miss each other's cache. `scripts/openrouter-lane-check.mjs`
+  # now audits each probe against `GET /v1/generation` (the billed truth, which
+  # names the serving host) so that misreading cannot happen again.
   - id: openrouter-glm
     label: OpenRouter (GLM open weights)
     adapter: claude-code
@@ -191,14 +195,31 @@ lanes:
       heavy: z-ai/glm-5.3
       standard: z-ai/glm-5.3-flash
       light: z-ai/glm-4.7-flash
-    # USD per million tokens, from OpenRouter's model listing on 2026-09-02.
+    # USD per million tokens — the WORST serving endpoint's rates, not the
+    # listing's cheapest (issue #193). OpenRouter's default routing scatters
+    # across every host serving a slug, and their prices spread up to 2x:
+    # measured live, `z-ai/glm-5.3-flash` cold turns billed by NextBit at
+    # $0.15/MTok against the $0.075 floor this file used to declare. The fleet
+    # books spend from these figures, and under-reading cost is how it spends
+    # money nobody authorised (the `lane-cost.ts` asymmetry), so each column is
+    # the maximum across the slug's endpoints on 2026-09-02.
+    #
+    # Reclaiming the ~2x back to floor rates is an operator action, not a code
+    # change: create an OpenRouter preset pinning `provider.only: ["z-ai"]`,
+    # point a tier's slug at `@preset/<name>`, and restore that tier's floor
+    # prices here. (The `:floor` slug suffix is NOT that fix — measured, it
+    # still routed to the $0.15 host. Body-level `provider` pinning does pass
+    # through the Anthropic skin, but the harness cannot send body fields.)
+    #
     # `cache_write` is deliberately absent across the family: OpenRouter
     # publishes no cache-write price for these models, and the cost calculation
-    # reads an absent cache price as the input rate rather than as free.
+    # reads an absent cache price as the input rate rather than as free. Same
+    # rule for `light`'s absent cache_read: one of its hosts (Cloudflare)
+    # publishes no cache-read price, so the worst case IS the input rate.
     prices:
-      heavy: { input: 1.4, output: 4.4, cache_read: 0.26 }
-      standard: { input: 0.075, output: 0.25, cache_read: 0.015 }
-      light: { input: 0.06, output: 0.4, cache_read: 0.01 }
+      heavy: { input: 1.75, output: 5.5, cache_read: 0.325 }
+      standard: { input: 0.15, output: 0.5, cache_read: 0.03 }
+      light: { input: 0.07, output: 0.4 }
     caps:
       # Enforced as above (issue #174, #173) — the lower of this and the
       # operator's own real-money cap binds.

--- a/scripts/openrouter-lane-check.mjs
+++ b/scripts/openrouter-lane-check.mjs
@@ -19,7 +19,13 @@
  *      response? (`--check skin`)
  *   2. Does prompt caching work through it, and does the endpoint report cache
  *      reads and cache *writes*? (`--check cache` — sends the same cacheable
- *      prefix twice)
+ *      prefix twice, and audits each response against OpenRouter's
+ *      `GET /v1/generation` record: the billed truth, which also names the
+ *      upstream host that served the request. Issue #193's lesson: the skin's
+ *      `usage` block alone cannot distinguish "this model does not cache" from
+ *      "OpenRouter routed my two probes to two different hosts" — a first
+ *      reading of `cache_read: 0` on GLM was the latter, and the model caches
+ *      fine.)
  *   3. Does the endpoint emit any `anthropic-ratelimit-*` header? (Every check
  *      reports this: it is the fact `quota_state` being per-lane rests on.)
  *
@@ -109,6 +115,28 @@ async function call(args, key, body) {
   return { status: response.status, json, text, rateLimitHeaders };
 }
 
+/**
+ * OpenRouter's audit record for one response — what was actually billed, and
+ * by which upstream host. This is the ground truth the skin's `usage` block is
+ * a lossy view of: `provider_name` exposes the fan-out across a slug's ~20
+ * hosts (the cache-miss and rate-spread mechanism of issue #193), and
+ * `cache_discount` is the money the cache actually saved. Returns null off
+ * OpenRouter, or if the record never appears; the record lags the response by
+ * a second or two, hence the retry.
+ */
+async function fetchGeneration(args, key, id) {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    const response = await fetch(`${args.baseUrl}/v1/generation?id=${id}`, {
+      headers: { authorization: `Bearer ${key}` },
+    });
+    if (response.status === 200) {
+      return (await response.json()).data;
+    }
+  }
+  return null;
+}
+
 function reportQuotaHeaders(result) {
   if (result.rateLimitHeaders.length > 0) {
     console.log("  quota headers:", result.rateLimitHeaders.join("; "));
@@ -168,6 +196,7 @@ async function checkCache(args, key) {
     messages: [{ role: "user", content: "Say A" }],
   };
 
+  const hosts = [];
   for (const attempt of [1, 2]) {
     const result = await call(args, key, body);
     if (result.status !== 200) {
@@ -180,14 +209,37 @@ async function checkCache(args, key) {
         `cache_read=${usage.cache_read_input_tokens} ` +
         `cache_write=${usage.cache_creation_input_tokens}`
     );
+    const generation = await fetchGeneration(args, key, result.json.id);
+    if (generation !== null) {
+      hosts.push(generation.provider_name);
+      console.log(
+        `    billed: host=${generation.provider_name} ` +
+          `cost=$${generation.total_cost} ` +
+          `cached=${generation.native_tokens_cached}/${generation.native_tokens_prompt} ` +
+          `cache_discount=${generation.cache_discount}`
+      );
+    } else {
+      console.log("    billed: no generation record (not OpenRouter?)");
+    }
     if (attempt === 2) {
       const read = usage.cache_read_input_tokens ?? 0;
-      console.log(
-        read > 0
-          ? "  -> caching works through the skin; the lane's cache_read price applies."
-          : "  -> NO cache read on an identical prefix. Every turn re-pays full " +
-              "input price for the whole context, which dominates a long pass."
-      );
+      if (read > 0) {
+        console.log(
+          "  -> caching works through the skin; the lane's cache_read price applies."
+        );
+      } else if (hosts.length === 2 && hosts[0] !== hosts[1]) {
+        console.log(
+          `  -> no cache read, but the probes were served by two DIFFERENT hosts ` +
+            `(${hosts[0]}, ${hosts[1]}) — a routing miss, not evidence the model ` +
+            "cannot cache (issue #193). Re-run before concluding anything."
+        );
+      } else {
+        console.log(
+          "  -> NO cache read on an identical prefix on one host. Every turn " +
+            "re-pays full input price for the whole context, which dominates " +
+            "a long pass."
+        );
+      }
       // Null on OpenRouter today; undefined on a provider that omits the field
       // entirely. Both mean the same thing: no cache-write count to price.
       if (usage.cache_creation_input_tokens == null) {


### PR DESCRIPTION
## What this is

Issue #193 claimed the GLM lane is uncached and proposed redesigning lane routing around cache-aware effective cost. Live verification (matrix recorded on the issue) **disproved the premise** — caching works — and found the real defect instead: **unpinned OpenRouter routing bills up to 2× the declared rate card**. This PR carries what's real and nothing else.

## Changes

**`lanes.yaml`** — the `openrouter-glm` price table is re-declared at the **worst serving endpoint's rates** (max across each slug's ~20 OpenRouter hosts, 2026-09-02): heavy 1.75/5.5/0.325, standard 0.15/0.5/0.03, light 0.07/0.4 with `cache_read` omitted (one of its hosts publishes no cache-read price, so the worst case *is* the input rate — which is exactly what an absent column already means to `priceTokens`). Measured live: cold turns on `z-ai/glm-5.3-flash` billed by NextBit and DigitalOcean at ~$0.15/MTok against the $0.075 floor previously declared, so booking from floor prices under-reads real spend — the `lane-cost.ts` asymmetry. The lane comment now records the verified cache findings and the operator path to reclaim floor rates (an OpenRouter preset pinning `provider.only: ["z-ai"]`, pointed at by a tier slug — config only).

**`scripts/openrouter-lane-check.mjs`** — the cache probe now audits each response against `GET /v1/generation` (billed cost, **serving host**, `cache_discount`), and a zero-cache result served by two *different* hosts is reported as a routing miss rather than "this model cannot cache". That instrument gap is what produced #175's false `cache_read: 0` finding. Verified live post-change — it reproduced the exact failure mode and diagnosed it correctly:

```
attempt 1: input=4016 cache_read=0
  billed: host=DigitalOcean cost=$0.0006104 cached=0/4016
attempt 2: input=4016 cache_read=0
  billed: host=Z.AI cost=$0.0003052 cached=0/4016
-> no cache read, but the probes were served by two DIFFERENT hosts — a routing miss,
   not evidence the model cannot cache (issue #193).
```

## Ranking impact

None. `laneBlendedRateUsd` ranks lanes whose rates differ ~40×; a 2× move in GLM's columns changes no ordering (the `RANKING_PASS_USAGE` comment's "any non-perverse mix" argument, now true of the price columns too).

## Tests

`src/lib/lanes` (163), `lane-cost-fixture` + `execution-lane-settings-render` (28) — all pass. The shipped-`lanes.yaml` structural suite parses the edited file. Lint clean on the script.

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)