### PR TITLE
Cap app and caddy memory so a leak can't take the whole host down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,14 @@ services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    # Memory caps: the host has no headroom to spare (4GB, and one agent
+    # container is entitled to 2GB of it). Uncapped, a leak here competes with
+    # the kernel itself — on 2026-09-03 dockerd's leak plus a stuck run tipped
+    # the box into a global OOM and a 3-hour reclaim livelock (kernel answering
+    # SYN, no userspace process able to emit a byte). A per-service cap turns
+    # that into a single contained restart. dockerd/containerd are capped
+    # separately via systemd drop-ins; the agent cap is AGENT_MEMORY_MB.
+    mem_limit: 192m
     ports:
       - "80:80"
       - "443:443"
@@ -28,6 +36,7 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: unless-stopped
+    mem_limit: 768m
     env_file: .env
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Incident

2026-09-03 17:26 UTC the VPS hit a **global OOM** (`constraint=CONSTRAINT_NONE`) and never recovered — three hours of continuous page reclaim, kernel answering SYN on 22/80/443 while no userspace process could emit a byte. Needed an out-of-band reboot.

```
Sep 03 17:26:50  oom-kill:constraint=CONSTRAINT_NONE ... global_oom
Sep 03 20:30:42  systemd-journald: Under memory pressure, flushing caches.   ← still, 3h later
```

Every earlier OOM (Sep 02, ×4) was `CONSTRAINT_MEMCG` — an agent hitting its own 2GB cap, harmless by design. This one was the whole machine.

With no swap the only reclaim target was the page cache, so processes evicted each other's executable pages in a loop. The OOM killer fired but couldn't complete. Livelock, not a crash.

Root cause: nothing on a 4GB box was bounded except the agent's 2GB. dockerd (1.19GB on 2026-08-19), containerd, app and caddy were all uncapped — no guaranteed headroom for the host.

## Fix (3 parts, this PR is part 3)

| part | where | status |
|---|---|---|
| 2GB swapfile + `vm.swappiness=10` | host, `/etc/fstab` + `/etc/sysctl.d` | ✅ live |
| `MemoryHigh`/`MemoryMax` on docker + containerd | host, systemd drop-ins | ✅ live |
| `mem_limit` on app + caddy | this PR | ⏳ needs deploy |

Both host changes were applied live with no restart and no disruption to the running agent.

Budget after this lands:

| | cap | observed |
|---|---|---|
| dockerd | 400M high / 1G max | 177M |
| containerd | 448M high / 768M max | 262M |
| app | 768M | 185M |
| caddy | 192M | 50M |
| agent | 2048M (`AGENT_MEMORY_MB`) | ~1.8G peak |

Every process bounded; caps sum below physical RAM, with 2GB swap as the valve.

`AGENT_MEMORY_MB` deliberately left at 2048 — the Sep 02 logs show agents genuinely want ~1.8GB, and lowering it trades host uptime for failed runs. Swap plus the daemon caps remove the need.

## Notes

- Same failure mode as #40 (2026-08-01), which the deploy workflow header already documents.
- Merging triggers a deploy (`docker compose down` → build → up), which will interrupt any live run. Worth timing.
- Related: #36 (OOM kills inside agent containers are invisible) — why the Sep 02 memcg kills passed unnoticed. That's the missing early warning for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)