### PR TITLE
Tracker contract: every published ticket declares a tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,7 @@ This project's registry entry: products/interlude.yaml
 
 ### Issue tracker
 
-Issues live in this repo's GitHub Issues, operated via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+Issues live in this repo's GitHub Issues, operated via the `gh` CLI. Every published ticket carries a `## Workflow` section naming a tier (`model: light | standard | heavy`), chosen against the three-way rubric in the ticket contract there (issue #197). See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -47,7 +47,7 @@ This section extends the generation skill's issue template. The skill (`/to-tick
 model: light
 ```
 
-The tier says how hard the ticket's *work* is, so the fleet can run a one-line guard and a new state machine at different tiers instead of running both at whatever the lane's default resolves to. Put the section after `## Acceptance criteria` and before `## Blocked by`. One `model:` line per ticket, on its own line, not inside a code fence; the executor reads whole lines inside the Workflow section and nothing else, so a tier mentioned in prose is data, not a decision.
+The tier says how hard the ticket's *work* is, so the fleet can run a one-line guard and a new state machine at different tiers instead of running both at whatever the fleet's configured default resolves to. Put the section after `## Acceptance criteria` and before `## Blocked by`. One `model:` line per ticket, on its own line, not inside a code fence; the executor reads whole lines inside the Workflow section and nothing else, so a tier mentioned in prose is data, not a decision.
 
 The key is `model:`, not `tier:`, because `model:` is the directive the executor already reads. The vendor names `opus`, `sonnet` and `haiku` still resolve as aliases for `heavy`, `standard` and `light`, but write the tier: the tier is what the fleet acts on, records on the run and reports.
 
@@ -61,22 +61,20 @@ Three tiers, and each one is **chosen positively**. There is no default and no "
 
 `standard` is not the middle to settle on when the choice feels hard; it is chosen when the route is genuinely the implementer's to find within conventions the repo already has. `light` is not reserved for the trivially obvious; it is chosen whenever the spec has already made every decision the implementer would otherwise make, however many lines that takes. `heavy` is chosen for the decision the ticket asks the implementer to make, not for the size of the diff. When none of the three fits, the ambiguity is usually in the ticket rather than the rubric — sharpen *what to build* until one criterion describes it.
 
-Three tickets from this repo, as calibration: "add a `## Workflow` section to a document, with these three bullets" is `light` — the words are in the spec. "A repair pass derives one rung above the implement tier, capped by the per-kind setting when one is set" is `standard` — several files, an existing pure function to extend, the acceptance criteria say what but not how. "A parked run re-checks lanes on every sweep and resumes early where one can now serve it" is `heavy` — reducer state, ordering against three existing wall behaviours, and a bound that must stay true across them.
-
 ### What a ticket may and may not say
 
 - **A tier, never a lane.** Which lane runs a pass — the subscription, the Anthropic API, OpenRouter — is fleet policy and cost routing. A ticket body is semi-trusted text and may not send the fleet somewhere that spends money. There is no lane directive, and the executor ignores unknown keys rather than interpreting them.
-- **A tier, never a raw model identifier.** `model: claude-opus-4-8` names no tier. The executor drops it, runs the pass at the fleet default and notes on the issue that the directive was not recognised — so a mistyped tier is visible, never fatal, and never obeyed.
+- **A tier, never a raw model identifier.** `model: claude-opus-4-8` names no tier. The executor drops it, runs the pass at the configured default and notes on the issue that the directive was not recognised — so a mistyped tier is visible, never fatal, and never obeyed.
 - **The tier applies to the ticket's work passes only** — the implement pass and any repair pass of the run. Review and triage run at the fleet's own settings. A ticket cannot cheapen the gate that judges it or the pass that assesses it, and the Workflow section has no key that would let it.
 - `budget:`, `max-turns:`, `checkpoint:` and `effort:` stay hand-written escape hatches in the same section (see `docs/runbook.md`). They are not part of the tier decision: a budget is a ceiling, not a lever, and declaring a low one on a cheap ticket saves nothing.
 
 ### A ticket that arrives without a tier
 
-It is not refused. It runs exactly as it did before this contract, at the lane's default tier: a forgotten section costs the fleet nothing it was not already paying — it only forfeits the choice. Refusing to claim such a ticket would wedge the frontier over a missing doc section, so the contract is enforced by the producer writing the section, not by the executor.
+It is not refused. It runs exactly as it did before this contract, at the configured default tier for the pass: a forgotten section costs the fleet nothing it was not already paying — it only forfeits the choice. Refusing to claim such a ticket would wedge the frontier over a missing doc section, so the contract is enforced by the producer writing the section, not by the executor.
 
 ### The section and `workflow:<skill>` labels
 
-The executor reads a body Workflow section as the ticket's *own* workflow: when one is present, the implement pass is told to follow the section and a `workflow:<skill>` label (`workflow:tdd`, `workflow:diagnosing-bugs`) is not applied. This contract puts a section on every ticket, so a label alone no longer selects a method. A ticket that needs one writes the method into the section itself — the steps, the seams under test, the done-signal — alongside its tier, which is the per-ticket override the estate contract already provides for. Teaching the executor to combine a directives-only section with a label is a reader change and out of this contract's scope.
+Know one consequence before you publish. The executor reads a body Workflow section as the ticket's *own* workflow: when one is present, the implement pass is told to follow the section, and a `workflow:<skill>` label (`workflow:tdd`) is **not** applied. This contract puts a section on every ticket, so a label alone no longer selects a method. The right fix is in the reader — a section carrying only directives should not count as a bespoke workflow — and is deliberately outside this contract, which changes no parser. Until it lands, a ticket that needs a named method writes the method into its Workflow section alongside the tier (the steps, the seams under test, the done-signal: the per-ticket override the estate contract already provides for) rather than relying on the label.
 
 ### The extended shape
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -27,11 +27,87 @@ GitHub shares one number space across issues and PRs, so a bare `#42` may be eit
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a GitHub issue, in the shape the *Ticket contract* section below requires: every published ticket carries a `## Workflow` section naming a tier.
 
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Ticket contract: every published ticket declares a tier
+
+This section extends the generation skill's issue template. The skill (`/to-tickets`) is not forked, wrapped or vendored: its template is a shape, and this contract adds one section to that shape, the same way `docs/agents/review-gates.yaml` adds gates to the estate defaults without removing any. Read it whenever you publish a ticket to this repo — from `/to-tickets`, by hand, or inside an interlude generation session. All three have this file checked out.
+
+### The rule
+
+**Every published ticket carries a `## Workflow` section, and that section names a tier** on a `model:` line:
+
+```markdown
+## Workflow
+
+model: light
+```
+
+The tier says how hard the ticket's *work* is, so the fleet can run a one-line guard and a new state machine at different tiers instead of running both at whatever the lane's default resolves to. Put the section after `## Acceptance criteria` and before `## Blocked by`. One `model:` line per ticket, on its own line, not inside a code fence; the executor reads whole lines inside the Workflow section and nothing else, so a tier mentioned in prose is data, not a decision.
+
+The key is `model:`, not `tier:`, because `model:` is the directive the executor already reads. The vendor names `opus`, `sonnet` and `haiku` still resolve as aliases for `heavy`, `standard` and `light`, but write the tier: the tier is what the fleet acts on, records on the run and reports.
+
+### Choosing the tier
+
+Three tiers, and each one is **chosen positively**. There is no default and no "otherwise" branch: read all three criteria and state the one that describes the work. The axis is what the spec leaves for the implementer to decide — nothing, the route, or a design decision — not how confident you feel about the ticket.
+
+- `light` — the change is determined by the spec: an explicit instruction, a mechanical edit, a well-bounded change with no ambiguity about what to write.
+- `standard` — judgement within a known pattern: multi-file, follows existing conventions, acceptance criteria clear but the route not spelled out.
+- `heavy` — a design decision the spec does not make: a new seam or abstraction, concurrency or state reasoning, a subtle invariant, or blast radius crossing module boundaries.
+
+`standard` is not the middle to settle on when the choice feels hard; it is chosen when the route is genuinely the implementer's to find within conventions the repo already has. `light` is not reserved for the trivially obvious; it is chosen whenever the spec has already made every decision the implementer would otherwise make, however many lines that takes. `heavy` is chosen for the decision the ticket asks the implementer to make, not for the size of the diff. When none of the three fits, the ambiguity is usually in the ticket rather than the rubric — sharpen *what to build* until one criterion describes it.
+
+Three tickets from this repo, as calibration: "add a `## Workflow` section to a document, with these three bullets" is `light` — the words are in the spec. "A repair pass derives one rung above the implement tier, capped by the per-kind setting when one is set" is `standard` — several files, an existing pure function to extend, the acceptance criteria say what but not how. "A parked run re-checks lanes on every sweep and resumes early where one can now serve it" is `heavy` — reducer state, ordering against three existing wall behaviours, and a bound that must stay true across them.
+
+### What a ticket may and may not say
+
+- **A tier, never a lane.** Which lane runs a pass — the subscription, the Anthropic API, OpenRouter — is fleet policy and cost routing. A ticket body is semi-trusted text and may not send the fleet somewhere that spends money. There is no lane directive, and the executor ignores unknown keys rather than interpreting them.
+- **A tier, never a raw model identifier.** `model: claude-opus-4-8` names no tier. The executor drops it, runs the pass at the fleet default and notes on the issue that the directive was not recognised — so a mistyped tier is visible, never fatal, and never obeyed.
+- **The tier applies to the ticket's work passes only** — the implement pass and any repair pass of the run. Review and triage run at the fleet's own settings. A ticket cannot cheapen the gate that judges it or the pass that assesses it, and the Workflow section has no key that would let it.
+- `budget:`, `max-turns:`, `checkpoint:` and `effort:` stay hand-written escape hatches in the same section (see `docs/runbook.md`). They are not part of the tier decision: a budget is a ceiling, not a lever, and declaring a low one on a cheap ticket saves nothing.
+
+### A ticket that arrives without a tier
+
+It is not refused. It runs exactly as it did before this contract, at the lane's default tier: a forgotten section costs the fleet nothing it was not already paying — it only forfeits the choice. Refusing to claim such a ticket would wedge the frontier over a missing doc section, so the contract is enforced by the producer writing the section, not by the executor.
+
+### The section and `workflow:<skill>` labels
+
+The executor reads a body Workflow section as the ticket's *own* workflow: when one is present, the implement pass is told to follow the section and a `workflow:<skill>` label (`workflow:tdd`, `workflow:diagnosing-bugs`) is not applied. This contract puts a section on every ticket, so a label alone no longer selects a method. A ticket that needs one writes the method into the section itself — the steps, the seams under test, the done-signal — alongside its tier, which is the per-ticket override the estate contract already provides for. Teaching the executor to combine a directives-only section with a label is a reader change and out of this contract's scope.
+
+### The extended shape
+
+The generation skill's issue template, with this contract's one addition:
+
+```markdown
+## Parent
+
+Spec: #<n> (omit when there is no parent)
+
+## What to build
+
+The end-to-end behaviour this ticket makes work, from the user's perspective.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Workflow
+
+model: standard
+
+## Blocked by
+
+- #<n>, or "None — can start immediately"
+```
+
+### Scope
+
+The tier vocabulary is interlude's own. The estate's other executor ignores `model:`, so this contract lives here and not in the estate's workflow choice document; promoting it estate-wide is a later decision, deliberately not taken until the rubric is proven on this repo's tickets.
 
 ## Wayfinding operations
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -458,6 +458,10 @@ text is semi-trusted, so it may only select a tier, never name an arbitrary
 model); an unrecognised value is ignored — the run keeps its configured default
 and the claim comment notes that it was dropped. Review and triage passes keep
 their own (cheaper) tier regardless. The honoured tier is recorded on the run.
+Since issue #197 the directive is not optional: every published ticket names
+its tier, chosen against the three-way rubric in the ticket contract in
+`docs/agents/issue-tracker.md`, which is where a producer — `/to-tickets`, a
+human, or a generation session — reads how to choose.
 
 ### Spending real money (metered lanes)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -458,10 +458,11 @@ text is semi-trusted, so it may only select a tier, never name an arbitrary
 model); an unrecognised value is ignored — the run keeps its configured default
 and the claim comment notes that it was dropped. Review and triage passes keep
 their own (cheaper) tier regardless. The honoured tier is recorded on the run.
-Since issue #197 the directive is not optional: every published ticket names
-its tier, chosen against the three-way rubric in the ticket contract in
-`docs/agents/issue-tracker.md`, which is where a producer — `/to-tickets`, a
-human, or a generation session — reads how to choose.
+Since issue #197 every published ticket is expected to name its tier, chosen
+against the three-way rubric in the ticket contract in
+`docs/agents/issue-tracker.md` — the contract binds the producer (`/to-tickets`,
+a human, a generation session), not the executor: a ticket that arrives
+without one still runs at the configured default exactly as above.
 
 ### Spending real money (metered lanes)
 

--- a/src/lib/__tests__/tracker-contract.test.ts
+++ b/src/lib/__tests__/tracker-contract.test.ts
@@ -15,35 +15,61 @@ import { parseTicketDirectives } from "@/lib/orchestrator/autonomy/ticket";
 import { MODEL_TIERS } from "@/lib/model-tiers";
 
 const CONTRACT_HEADING = "## Ticket contract";
+const RUBRIC_HEADING = "### Choosing the tier";
 
-/** The contract section: from its H2 to the next H2 *outside* a code fence —
- * the examples inside it are ticket shapes and carry `## Workflow` headings
- * of their own, which must not end the section early. */
-function contractSection(): string {
+interface Contract {
+  /** The section's prose, fenced code removed, keyed by `###` subsection. */
+  prose: Map<string, string[]>;
+  /** Each fenced example in the section, verbatim. */
+  examples: string[];
+}
+
+/**
+ * One walk over the document, from the contract's H2 to the next H2 outside
+ * a code fence. Deliberately its own reader rather than the parser's
+ * `workflowSectionLines`: the examples inside the section are whole ticket
+ * shapes carrying `## Workflow` headings of their own, which must not end
+ * the section early, and this walk *keeps* fenced lines (as examples) where
+ * the parser drops them.
+ */
+function readContract(): Contract {
   const doc = readFileSync(path.join(process.cwd(), "docs/agents/issue-tracker.md"), "utf8");
-  const lines: string[] = [];
+  const prose = new Map<string, string[]>();
+  const examples: string[] = [];
+  let subsection = "";
   let inSection = false;
-  let inFence = false;
+  let fence: string[] | null = null;
+
   for (const line of doc.split("\n")) {
-    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence;
-    if (!inFence && line.startsWith("## ")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      if (fence) {
+        if (inSection) examples.push(fence.join("\n"));
+        fence = null;
+      } else {
+        fence = [];
+      }
+      continue;
+    }
+    if (fence) {
+      fence.push(line);
+      continue;
+    }
+    if (line.startsWith("## ")) {
       if (inSection) break;
       inSection = line.startsWith(CONTRACT_HEADING);
       continue;
     }
-    if (inSection) lines.push(line);
+    if (!inSection) continue;
+    if (line.startsWith("### ")) subsection = line;
+    if (!prose.has(subsection)) prose.set(subsection, []);
+    prose.get(subsection)!.push(line);
   }
-  expect(lines.length, `the tracker doc has a "${CONTRACT_HEADING}" section`).toBeGreaterThan(0);
-  return lines.join("\n");
-}
-
-function fencedExamples(section: string): string[] {
-  return [...section.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+  return { prose, examples };
 }
 
 describe("tracker ticket contract (issue #197)", () => {
   it("shows examples the directive parser reads as a tier", () => {
-    const examples = fencedExamples(contractSection());
+    const { examples } = readContract();
     expect(examples.length).toBeGreaterThan(0);
     for (const example of examples) {
       const { model } = parseTicketDirectives(example);
@@ -53,8 +79,11 @@ describe("tracker ticket contract (issue #197)", () => {
   });
 
   it("gives a rubric criterion for exactly the parser's tier vocabulary", () => {
-    const section = contractSection();
-    const criteria = [...section.matchAll(/^- `([a-z]+)` — /gm)].map((m) => m[1]);
+    const rubric = readContract().prose.get(RUBRIC_HEADING);
+    expect(rubric, `the contract has a "${RUBRIC_HEADING}" subsection`).toBeDefined();
+    const criteria = rubric!
+      .map((line) => line.match(/^- `([a-z]+)` — /))
+      .flatMap((m) => (m ? [m[1]] : []));
     expect([...criteria].sort()).toEqual([...MODEL_TIERS].sort());
   });
 });

--- a/src/lib/__tests__/tracker-contract.test.ts
+++ b/src/lib/__tests__/tracker-contract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The ticket contract in docs/agents/issue-tracker.md (issue #197) tells
+ * every producer of tickets to write a `## Workflow` section naming a tier.
+ * The rubric itself is documentation and is judged by the tickets it
+ * produces, not here. What this pins is the seam between the document and
+ * the reader: the syntax the contract shows must be the syntax the directive
+ * parser accepts, and the tiers the rubric names must be the parser's own
+ * vocabulary — otherwise a generation session follows the document faithfully
+ * and the fleet silently runs every ticket at the default tier.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseTicketDirectives } from "@/lib/orchestrator/autonomy/ticket";
+import { MODEL_TIERS } from "@/lib/model-tiers";
+
+const CONTRACT_HEADING = "## Ticket contract";
+
+/** The contract section: from its H2 to the next H2 *outside* a code fence —
+ * the examples inside it are ticket shapes and carry `## Workflow` headings
+ * of their own, which must not end the section early. */
+function contractSection(): string {
+  const doc = readFileSync(path.join(process.cwd(), "docs/agents/issue-tracker.md"), "utf8");
+  const lines: string[] = [];
+  let inSection = false;
+  let inFence = false;
+  for (const line of doc.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence;
+    if (!inFence && line.startsWith("## ")) {
+      if (inSection) break;
+      inSection = line.startsWith(CONTRACT_HEADING);
+      continue;
+    }
+    if (inSection) lines.push(line);
+  }
+  expect(lines.length, `the tracker doc has a "${CONTRACT_HEADING}" section`).toBeGreaterThan(0);
+  return lines.join("\n");
+}
+
+function fencedExamples(section: string): string[] {
+  return [...section.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+}
+
+describe("tracker ticket contract (issue #197)", () => {
+  it("shows examples the directive parser reads as a tier", () => {
+    const examples = fencedExamples(contractSection());
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      const { model } = parseTicketDirectives(example);
+      expect(model, `example parses to a tier:\n${example}`).not.toBeNull();
+      expect(MODEL_TIERS).toContain(model);
+    }
+  });
+
+  it("gives a rubric criterion for exactly the parser's tier vocabulary", () => {
+    const section = contractSection();
+    const criteria = [...section.matchAll(/^- `([a-z]+)` — /gm)].map((m) => m[1]);
+    expect([...criteria].sort()).toEqual([...MODEL_TIERS].sort());
+  });
+});


### PR DESCRIPTION
Closes #197

## What this does

Extends `docs/agents/issue-tracker.md` with the ticket contract the parent spec (#196) calls for. Every published ticket carries a `## Workflow` section naming a tier on a `model:` line, chosen against a three-way rubric in which `light`, `standard` and `heavy` are each positively chosen and none is framed as a default. The document also states that a ticket may name a tier but never a lane or a raw model identifier, that the tier reaches the run's work passes only (implement and repair, never review or triage), what happens to a ticket that arrives without one (it runs at the configured default, exactly as before), and shows the extended issue shape.

The external `/to-tickets` skill is untouched. Its template is a shape and the contract extends it additively, as `review-gates.yaml` extends the estate defaults. `CLAUDE.md`'s issue-tracker block and the runbook's per-ticket tier paragraph point at the contract so a generation session that only skims the summary still meets the rule.

No change to the directive parser or the reducer.

## One thing the ticket-reviewer and the spec owner should know

**This contract collides with `selectWorkflow`.** The reader treats any `## Workflow` heading in a body as the ticket's *own* workflow: the implement pass is told to "follow those steps and gates exactly" and a `workflow:<skill>` label is not applied (`src/lib/orchestrator/autonomy/ticket.ts`, `selectWorkflow`; the estate runner's prompt has the same precedence). Twenty of this repo's issues carry `workflow:tdd`. Once every ticket carries a section for its tier, a `workflow:tdd` ticket silently loses the vendored tdd injection.

The ticket forbids changing the parser ("No change is made to the directive parser or the reducer"), and that path is human-signoff gated, so I did not fix it here. The doc states the fact plainly and tells producers what to do until it is fixed (write the method's steps into the section). The right fix is small and belongs in a follow-up: a Workflow section whose non-blank lines are all recognised directive lines should not count as a bespoke workflow, so the label still selects. I have **not** filed that issue, because `issues.opened` on this repo triggers a paid triage pass and filing tickets was not part of this one. Suggested title: "selectWorkflow: a directives-only Workflow section must not override a workflow label".

## Self-review (`/code-review`, fixed point `origin/main`, spec #197)

Acted on:
- Both axes flagged the `selectWorkflow` interaction above. Kept the doc honest about it; headlined here.
- Standards: "the lane's default tier" was imprecise (fallthrough is UI override, then `AGENT_MODEL`, then the lane's fallback). Now "configured default" throughout.
- Standards: the runbook said the directive "is not optional" while the contract says an untiered ticket is not refused. Reconciled: the contract binds the producer, not the executor.
- Spec: a calibration paragraph pre-assigned tiers to sibling tickets by paraphrase and was not asked for. Dropped.
- Standards (smells): the test had two fence detectors that disagreed and duplicated the parser's walk. Now one fence-aware walk; the rubric check is scoped to its own subsection.

Disagreed with, and why:
- **Spec: the test file is unasked-for** ("the tracker contract and rubric are documentation … not unit-tested"). Kept. It does not test the rubric. It pins the seam between the document and the reader: if the contract showed `tier:` where the parser reads `model:`, or named a tier outside `MODEL_TIERS`, every generated ticket would run at the default tier with nothing failing. It lives in `src/lib/__tests__/` beside other doc-pinning tests, outside the autonomy gate. A negative check (changing the example's key to `tier:`) fails it.
- **Standards: register** (the new section is argued prose in a terse config file). Partly accepted by trimming; the rest kept because the section is read by LLM generation sessions applying a three-way judgement, and the reasons are what make the "no default" rule followable.

## Acceptance criteria

- [x] The tracker conventions document states that every published ticket carries a `## Workflow` section naming a tier
- [x] The rubric gives a positive criterion for each tier and frames none as a default or fallback
- [x] A ticket may name a tier but never a lane, and never a raw model identifier
- [x] A ticket's tier applies to its work passes only, not review or triage
- [x] No change to the directive parser or the reducer
- [x] The external generation skill is not forked, wrapped, vendored or modified
- [ ] A ticket generated after this change carries a Workflow section with a tier — verifiable only at the next `/to-tickets` run; the spec's own note says this is how the contract is judged

## Verification

- `pnpm test`: 91 files, 1729 tests passed (full suite, before the review follow-ups; the contract test re-run after them: 2/2).
- `pnpm lint src/lib/__tests__/tracker-contract.test.ts`: clean. `pnpm exec tsc --noEmit`: clean.
- Negative check: changing the doc's example to `tier: light` fails the contract test; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
